### PR TITLE
Fix Railway start command so $PORT expands (run uvicorn via sh)

### DIFF
--- a/railway.json
+++ b/railway.json
@@ -5,7 +5,7 @@
     "dockerfilePath": "Dockerfile"
   },
   "deploy": {
-    "startCommand": "uvicorn app.main:app --host 0.0.0.0 --port ${PORT:-8000}",
+    "startCommand": "sh -c 'uvicorn app.main:app --host 0.0.0.0 --port ${PORT:-8000}'",
     "healthcheckPath": "/api/health",
     "restartPolicyType": "ON_FAILURE",
     "restartPolicyMaxRetries": 3


### PR DESCRIPTION
`railway.json`'s `startCommand` uses `${PORT:-8000}`, but Railway passes the string to the container without a shell to expand it — so uvicorn receives the literal `${PORT:-8000}` as its `--port` argument, rejects it as not a valid integer, and the container crash-loops. Wrapping the command in `sh -c '...'` restores the expansion.

```diff
- "startCommand": "uvicorn app.main:app --host 0.0.0.0 --port ${PORT:-8000}",
+ "startCommand": "sh -c 'uvicorn app.main:app --host 0.0.0.0 --port ${PORT:-8000}'",
```

I hit this deploying a fork of this project to Railway. I know you deploy to Cloud Run, so this file probably isn't in your own path — but you ship `railway.json` and `SELF-HOSTING.md` together, so anyone following the self-hosting docs onto Railway hits it on their first deploy.

No behavior change for any other deployment target: the file is only read by Railway.

---

Some context, since this is my first PR here: WXYC 89.3 FM (the student station at UNC Chapel Hill) runs a fork of this project for a Triangle-area concert calendar. It's been genuinely useful — thank you for building it and putting it out there. I have a handful of other fixes I'd like to send back upstream over the next few weeks (scraper robustness, poster images on event cards, a few data fixes). Starting with the smallest one to make sure the cross-fork PR flow works on your end.

Happy to retarget this at `dev` if you'd prefer — I based it on `main` because `main` is currently ahead of `dev`, so a `dev`-based PR would be missing the Carolina Theatre and Squarespace work.
