### PR TITLE
Fix escaped-apostrophe title truncation in the Motorco scraper

### DIFF
--- a/backend/app/scrapers/motorco.py
+++ b/backend/app/scrapers/motorco.py
@@ -22,6 +22,31 @@ from app.scrapers.base import BaseScraper, ScrapedEvent, BROWSER_HEADERS
 
 logger = logging.getLogger(__name__)
 
+# Each JS event object looks like:
+#   { title: 'Name', start: '2026-04-03 21:00', url: 'https://...', classNames: '...' }
+#
+# `title` is free text, so it must be matched as a proper JS string literal rather
+# than with a stop-at-the-first-quote pattern. WordPress `esc_js` backslash-escapes
+# any apostrophe inside the single-quoted value, and a naive `(.+?)['"]` terminates
+# at that escaped quote — truncating e.g. "This Tour Won't Save You" to
+# "This Tour Won\". Match the opening quote, then a run of escaped characters
+# (`\\.`) or non-quote characters, up to the matching closing quote. The captured
+# value still holds its backslashes; `_parse_event` collapses them.
+#
+# `start` and `url` values never contain a quote, so the simpler form is sufficient
+# (and clearer) for them.
+_EVENT_PATTERN = re.compile(
+    r'\{[^{}]*?title\s*:\s*(?P<q>[\'"])(?P<title>(?:\\.|(?!(?P=q)).)*)(?P=q)'
+    r'[^{}]*?start\s*:\s*[\'"](?P<start>\d{4}-\d{2}-\d{2}[^\'\"]*)[\'"]'
+    r'[^{}]*?url\s*:\s*[\'"](?P<url>[^\'\"]+)[\'"]',
+    re.S,
+)
+
+# A JS string escape is a backslash followed by any single character (`\'`, `\"`,
+# `\\`, `\/`). `esc_js` only ever emits a backslash as an escape introducer, so
+# collapsing each pair to its second character never eats a literal backslash.
+_JS_ESCAPE_PATTERN = re.compile(r"\\(.)")
+
 
 # --- Scraper class ---
 
@@ -46,23 +71,14 @@ class MotorcoScraper(BaseScraper):
             resp.raise_for_status()
             html = resp.text
 
-        # Each JS event object looks like:
-        #   { title: 'Name', start: '2026-04-03 21:00', url: 'https://...', classNames: '...' }
-        # Extract title, start, and url per event block.
-        pattern = re.compile(
-            r'\{[^{}]*?title\s*:\s*[\'"](.+?)[\'"]'
-            r'[^{}]*?start\s*:\s*[\'"](\d{4}-\d{2}-\d{2}[^\'\"]*)[\'"]'
-            r'[^{}]*?url\s*:\s*[\'"]([^\'\"]+)[\'"]',
-            re.S,
-        )
-
-        # Deduplicate by (title, start) — the regex can produce overlapping matches
-        # when event objects share similar surrounding HTML context.
+        # Deduplicate by (title, start). `finditer` yields non-overlapping matches,
+        # so this guards against the same event genuinely appearing twice in the
+        # page markup rather than against overlapping regex matches.
         seen = set()
-        for m in pattern.finditer(html):
-            raw_title, raw_start, raw_url = m.group(1), m.group(2), m.group(3)
+        for m in _EVENT_PATTERN.finditer(html):
+            raw_title, raw_start, raw_url = m.group("title"), m.group("start"), m.group("url")
 
-            # Skip duplicates (the regex can match overlapping regions)
+            # Skip an event object we have already seen
             key = (raw_title, raw_start)
             if key in seen:
                 continue
@@ -78,7 +94,9 @@ class MotorcoScraper(BaseScraper):
     def _parse_event(self, title: str, start_str: str, url: str, today: date) -> Optional[ScrapedEvent]:
         """Parse raw JS-extracted strings into a ScrapedEvent, or return None on failure."""
         try:
-            # Unescape HTML entities in title
+            # Collapse JS string escapes (esc_js turns an apostrophe into \'),
+            # then unescape HTML entities in title
+            title = _JS_ESCAPE_PATTERN.sub(r"\1", title)
             title = title.replace("&#038;", "&").replace("&amp;", "&").replace("&#8217;", "'")
 
             # Parse datetime — format is "2026-04-03 21:00" or "2026-04-03"

--- a/backend/requirements-dev.txt
+++ b/backend/requirements-dev.txt
@@ -1,0 +1,3 @@
+# Development / test dependencies (not installed in the production image).
+-r requirements.txt
+pytest==8.3.4

--- a/backend/tests/test_motorco.py
+++ b/backend/tests/test_motorco.py
@@ -1,0 +1,94 @@
+"""
+Unit tests for app.scrapers.motorco — the FullCalendar JS extraction.
+
+Covers the title field specifically: WordPress `esc_js` backslash-escapes any
+apostrophe inside the single-quoted `title:` value, and the previous
+stop-at-the-first-quote pattern terminated there, storing a truncated title with
+a trailing backslash. A fetch of the live calendar showed 61 of 625 titles
+carrying such an escape.
+
+Run from the backend/ directory:  python -m pytest tests/test_motorco.py
+The extraction is pure stdlib regex, so no DB, no network and no fixtures are
+needed — the scraper's own HTTP call is not exercised here.
+"""
+
+import sys
+from datetime import date, timedelta
+from pathlib import Path
+
+# Make `app` importable when running pytest from backend/.
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from app.scrapers.motorco import _EVENT_PATTERN, MotorcoScraper  # noqa: E402
+
+
+def _scraper() -> MotorcoScraper:
+    return MotorcoScraper("motorco", {"url": "https://motorcomusic.com/calendar/"})
+
+
+def _event_object(title: str, day: str) -> str:
+    """One JS event object, shaped like the live FullCalendar init array."""
+    return (
+        "{"
+        f"title: '{title}',"
+        f"start: '{day} 20:00',"
+        "url: 'https://motorcomusic.com/event/example/',"
+        "classNames: 'tcec-event-'"
+        "}"
+    )
+
+
+# `\\'` in this Python string is one backslash + one apostrophe in the JS source —
+# exactly what `esc_js` emits for a title containing an apostrophe.
+_ESCAPED = "Wednesday : It\\'s Fine"
+_PLAIN = "Hermanos Gutierrez"
+
+
+def test_escaped_apostrophe_title_is_captured_whole():
+    """The old pattern stopped at the escaped quote, yielding 'Wednesday : It\\'."""
+    m = _EVENT_PATTERN.search(_event_object(_ESCAPED, "2026-09-12"))
+    assert m is not None
+    assert m.group("title") == _ESCAPED
+
+
+def test_plain_title_still_captured():
+    m = _EVENT_PATTERN.search(_event_object(_PLAIN, "2026-09-12"))
+    assert m is not None
+    assert m.group("title") == _PLAIN
+
+
+def test_start_and_url_still_captured():
+    m = _EVENT_PATTERN.search(_event_object(_ESCAPED, "2026-09-12"))
+    assert m is not None
+    assert m.group("start") == "2026-09-12 20:00"
+    assert m.group("url") == "https://motorcomusic.com/event/example/"
+
+
+def test_both_titles_survive_in_a_mixed_array():
+    """Events were never dropped — each escaped title was silently truncated."""
+    html = "events: [%s,%s]," % (
+        _event_object(_ESCAPED, "2026-09-12"),
+        _event_object(_PLAIN, "2026-09-20"),
+    )
+    titles = [m.group("title") for m in _EVENT_PATTERN.finditer(html)]
+    assert titles == [_ESCAPED, _PLAIN]
+
+
+def test_parse_event_collapses_the_escape_to_a_real_apostrophe():
+    future = (date.today() + timedelta(days=45)).strftime("%Y-%m-%d %H:%M")
+    parsed = _scraper()._parse_event(
+        _ESCAPED, future, "https://motorcomusic.com/event/example/", date.today()
+    )
+    assert parsed is not None
+    assert parsed.name == "Wednesday : It's Fine"
+    assert parsed.artist == "Wednesday : It's Fine"
+    assert "\\" not in parsed.name
+
+
+def test_parse_event_leaves_a_plain_title_alone():
+    future = (date.today() + timedelta(days=45)).strftime("%Y-%m-%d %H:%M")
+    parsed = _scraper()._parse_event(
+        _PLAIN, future, "https://motorcomusic.com/event/example/", date.today()
+    )
+    assert parsed is not None
+    assert parsed.name == _PLAIN


### PR DESCRIPTION
The Motorco title regex matches the value with a non-greedy `(.+?)['"]`, which stops at the first quote it sees. WordPress `esc_js` backslash-escapes any apostrophe inside the single-quoted `title:` value, so a title containing an apostrophe terminates the match early and gets stored truncated, with a trailing backslash.

On a fetch of the live calendar, **61 of 625 titles** carried such an escape:

| | |
|---|---|
| JS source | `title: 'ANTHONY GREEN : This Tour Won\'t Save You'` |
| stored today | `ANTHONY GREEN : This Tour Won\` |
| stored after this | `ANTHONY GREEN : This Tour Won't Save You` |

No events are dropped — the titles are just silently wrong, which also weakens anything downstream that matches on artist name.

### The fix

Match the title as a proper JS string literal: the opening quote, then a run of escaped-or-non-quote characters, then the matching closing quote. The captured value keeps its backslashes, and `_parse_event` collapses them to the literal characters alongside the HTML-entity unescaping that's already there.

`start` and `url` values never contain a quote, so they keep the simpler stop-at-first-quote form.

Two incidental changes, both small and both in the same function:

- **The pattern moves to module level.** The extraction otherwise sits inside `scrape()` behind an HTTP call, so there's no way to test it without hitting the network. Happy to revert this if you'd rather keep it inline.
- **The dedup comment is corrected.** It said the regex "can produce overlapping matches" — `finditer` yields non-overlapping matches, so the guard is really against the same event appearing twice in the page markup. The dedup itself is unchanged.

### Tests

I noticed the repo doesn't have a test tier yet, so this adds `backend/tests/` with six tests covering the extraction and the unescaping. They're pure stdlib regex — no DB, no network, no fixtures.

```
cd backend
pip install -r requirements-dev.txt
python -m pytest tests/test_motorco.py
```

I matched the conventions from your `feature/filter-non-live-music` branch, which already introduces `requirements-dev.txt` with `pytest==8.3.4` and uses `sys.path.insert` to make `app` importable — so if that branch lands, these should sit alongside it without conflicting. If you'd rather not take a test directory in this PR, say so and I'll strip it back to the scraper change.

Verified against your `main` (`3f35a01`): all six pass, and every module in `app/scrapers/` still imports.
