### PR TITLE
Add live-music filter with classification + admin overrides

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,7 +27,7 @@ _context-history/
 .claude*
 CLAUDE.md
 
-# Claude-managed session files. `_*.md` above covers _SESSION-CONTEXT.md and the
-# archived copies inside _context-history/, but not the directory itself or _todo.
+# Claude-managed session files. `_*.md` above covers _SESSION-CONTEXT.md, _todo.md,
+# and the archived copies inside _context-history/ — it does not match the directory
+# itself, hence this line.
 _context-history/
-_todo

--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,9 @@ _context-history/
 .claude/
 .claude*
 CLAUDE.md
+
+# Claude-managed session files. These moved from a `_` prefix to a `.` prefix,
+# which `_*.md` above no longer covers.
+.SESSION-CONTEXT.md
+.context-history/
+.todo

--- a/.gitignore
+++ b/.gitignore
@@ -27,8 +27,7 @@ _context-history/
 .claude*
 CLAUDE.md
 
-# Claude-managed session files. These moved from a `_` prefix to a `.` prefix,
-# which `_*.md` above no longer covers.
-.SESSION-CONTEXT.md
-.context-history/
-.todo
+# Claude-managed session files. `_*.md` above covers _SESSION-CONTEXT.md and the
+# archived copies inside _context-history/, but not the directory itself or _todo.
+_context-history/
+_todo

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,9 @@
-FROM python:3.12-slim
+# Multi-stage so local development can have test dependencies without shipping them
+# to Cloud Run. `prod` is deliberately the LAST stage: an untargeted `docker build`
+# — which is what cloudbuild.yaml runs — resolves to the final stage, so production
+# stays lean by default and nobody has to remember a flag.
+
+FROM python:3.12-slim AS base
 
 WORKDIR /app
 
@@ -18,3 +23,15 @@ ENV GIT_COMMIT=$GIT_COMMIT
 EXPOSE 8000
 
 CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000"]
+
+
+# Development image — adds pytest and anything else in requirements-dev.txt.
+# Selected by docker-compose.yml via `target: dev`, so `docker-compose up --build`
+# gives you a container you can run the test suite in without a manual pip install.
+FROM base AS dev
+RUN pip install --no-cache-dir -r requirements-dev.txt
+
+
+# Production image. An alias of `base` with no test dependencies, kept last so it
+# is what an untargeted build produces.
+FROM base AS prod

--- a/backend/alembic/env.py
+++ b/backend/alembic/env.py
@@ -13,7 +13,7 @@ import os
 import sys
 from logging.config import fileConfig
 
-from sqlalchemy import engine_from_config, pool
+from sqlalchemy import engine_from_config, pool, text
 from alembic import context
 
 # Add parent directory to path so we can import app modules
@@ -41,6 +41,11 @@ if config.config_file_name is not None:
 # Point Alembic at the full set of ORM models so it can diff against the live schema
 target_metadata = Base.metadata
 
+# Advisory lock held while migrations run, so two processes cannot apply them at once.
+# The value is arbitrary but must never change: processes serialize only if they ask
+# for the same key.
+MIGRATION_LOCK_KEY = 4021755
+
 
 # --- Migration Runners ---
 
@@ -53,7 +58,28 @@ def run_migrations_offline():
 
 
 def run_migrations_online():
-    """Run migrations against a live database connection."""
+    """Run migrations against a live database connection, one process at a time.
+
+    Migrations run from the FastAPI lifespan handler (app/main.py), not as a deploy
+    step, so with Cloud Run at max-instances=2 two containers can boot together and
+    both call `upgrade head` against the same database. Both read alembic_version,
+    both decide the same work is outstanding, and whichever loses the race then fails
+    on an object the winner has already created. The exception escapes `lifespan`, so
+    that container never becomes healthy — a deploy that half-succeeds.
+
+    Taking an advisory lock *before* run_migrations() reads the version table
+    serializes them. The loser waits at the lock, then re-reads alembic_version and
+    correctly finds nothing to do.
+
+    pg_advisory_xact_lock rather than pg_advisory_lock, for two reasons. It releases
+    on commit or rollback with no explicit unlock, so a crashed or killed migration
+    cannot leave a lock wedging every future boot. And it stays correct through Neon's
+    transaction-mode pooler, which pins a transaction to a single backend but is free
+    to route the next statement of a *session* somewhere else — where a session-scoped
+    lock would be invisible.
+
+    Postgres-only, like the rest of this project.
+    """
     connectable = engine_from_config(
         config.get_section(config.config_ini_section, {}),
         prefix="sqlalchemy.",
@@ -62,6 +88,13 @@ def run_migrations_online():
     with connectable.connect() as connection:
         context.configure(connection=connection, target_metadata=target_metadata)
         with context.begin_transaction():
+            # Must precede run_migrations(): the point is to hold the lock across the
+            # read of alembic_version *and* the migrations themselves, so the decision
+            # about what is outstanding cannot go stale between the two.
+            connection.execute(
+                text("SELECT pg_advisory_xact_lock(:key)"),
+                {"key": MIGRATION_LOCK_KEY},
+            )
             context.run_migrations()
 
 

--- a/backend/alembic/versions/0003_add_live_music_classification.py
+++ b/backend/alembic/versions/0003_add_live_music_classification.py
@@ -1,0 +1,48 @@
+"""Alembic migration 0003: add live-music classification columns to events.
+
+Role: Adds the three columns that drive the live-music filter and admin override
+feature — is_live_music (the effective flag the calendar/feeds read),
+is_manual_override (protects admin decisions from being overwritten by re-scrapes),
+and classification_reason (human-readable explanation). Additive and safe on an
+existing DB: every current row defaults to is_live_music=True (visible) until the
+first post-migration scrape runs ScrapeManager.reclassify_all().
+Requires: A live PostgreSQL database at revision 0002.
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = '0003'
+down_revision = '0002'
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # server_default is set so the columns backfill on existing rows without a
+    # rewrite; the ORM-level Python default (models.py) handles new inserts.
+    op.add_column(
+        'events',
+        sa.Column('is_live_music', sa.Boolean(), nullable=False, server_default=sa.true()),
+    )
+    op.add_column(
+        'events',
+        sa.Column('is_manual_override', sa.Boolean(), nullable=False, server_default=sa.false()),
+    )
+    op.add_column(
+        'events',
+        sa.Column('classification_reason', sa.String(200), nullable=True),
+    )
+    op.create_index('ix_events_is_live_music', 'events', ['is_live_music'])
+
+    # Drop the server_defaults now that existing rows are backfilled; going forward
+    # the application layer supplies these values explicitly.
+    op.alter_column('events', 'is_live_music', server_default=None)
+    op.alter_column('events', 'is_manual_override', server_default=None)
+
+
+def downgrade() -> None:
+    op.drop_index('ix_events_is_live_music', table_name='events')
+    op.drop_column('events', 'classification_reason')
+    op.drop_column('events', 'is_manual_override')
+    op.drop_column('events', 'is_live_music')

--- a/backend/alembic/versions/0004_add_series_overrides.py
+++ b/backend/alembic/versions/0004_add_series_overrides.py
@@ -27,7 +27,11 @@ def upgrade() -> None:
         sa.Column('note', sa.String(500), nullable=True),
         sa.Column('created_at', sa.DateTime(), nullable=False),
         sa.Column('updated_at', sa.DateTime(), nullable=False),
-        sa.ForeignKeyConstraint(['venue_id'], ['venues.id']),
+        # ON DELETE CASCADE so retiring a venue cannot be blocked by its series rules.
+        # Edited into this migration rather than added by a later one: 0003-0005 have never
+        # been applied anywhere (both main and prod sit at 0002), so there is no deployed
+        # constraint to alter.
+        sa.ForeignKeyConstraint(['venue_id'], ['venues.id'], ondelete='CASCADE'),
         sa.PrimaryKeyConstraint('id'),
         sa.UniqueConstraint('venue_id', 'normalized_name', name='uq_series_override_key'),
     )

--- a/backend/alembic/versions/0004_add_series_overrides.py
+++ b/backend/alembic/versions/0004_add_series_overrides.py
@@ -1,0 +1,39 @@
+"""Alembic migration 0004: add the series_overrides table.
+
+Role: Backs admin series-level overrides for the live-music filter. A row keyed by
+(venue_id, normalized_name) forces is_live_music for every event in a recurring
+series, including future scraped instances (applied in ScrapeManager.reclassify_all).
+Additive and safe: creates a new empty table, touches no existing data.
+Requires: A live PostgreSQL database at revision 0003.
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = '0004'
+down_revision = '0003'
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        'series_overrides',
+        sa.Column('id', sa.Integer(), nullable=False),
+        sa.Column('venue_id', sa.Integer(), nullable=False),
+        sa.Column('normalized_name', sa.String(200), nullable=False),
+        sa.Column('display_name', sa.String(500), nullable=True),
+        sa.Column('is_live_music', sa.Boolean(), nullable=False),
+        sa.Column('note', sa.String(500), nullable=True),
+        sa.Column('created_at', sa.DateTime(), nullable=False),
+        sa.Column('updated_at', sa.DateTime(), nullable=False),
+        sa.ForeignKeyConstraint(['venue_id'], ['venues.id']),
+        sa.PrimaryKeyConstraint('id'),
+        sa.UniqueConstraint('venue_id', 'normalized_name', name='uq_series_override_key'),
+    )
+    op.create_index('ix_series_overrides_venue_id', 'series_overrides', ['venue_id'])
+
+
+def downgrade() -> None:
+    op.drop_index('ix_series_overrides_venue_id', table_name='series_overrides')
+    op.drop_table('series_overrides')

--- a/backend/alembic/versions/0005_add_event_approved_at.py
+++ b/backend/alembic/versions/0005_add_event_approved_at.py
@@ -1,0 +1,37 @@
+"""Alembic migration 0005: add events.approved_at.
+
+Role: Backs admin review tracking for the live-music filter. A non-null approved_at
+means someone has checked that event's classification and agreed with it; the admin
+list hides approved events by default so the queue only shows unreviewed work.
+
+Approval records agreement with a *specific verdict*, not the event as a whole:
+ScrapeManager.reclassify_all clears approved_at whenever it changes an event's
+is_live_music, so a re-classified event returns to the queue instead of staying
+hidden behind a stale approval.
+
+Additive and safe: adds one nullable column, so existing rows are simply unapproved
+and a rollback to the previous revision leaves the column unread rather than broken.
+Requires: A live PostgreSQL database at revision 0004.
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = '0005'
+down_revision = '0004'
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # Nullable with no server_default: every existing event starts unapproved, which
+    # is the correct starting state for a review queue.
+    op.add_column('events', sa.Column('approved_at', sa.DateTime(), nullable=True))
+    # Partial index — the common query filters approved_at IS NULL, and only a
+    # minority of rows will ever be non-null.
+    op.create_index('ix_events_approved_at', 'events', ['approved_at'])
+
+
+def downgrade() -> None:
+    op.drop_index('ix_events_approved_at', table_name='events')
+    op.drop_column('events', 'approved_at')

--- a/backend/app/admin_ui.py
+++ b/backend/app/admin_ui.py
@@ -16,16 +16,18 @@ LOGIN_HTML = """<!doctype html>
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>admin · triangle-shows</title>
 <style>
-  :root { color-scheme: dark; }
+  /* Deliberately green, not the public site's amber (--accent in frontend/css/styles.css),
+     so the admin surface is visually distinct from the live site at a glance. */
+  :root { color-scheme: dark; --accent:#4fae7a; }
   body { margin:0; min-height:100vh; display:grid; place-items:center;
          background:#0e0e10; color:#e8e6e3; font-family:'Space Mono',ui-monospace,monospace; }
   .box { width:min(90vw,340px); border:1px solid #2a2a2e; padding:1.6rem; border-radius:2px; }
-  h1 { font-size:0.95rem; letter-spacing:0.08em; text-transform:uppercase; color:#c87941; margin:0 0 1.2rem; }
+  h1 { font-size:0.95rem; letter-spacing:0.08em; text-transform:uppercase; color:var(--accent); margin:0 0 1.2rem; }
   input, button { width:100%; font-family:inherit; font-size:0.85rem; padding:0.55rem 0.6rem;
                   box-sizing:border-box; border-radius:2px; }
   input { background:#17171a; border:1px solid #2a2a2e; color:#e8e6e3; margin-bottom:0.7rem; }
-  input:focus { outline:none; border-color:#c87941; }
-  button { background:#c87941; border:1px solid #c87941; color:#0e0e10; cursor:pointer; font-weight:700; }
+  input:focus { outline:none; border-color:var(--accent); }
+  button { background:var(--accent); border:1px solid var(--accent); color:#0e0e10; cursor:pointer; font-weight:700; }
   button:hover { filter:brightness(1.1); }
   .err { color:#e0625f; font-size:0.75rem; min-height:1em; margin:0.7rem 0 0; }
 </style>
@@ -66,21 +68,24 @@ ADMIN_HTML = """<!doctype html>
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>admin · triangle-shows</title>
 <style>
-  :root { color-scheme: dark; }
+  /* Deliberately green, not the public site's amber (--accent in frontend/css/styles.css),
+     so the admin surface is visually distinct from the live site at a glance. */
+  :root { color-scheme: dark; --accent:#4fae7a; }
   * { box-sizing:border-box; }
   body { margin:0; background:#0e0e10; color:#e8e6e3;
          font-family:'Space Mono',ui-monospace,monospace; font-size:0.82rem; }
   header { display:flex; align-items:center; gap:1rem; padding:0.8rem 1.1rem;
            border-bottom:1px solid #2a2a2e; position:sticky; top:0; background:#0e0e10; z-index:2; }
-  header h1 { font-size:0.9rem; letter-spacing:0.08em; text-transform:uppercase; color:#c87941; margin:0; }
+  header h1 { font-size:0.9rem; letter-spacing:0.08em; text-transform:uppercase; color:var(--accent); margin:0; }
   header .sp { flex:1; }
-  a { color:#c87941; }
+  a { color:var(--accent); }
   main { padding:1.1rem; max-width:1100px; margin:0 auto; }
   .controls { display:flex; flex-wrap:wrap; gap:0.5rem; align-items:center; margin-bottom:1rem; }
   .fbtn, button.link { font-family:inherit; font-size:0.72rem; text-transform:uppercase; letter-spacing:0.06em;
           padding:0.3rem 0.6rem; border:1px solid #3a3a3e; background:transparent; color:#a8a6a3;
           cursor:pointer; border-radius:2px; }
-  .fbtn.on { background:#c87941; border-color:#c87941; color:#0e0e10; font-weight:700; }
+  .fbtn.on, button.link.on { background:var(--accent); border-color:var(--accent); color:#0e0e10; font-weight:700; }
+  button.link.on::after { content:' ×'; }
   #search { flex:1; min-width:160px; font-family:inherit; font-size:0.8rem; padding:0.35rem 0.6rem;
             background:#17171a; border:1px solid #2a2a2e; color:#e8e6e3; border-radius:2px; }
   #count { color:#8a8a8e; font-size:0.72rem; margin-left:auto; }
@@ -92,11 +97,36 @@ ADMIN_HTML = """<!doctype html>
   .b.live { background:#1f3d2a; color:#7fd69a; }
   .b.nonlive { background:#3d2020; color:#e08a88; }
   .b.manual { background:#3a2f12; color:#e0b45f; }
+  .b.mixed { background:#2a2a3d; color:#9a9ad6; }
   .reason { color:#8a8a8e; font-size:0.7rem; }
+  tr.grow { cursor:pointer; }
+  tr.grow:hover > td { background:#17171a; }
+  tr.grow td:first-child { color:#c8c6c3; }
+  .caret { display:inline-block; width:1em; color:var(--accent); }
+  .gcount { color:#8a8a8e; font-size:0.72rem; }
+  .divider { width:1px; align-self:stretch; background:#2a2a2e; margin:0 0.2rem; }
+  .warn { color:#e0b45f; }
+  tr.erow { cursor:pointer; }
+  tr.erow:hover > td { background:#17171a; }
+  tr.eopen > td { background:#17171a; }
+  tr.detail > td { background:#141417; border-bottom:1px solid #1e1e22; padding-top:0.4rem; }
+  tr.detail .dk { color:#8a8a8e; text-transform:uppercase; font-size:0.64rem; letter-spacing:0.06em; margin-right:0.4rem; }
+  tr.detail .desc { color:#c8c6c3; margin:0.35rem 0; max-width:60ch; line-height:1.45; }
+  tr.detail div { margin:0.12rem 0; }
+  td.actions button.ok { border-color:#2f5c40; color:#7fd69a; }
+  #help { background:#17171a; border:1px solid #2a2a2e; border-radius:2px;
+          padding:0.4rem 1rem 1rem; margin-top:1rem; max-width:76ch; }
+  #help h2 { font-size:0.72rem; text-transform:uppercase; letter-spacing:0.08em;
+             color:var(--accent); margin:1.1rem 0 0.3rem; }
+  #help p { color:#b8b6b3; line-height:1.55; margin:0.4rem 0; }
+  #help b { color:#e8e6e3; }
+  tr.child > td { border-bottom:1px solid #1a1a1e; }
+  tr.child td:first-child { padding-left:1.6rem; color:#8a8a8e; }
+  tr.child > td:first-child { border-left:2px solid #2a2a2e; }
   td.actions { white-space:nowrap; }
   td.actions button { font-family:inherit; font-size:0.68rem; margin:0.1rem 0.15rem 0.1rem 0; padding:0.22rem 0.45rem;
           border:1px solid #3a3a3e; background:transparent; color:#c8c6c3; cursor:pointer; border-radius:2px; }
-  td.actions button:hover { border-color:#c87941; color:#c87941; }
+  td.actions button:hover { border-color:var(--accent); color:var(--accent); }
   .series { color:#8a8a8e; }
   .empty { color:#8a8a8e; text-align:center; padding:1.5rem; }
   #rules { white-space:pre-wrap; background:#17171a; border:1px solid #2a2a2e; padding:0.8rem;
@@ -106,7 +136,8 @@ ADMIN_HTML = """<!doctype html>
 </head><body>
   <header>
     <h1>triangle-shows admin</h1>
-    <button class="link" onclick="showRules()">detection rules</button>
+    <button class="link" id="rulesBtn" aria-expanded="false" onclick="showRules()">detection rules</button>
+    <button class="link" id="helpBtn" aria-expanded="false" onclick="showHelp()">how this works</button>
     <span class="sp"></span>
     <a href="/admin/logout">log out</a>
   </header>
@@ -115,10 +146,58 @@ ADMIN_HTML = """<!doctype html>
       <button class="fbtn on" data-f="non_live" onclick="setFilter('non_live')">non-live</button>
       <button class="fbtn" data-f="live" onclick="setFilter('live')">live</button>
       <button class="fbtn" data-f="all" onclick="setFilter('all')">all</button>
+      <span class="divider"></span>
+      <button class="fbtn tog" id="futureBtn" aria-pressed="false" onclick="toggleFuture()">future dates only</button>
+      <button class="fbtn tog" id="approvedBtn" aria-pressed="false" onclick="toggleApproved()">show approved</button>
       <input id="search" placeholder="search name / artist...">
       <span id="count"></span>
     </div>
     <pre id="rules" class="hidden"></pre>
+    <div id="help" class="hidden">
+      <h2>What this page is for</h2>
+      <p>Every event is flagged <b>live music</b> or <b>non-live</b>. The public calendar
+      uses that flag to let visitors hide karaoke, trivia, DJ nights and the like. This page
+      is where wrong guesses get corrected.</p>
+      <p>The list is a <b>review queue</b>: it opens on non-live events, because those are
+      the ones the detector had to make a judgement call about. Click any row to see its
+      description, genre and a link to the venue page — often the only way to settle an
+      ambiguous one.</p>
+
+      <h2>The two kinds of correction</h2>
+      <p><b>mark live / mark non-live</b> fixes one event. It sets a manual override, which
+      survives re-scrapes and reclassification — the detector will never overwrite it.</p>
+      <p><b>series live / series non-live</b> creates a standing rule for a repeating event
+      at one venue, matched on its name. It applies to every date in the series <i>and to
+      future instances that haven't been scraped yet</i>. The number on the button is how
+      many events it currently affects. Use this for anything recurring: one rule beats
+      twenty corrections.</p>
+
+      <h2>Approving</h2>
+      <p><b>approve</b> means "I checked this and the flag is right". It doesn't change the
+      flag — it just removes the event from the queue so you can tell reviewed work from
+      work you haven't looked at yet. On a collapsed series row it approves every date at
+      once.</p>
+      <p>An approval applies to <i>that verdict</i>, not the event forever. If something
+      later changes the flag — a new series rule, or the detector spotting a recurrence it
+      had missed — the approval is dropped and the event comes back to the queue. Marking an
+      event live or non-live by hand also approves it, since you've just made the call.</p>
+
+      <h2>Reading the list</h2>
+      <p>Repeating events collapse into one row showing a date range and a count; click to
+      expand. A collapsed row sits at the series' <i>first</i> date, so the dates in the
+      left column aren't a straight timeline — a row near the top may run for months.</p>
+      <p><b>mixed</b> means some dates in a series are flagged differently from others,
+      usually because one was overridden by hand.</p>
+      <p>The list covers the last 30 days as well as everything upcoming, because the
+      calendar can be scrolled back. <b>future dates only</b> narrows it; <b>show approved</b>
+      brings reviewed events back into view. Neither changes what a series action affects —
+      that always reaches every matching event, shown or not.</p>
+
+      <h2>Where the guesses come from</h2>
+      <p><b>detection rules</b> lists the automatic criteria: keyword matches, and how many
+      repeats at one venue count as a recurring series. Anything auto-flagged shows its
+      reason next to the badge.</p>
+    </div>
     <table>
       <thead><tr><th>date</th><th>event</th><th>status</th><th>actions</th></tr></thead>
       <tbody id="tbody"></tbody>
@@ -127,7 +206,7 @@ ADMIN_HTML = """<!doctype html>
 <script>
   let RULES = null;
   const $ = (s) => document.querySelector(s);
-  const state = { filter: 'non_live', search: '' };
+  const state = { filter: 'non_live', search: '', futureOnly: false, showApproved: false };
 
   async function api(path, opts) {
     const r = await fetch(path, Object.assign({ headers: { 'Content-Type': 'application/json' } }, opts));
@@ -148,8 +227,17 @@ ADMIN_HTML = """<!doctype html>
            '<span class="reason">' + esc(ev.classification_reason || '') + '</span>';
   }
 
+  function approveAction(ev, isSeries, n) {
+    const suffix = (isSeries && n > 1) ? ' (' + n + ')' : '';
+    if (ev.is_approved && !isSeries) {
+      return '<button class="ok" onclick="unapprove(' + ev.id + ',false)">approved ✓</button>';
+    }
+    const fn = isSeries ? 'approve(' + ev.id + ',true)' : 'approve(' + ev.id + ',false)';
+    return '<button onclick="' + fn + '">approve' + suffix + '</button>';
+  }
+
   function actions(ev) {
-    let a = '';
+    let a = approveAction(ev, false, 1) + ' ';
     if (ev.is_manual_override) {
       a += '<button onclick="clearOv(' + ev.id + ')">clear override</button>';
     } else {
@@ -166,20 +254,152 @@ ADMIN_HTML = """<!doctype html>
     return a;
   }
 
-  function render(evs, count) {
-    $('#count').textContent = count + ' event(s)';
-    $('#tbody').innerHTML = evs.length ? evs.map((ev) =>
-      '<tr><td>' + ev.date + '</td>' +
+  // Grouping. Events sharing a venue and series_key collapse into one expandable
+  // row. series_key comes from the server's normalize_series_name, the same key a
+  // series override matches on — so what you see grouped is exactly what a series
+  // action will affect. GROUPS is rebuilt on every load; `expanded` is keyed by
+  // series so open rows survive the re-render that follows an action.
+  let GROUPS = [];
+  const expanded = new Set();
+
+  function groupKeyOf(ev) {
+    // A blank series_key would otherwise collapse unrelated events into one row.
+    if (!ev.series_key) return 'ev||' + ev.id;
+    return 'series||' + (ev.venue_slug || '') + '||' + ev.series_key;
+  }
+
+  function buildGroups(evs) {
+    const map = new Map();
+    evs.forEach((ev) => {
+      const k = groupKeyOf(ev);
+      if (!map.has(k)) map.set(k, []);
+      map.get(k).push(ev);
+    });
+    return Array.from(map.entries());
+  }
+
+  function groupBadge(evs) {
+    const live = evs.filter((e) => e.is_live_music).length;
+    if (live === evs.length) return '<span class="b live">live</span>';
+    if (live === 0) return '<span class="b nonlive">non-live</span>';
+    return '<span class="b mixed">mixed</span> <span class="reason">' +
+           live + ' live / ' + (evs.length - live) + ' non-live</span>';
+  }
+
+  function seriesActions(ev) {
+    if (ev.series_override_id) {
+      return '<span class="series">series: ' + (ev.series_override_is_live ? 'live' : 'non-live') +
+             ' <button onclick="delSeries(' + ev.series_override_id + ')">remove</button></span>';
+    }
+    // Put the blast radius on the button. series_size counts every matching event in
+    // the reclassify range, not just the rows on screen, so a collapsed or filtered
+    // view can't make the action look smaller than it is. Omitted at 1, where there
+    // is no series to speak of.
+    const n = ev.series_size > 1 ? ' (' + ev.series_size + ')' : '';
+    const t = ev.series_size > 1
+      ? ' title="applies to ' + ev.series_size + ' events at this venue, including ones not shown"'
+      : '';
+    return '<button' + t + ' onclick="series(' + ev.id + ',true)">series live' + n + '</button>' +
+           '<button' + t + ' onclick="series(' + ev.id + ',false)">series non-live' + n + '</button>';
+  }
+
+  // Event ids whose detail panel is open. Like `expanded`, this is keyed by id so
+  // open panels survive the re-render that follows every action.
+  const detailOpen = new Set();
+
+  function toggleDetail(id) {
+    if (detailOpen.has(id)) detailOpen.delete(id); else detailOpen.add(id);
+    renderGroups();
+  }
+
+  function detailRow(ev) {
+    let bits = '';
+    if (ev.genre) bits += '<div><span class="dk">genre</span> ' + esc(ev.genre) + '</div>';
+    if (ev.age_restriction) bits += '<div><span class="dk">ages</span> ' + esc(ev.age_restriction) + '</div>';
+    if (ev.artist && ev.artist !== ev.name) bits += '<div><span class="dk">listed as</span> ' + esc(ev.name) + '</div>';
+    if (ev.description) bits += '<div class="desc">' + esc(ev.description) + '</div>';
+    if (ev.ticket_url) {
+      bits += '<div><a href="' + esc(ev.ticket_url) + '" target="_blank" rel="noopener noreferrer">open venue page</a></div>';
+    }
+    // Most events carry no description at all, so say so rather than opening an
+    // empty panel that looks broken.
+    if (!bits) bits = '<div class="dk">no description, genre, or link on this event</div>';
+    return '<tr class="detail"><td></td><td colspan="3">' + bits + '</td></tr>';
+  }
+
+  function eventRow(ev, cls) {
+    const open = detailOpen.has(ev.id);
+    return '<tr class="' + cls + ' erow' + (open ? ' eopen' : '') + '" onclick="toggleDetail(' + ev.id + ')">' +
+      '<td>' + ev.date + '</td>' +
       '<td>' + esc(ev.artist || ev.name) + '<div class="sub">' + esc(ev.venue_name || '') + '</div></td>' +
       '<td>' + badge(ev) + '</td>' +
-      '<td class="actions">' + actions(ev) + '</td></tr>'
-    ).join('') : '<tr><td colspan="4" class="empty">no events</td></tr>';
+      '<td class="actions" onclick="event.stopPropagation()">' + actions(ev) + '</td></tr>' +
+      (open ? detailRow(ev) : '');
+  }
+
+  function groupRow(i, evs) {
+    const first = evs[0], last = evs[evs.length - 1];
+    const open = expanded.has(GROUPS[i][0]);
+    const dates = first.date === last.date ? first.date : first.date + ' - ' + last.date;
+    return '<tr class="grow" onclick="toggleGroup(' + i + ')">' +
+      '<td><span class="caret">' + (open ? 'v' : '>') + '</span>' + dates + '</td>' +
+      '<td>' + esc(first.name) + ' <span class="gcount">(' + evs.length + ' dates)</span>' +
+        '<div class="sub">' + esc(first.venue_name || '') + '</div></td>' +
+      '<td>' + groupBadge(evs) + '</td>' +
+      '<td class="actions" onclick="event.stopPropagation()">' +
+        approveAction(first, true, first.series_size) + ' ' + seriesActions(first) +
+      '</td></tr>';
+  }
+
+  function renderGroups() {
+    if (!GROUPS.length) {
+      $('#tbody').innerHTML = '<tr><td colspan="4" class="empty">no events</td></tr>';
+      return;
+    }
+    let html = '';
+    GROUPS.forEach((entry, i) => {
+      const evs = entry[1];
+      // A one-off event has nothing to collapse, so render it as a plain row.
+      if (evs.length === 1) { html += eventRow(evs[0], ''); return; }
+      html += groupRow(i, evs);
+      if (expanded.has(entry[0])) {
+        evs.forEach((ev) => { html += eventRow(ev, 'child'); });
+      }
+    });
+    $('#tbody').innerHTML = html;
+  }
+
+  function toggleGroup(i) {
+    const k = GROUPS[i][0];
+    if (expanded.has(k)) expanded.delete(k); else expanded.add(k);
+    renderGroups();
+  }
+
+  function render(evs, count, total, approvedHidden) {
+    GROUPS = buildGroups(evs);
+    const seriesCount = GROUPS.filter((g) => g[1].length > 1).length;
+    const hidden = approvedHidden ? ' · ' + approvedHidden + ' approved hidden' : '';
+    // Say when the view is partial. A series action reaches every matching event,
+    // including ones cut off by the row cap or hidden by future-only, so a silent
+    // count would understate what a series button affects.
+    const truncated = total > count;
+    $('#count').innerHTML =
+      (truncated ? '<span class="warn">' + count + ' of ' + total + ' shown</span>'
+                 : count + ' event(s)') +
+      (seriesCount ? ', ' + seriesCount + ' series' : '') +
+      (state.futureOnly ? ' · past dates hidden' : '') + hidden;
+    renderGroups();
   }
 
   async function load() {
-    const q = new URLSearchParams({ filter: state.filter, search: state.search });
+    const q = new URLSearchParams({
+      filter: state.filter,
+      search: state.search,
+      future_only: state.futureOnly ? 'true' : 'false',
+      show_approved: state.showApproved ? 'true' : 'false',
+    });
     const data = await api('/admin/api/events?' + q.toString());
-    render(data.events, data.count);
+    render(data.events, data.count, data.total, data.approved_hidden);
   }
 
   async function ov(id, isLive) {
@@ -200,13 +420,55 @@ ADMIN_HTML = """<!doctype html>
   }
   function setFilter(f) {
     state.filter = f;
-    document.querySelectorAll('.fbtn').forEach((b) => b.classList.toggle('on', b.dataset.f === f));
+    // Only the data-f buttons are a radio group; the future-only toggle is
+    // independent and must not be cleared when the classification filter changes.
+    document.querySelectorAll('.fbtn[data-f]').forEach((b) => b.classList.toggle('on', b.dataset.f === f));
     load();
   }
+
+  function toggleFuture() {
+    state.futureOnly = !state.futureOnly;
+    $('#futureBtn').classList.toggle('on', state.futureOnly);
+    $('#futureBtn').setAttribute('aria-pressed', state.futureOnly ? 'true' : 'false');
+    load();
+  }
+
+  function toggleApproved() {
+    state.showApproved = !state.showApproved;
+    $('#approvedBtn').classList.toggle('on', state.showApproved);
+    $('#approvedBtn').setAttribute('aria-pressed', state.showApproved ? 'true' : 'false');
+    load();
+  }
+
+  async function approve(id, isSeries) {
+    await api('/admin/api/events/' + id + '/approve?series=' + (isSeries ? 'true' : 'false'), { method: 'POST' });
+    load();
+  }
+  async function unapprove(id, isSeries) {
+    await api('/admin/api/events/' + id + '/unapprove?series=' + (isSeries ? 'true' : 'false'), { method: 'POST' });
+    load();
+  }
+  // Panel toggles. Reflect open/closed on the button itself, so each reads as a
+  // toggle rather than a one-way action and it's obvious how to dismiss it. The two
+  // panels are mutually exclusive — opening one closes the other.
+  function setPanel(panelId, btnId, shown) {
+    $(panelId).classList.toggle('hidden', !shown);
+    $(btnId).classList.toggle('on', shown);
+    $(btnId).setAttribute('aria-expanded', shown ? 'true' : 'false');
+  }
+
   async function showRules() {
     if (!RULES) RULES = await api('/admin/api/rules');
     $('#rules').textContent = JSON.stringify(RULES, null, 2);
-    $('#rules').classList.toggle('hidden');
+    const shown = $('#rules').classList.contains('hidden');
+    setPanel('#rules', '#rulesBtn', shown);
+    if (shown) setPanel('#help', '#helpBtn', false);
+  }
+
+  function showHelp() {
+    const shown = $('#help').classList.contains('hidden');
+    setPanel('#help', '#helpBtn', shown);
+    if (shown) setPanel('#rules', '#rulesBtn', false);
   }
 
   let t;

--- a/backend/app/admin_ui.py
+++ b/backend/app/admin_ui.py
@@ -1,0 +1,222 @@
+"""
+Static HTML/JS for the admin subsite, served by app.api.admin.
+
+Role: Two self-contained pages — a login screen and the moderation dashboard —
+returned as strings by the admin routes. Kept out of the public `frontend/` static
+mount so the dashboard is only reachable through the auth-guarded route. All data
+is loaded from the guarded /admin/api/* endpoints via fetch; these strings contain
+no secrets. Plain triple-quoted strings (NOT f-strings) so JS `${}`/`{}` are literal.
+"""
+
+# --- Login page ---
+
+LOGIN_HTML = """<!doctype html>
+<html lang="en"><head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>admin · triangle-shows</title>
+<style>
+  :root { color-scheme: dark; }
+  body { margin:0; min-height:100vh; display:grid; place-items:center;
+         background:#0e0e10; color:#e8e6e3; font-family:'Space Mono',ui-monospace,monospace; }
+  .box { width:min(90vw,340px); border:1px solid #2a2a2e; padding:1.6rem; border-radius:2px; }
+  h1 { font-size:0.95rem; letter-spacing:0.08em; text-transform:uppercase; color:#c87941; margin:0 0 1.2rem; }
+  input, button { width:100%; font-family:inherit; font-size:0.85rem; padding:0.55rem 0.6rem;
+                  box-sizing:border-box; border-radius:2px; }
+  input { background:#17171a; border:1px solid #2a2a2e; color:#e8e6e3; margin-bottom:0.7rem; }
+  input:focus { outline:none; border-color:#c87941; }
+  button { background:#c87941; border:1px solid #c87941; color:#0e0e10; cursor:pointer; font-weight:700; }
+  button:hover { filter:brightness(1.1); }
+  .err { color:#e0625f; font-size:0.75rem; min-height:1em; margin:0.7rem 0 0; }
+</style>
+</head><body>
+  <div class="box">
+    <h1>triangle-shows admin</h1>
+    <form id="f">
+      <input type="password" id="pw" placeholder="password" autocomplete="current-password" autofocus>
+      <button type="submit">log in</button>
+    </form>
+    <p id="err" class="err"></p>
+  </div>
+<script>
+  const f = document.getElementById('f'), err = document.getElementById('err');
+  f.addEventListener('submit', async (e) => {
+    e.preventDefault();
+    err.textContent = '';
+    try {
+      const r = await fetch('/admin/login', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ password: document.getElementById('pw').value }),
+      });
+      if (r.ok) { location.href = '/admin'; }
+      else { err.textContent = 'invalid password'; }
+    } catch (_) { err.textContent = 'something went wrong'; }
+  });
+</script>
+</body></html>
+"""
+
+
+# --- Dashboard page ---
+
+ADMIN_HTML = """<!doctype html>
+<html lang="en"><head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>admin · triangle-shows</title>
+<style>
+  :root { color-scheme: dark; }
+  * { box-sizing:border-box; }
+  body { margin:0; background:#0e0e10; color:#e8e6e3;
+         font-family:'Space Mono',ui-monospace,monospace; font-size:0.82rem; }
+  header { display:flex; align-items:center; gap:1rem; padding:0.8rem 1.1rem;
+           border-bottom:1px solid #2a2a2e; position:sticky; top:0; background:#0e0e10; z-index:2; }
+  header h1 { font-size:0.9rem; letter-spacing:0.08em; text-transform:uppercase; color:#c87941; margin:0; }
+  header .sp { flex:1; }
+  a { color:#c87941; }
+  main { padding:1.1rem; max-width:1100px; margin:0 auto; }
+  .controls { display:flex; flex-wrap:wrap; gap:0.5rem; align-items:center; margin-bottom:1rem; }
+  .fbtn, button.link { font-family:inherit; font-size:0.72rem; text-transform:uppercase; letter-spacing:0.06em;
+          padding:0.3rem 0.6rem; border:1px solid #3a3a3e; background:transparent; color:#a8a6a3;
+          cursor:pointer; border-radius:2px; }
+  .fbtn.on { background:#c87941; border-color:#c87941; color:#0e0e10; font-weight:700; }
+  #search { flex:1; min-width:160px; font-family:inherit; font-size:0.8rem; padding:0.35rem 0.6rem;
+            background:#17171a; border:1px solid #2a2a2e; color:#e8e6e3; border-radius:2px; }
+  #count { color:#8a8a8e; font-size:0.72rem; margin-left:auto; }
+  table { width:100%; border-collapse:collapse; }
+  th, td { text-align:left; padding:0.5rem 0.5rem; border-bottom:1px solid #1e1e22; vertical-align:top; }
+  th { color:#8a8a8e; font-size:0.66rem; text-transform:uppercase; letter-spacing:0.08em; }
+  td .sub { color:#8a8a8e; font-size:0.72rem; margin-top:0.15rem; }
+  .b { display:inline-block; padding:0.05rem 0.4rem; border-radius:2px; font-size:0.68rem; font-weight:700; text-transform:uppercase; }
+  .b.live { background:#1f3d2a; color:#7fd69a; }
+  .b.nonlive { background:#3d2020; color:#e08a88; }
+  .b.manual { background:#3a2f12; color:#e0b45f; }
+  .reason { color:#8a8a8e; font-size:0.7rem; }
+  td.actions { white-space:nowrap; }
+  td.actions button { font-family:inherit; font-size:0.68rem; margin:0.1rem 0.15rem 0.1rem 0; padding:0.22rem 0.45rem;
+          border:1px solid #3a3a3e; background:transparent; color:#c8c6c3; cursor:pointer; border-radius:2px; }
+  td.actions button:hover { border-color:#c87941; color:#c87941; }
+  .series { color:#8a8a8e; }
+  .empty { color:#8a8a8e; text-align:center; padding:1.5rem; }
+  #rules { white-space:pre-wrap; background:#17171a; border:1px solid #2a2a2e; padding:0.8rem;
+           border-radius:2px; font-size:0.72rem; margin-top:1rem; color:#b8b6b3; }
+  .hidden { display:none; }
+</style>
+</head><body>
+  <header>
+    <h1>triangle-shows admin</h1>
+    <button class="link" onclick="showRules()">detection rules</button>
+    <span class="sp"></span>
+    <a href="/admin/logout">log out</a>
+  </header>
+  <main>
+    <div class="controls">
+      <button class="fbtn on" data-f="non_live" onclick="setFilter('non_live')">non-live</button>
+      <button class="fbtn" data-f="live" onclick="setFilter('live')">live</button>
+      <button class="fbtn" data-f="all" onclick="setFilter('all')">all</button>
+      <input id="search" placeholder="search name / artist...">
+      <span id="count"></span>
+    </div>
+    <pre id="rules" class="hidden"></pre>
+    <table>
+      <thead><tr><th>date</th><th>event</th><th>status</th><th>actions</th></tr></thead>
+      <tbody id="tbody"></tbody>
+    </table>
+  </main>
+<script>
+  let RULES = null;
+  const $ = (s) => document.querySelector(s);
+  const state = { filter: 'non_live', search: '' };
+
+  async function api(path, opts) {
+    const r = await fetch(path, Object.assign({ headers: { 'Content-Type': 'application/json' } }, opts));
+    if (r.status === 401) { location.href = '/admin/login'; throw new Error('unauth'); }
+    if (!r.ok) throw new Error('http ' + r.status);
+    return r.status === 204 ? null : r.json();
+  }
+
+  function esc(s) {
+    return (s || '').replace(/[&<>"]/g, (c) => ({ '&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;' }[c]));
+  }
+
+  function badge(ev) {
+    if (ev.is_manual_override)
+      return '<span class="b manual">manual: ' + (ev.is_live_music ? 'live' : 'non-live') + '</span>';
+    return '<span class="b ' + (ev.is_live_music ? 'live' : 'nonlive') + '">' +
+           (ev.is_live_music ? 'live' : 'non-live') + '</span> ' +
+           '<span class="reason">' + esc(ev.classification_reason || '') + '</span>';
+  }
+
+  function actions(ev) {
+    let a = '';
+    if (ev.is_manual_override) {
+      a += '<button onclick="clearOv(' + ev.id + ')">clear override</button>';
+    } else {
+      a += '<button onclick="ov(' + ev.id + ',true)">mark live</button>';
+      a += '<button onclick="ov(' + ev.id + ',false)">mark non-live</button>';
+    }
+    if (ev.series_override_id) {
+      a += ' <span class="series">series: ' + (ev.series_override_is_live ? 'live' : 'non-live') +
+           ' <button onclick="delSeries(' + ev.series_override_id + ')">remove</button></span>';
+    } else {
+      a += ' <button onclick="series(' + ev.id + ',true)">series live</button>';
+      a += '<button onclick="series(' + ev.id + ',false)">series non-live</button>';
+    }
+    return a;
+  }
+
+  function render(evs, count) {
+    $('#count').textContent = count + ' event(s)';
+    $('#tbody').innerHTML = evs.length ? evs.map((ev) =>
+      '<tr><td>' + ev.date + '</td>' +
+      '<td>' + esc(ev.artist || ev.name) + '<div class="sub">' + esc(ev.venue_name || '') + '</div></td>' +
+      '<td>' + badge(ev) + '</td>' +
+      '<td class="actions">' + actions(ev) + '</td></tr>'
+    ).join('') : '<tr><td colspan="4" class="empty">no events</td></tr>';
+  }
+
+  async function load() {
+    const q = new URLSearchParams({ filter: state.filter, search: state.search });
+    const data = await api('/admin/api/events?' + q.toString());
+    render(data.events, data.count);
+  }
+
+  async function ov(id, isLive) {
+    await api('/admin/api/events/' + id + '/override', { method: 'POST', body: JSON.stringify({ is_live_music: isLive }) });
+    load();
+  }
+  async function clearOv(id) {
+    await api('/admin/api/events/' + id + '/clear-override', { method: 'POST' });
+    load();
+  }
+  async function series(eventId, isLive) {
+    await api('/admin/api/series', { method: 'POST', body: JSON.stringify({ event_id: eventId, is_live_music: isLive }) });
+    load();
+  }
+  async function delSeries(id) {
+    await api('/admin/api/series/' + id, { method: 'DELETE' });
+    load();
+  }
+  function setFilter(f) {
+    state.filter = f;
+    document.querySelectorAll('.fbtn').forEach((b) => b.classList.toggle('on', b.dataset.f === f));
+    load();
+  }
+  async function showRules() {
+    if (!RULES) RULES = await api('/admin/api/rules');
+    $('#rules').textContent = JSON.stringify(RULES, null, 2);
+    $('#rules').classList.toggle('hidden');
+  }
+
+  let t;
+  document.addEventListener('DOMContentLoaded', () => {
+    $('#search').addEventListener('input', (e) => {
+      clearTimeout(t);
+      t = setTimeout(() => { state.search = e.target.value.trim(); load(); }, 300);
+    });
+    load();
+  });
+</script>
+</body></html>
+"""

--- a/backend/app/api/admin.py
+++ b/backend/app/api/admin.py
@@ -1,0 +1,287 @@
+"""
+Admin subsite mounted at /admin: password-gated UI + JSON API for reviewing and
+overriding live-music classification.
+
+Role: Lets a site admin flip an event's is_live_music flag (per-event manual
+override), manage series-level overrides (SeriesOverride), and view the automatic
+detection criteria. Auth is a single shared password (settings.ADMIN_PASSWORD)
+exchanged for an itsdangerous-signed session cookie; if ADMIN_PASSWORD is blank the
+admin is disabled (fails closed). Must be registered before the "/" static mount in
+main.py so these routes take priority over the catch-all.
+Requires: async PostgreSQL session, app.classifier, app.scrapers.manager, itsdangerous.
+"""
+import secrets
+from datetime import date
+from typing import Optional
+
+from fastapi import APIRouter, Depends, HTTPException, Request, Query
+from fastapi.responses import HTMLResponse, JSONResponse, RedirectResponse
+from itsdangerous import URLSafeTimedSerializer, BadSignature, SignatureExpired
+from pydantic import BaseModel
+from sqlalchemy import select, and_, or_
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import joinedload
+
+from app.config import settings
+from app.database import get_session
+from app.models import Event, Venue, SeriesOverride
+from app.classifier import normalize_series_name, criteria_summary
+from app.scrapers.manager import ScrapeManager
+from app.admin_ui import LOGIN_HTML, ADMIN_HTML
+
+router = APIRouter(prefix="/admin", tags=["admin"])
+
+# --- Session cookie handling ---
+
+COOKIE_NAME = "ts_admin"
+SESSION_MAX_AGE = 60 * 60 * 12  # 12 hours
+
+# Prefer the configured secret; fall back to an ephemeral per-process key for local
+# dev (cookies won't survive a restart and won't validate across multiple Cloud Run
+# instances — SESSION_SECRET must be set in production).
+_signing_key = settings.SESSION_SECRET or secrets.token_urlsafe(32)
+_serializer = URLSafeTimedSerializer(_signing_key, salt="ts-admin-session")
+
+
+def _admin_enabled() -> bool:
+    """Admin is reachable only when a password is configured."""
+    return bool(settings.ADMIN_PASSWORD)
+
+
+def _issue_cookie(response) -> None:
+    token = _serializer.dumps("admin")
+    response.set_cookie(
+        COOKIE_NAME,
+        token,
+        max_age=SESSION_MAX_AGE,
+        httponly=True,
+        samesite="lax",  # blocks the cookie on cross-site POSTs -> basic CSRF protection
+        secure=(settings.APP_ENV == "production"),
+        path="/admin",
+    )
+
+
+def _is_authenticated(request: Request) -> bool:
+    token = request.cookies.get(COOKIE_NAME)
+    if not token:
+        return False
+    try:
+        _serializer.loads(token, max_age=SESSION_MAX_AGE)
+        return True
+    except (BadSignature, SignatureExpired):
+        return False
+
+
+async def require_admin(request: Request) -> bool:
+    """Dependency guarding /admin/api/* — raises 401 for the frontend to redirect on."""
+    if not _is_authenticated(request):
+        raise HTTPException(status_code=401, detail="Not authenticated")
+    return True
+
+
+# --- Request bodies ---
+
+class LoginBody(BaseModel):
+    password: str
+
+
+class OverrideBody(BaseModel):
+    is_live_music: bool
+
+
+class SeriesBody(BaseModel):
+    event_id: int
+    is_live_music: bool
+    note: Optional[str] = None
+
+
+# --- Auth + page routes ---
+
+@router.get("/login", response_class=HTMLResponse)
+async def login_page() -> HTMLResponse:
+    return HTMLResponse(LOGIN_HTML)
+
+
+@router.post("/login")
+async def login_submit(body: LoginBody):
+    # compare_digest guards against timing attacks; also fails closed when no
+    # password is configured (compare against "" would otherwise accept "").
+    if _admin_enabled() and secrets.compare_digest(body.password, settings.ADMIN_PASSWORD):
+        response = JSONResponse({"ok": True})
+        _issue_cookie(response)
+        return response
+    return JSONResponse({"ok": False, "error": "invalid"}, status_code=401)
+
+
+@router.get("/logout")
+async def logout() -> RedirectResponse:
+    response = RedirectResponse("/admin/login", status_code=303)
+    response.delete_cookie(COOKIE_NAME, path="/admin")
+    return response
+
+
+@router.get("", response_class=HTMLResponse)
+async def admin_page(request: Request):
+    if not _is_authenticated(request):
+        return RedirectResponse("/admin/login", status_code=303)
+    return HTMLResponse(ADMIN_HTML)
+
+
+# --- JSON API (all guarded) ---
+
+@router.get("/api/rules", dependencies=[Depends(require_admin)])
+async def admin_rules() -> dict:
+    """Return the current automatic detection criteria for display."""
+    return criteria_summary()
+
+
+@router.get("/api/events", dependencies=[Depends(require_admin)])
+async def admin_events(
+    filter: str = Query("non_live", pattern="^(non_live|live|all)$"),
+    search: Optional[str] = None,
+    limit: int = Query(200, ge=1, le=1000),
+    session: AsyncSession = Depends(get_session),
+) -> dict:
+    """List upcoming events with classification + override state for moderation."""
+    conditions = [Event.date >= date.today()]
+    if filter == "non_live":
+        conditions.append(Event.is_live_music.is_(False))
+    elif filter == "live":
+        conditions.append(Event.is_live_music.is_(True))
+    if search:
+        term = f"%{search}%"
+        conditions.append(or_(Event.name.ilike(term), Event.artist.ilike(term)))
+
+    result = await session.execute(
+        select(Event)
+        .options(joinedload(Event.venue))
+        .where(and_(*conditions))
+        .order_by(Event.date)
+        .limit(limit)
+    )
+    events = result.unique().scalars().all()
+
+    # Annotate each event with any matching series override.
+    so_result = await session.execute(select(SeriesOverride))
+    series = {(s.venue_id, s.normalized_name): s for s in so_result.scalars().all()}
+
+    out = []
+    for e in events:
+        so = series.get((e.venue_id, normalize_series_name(e.name)))
+        out.append({
+            "id": e.id,
+            "name": e.name,
+            "artist": e.artist,
+            "date": e.date.isoformat(),
+            "venue_name": e.venue.name if e.venue else None,
+            "venue_slug": e.venue.slug if e.venue else None,
+            "is_live_music": e.is_live_music,
+            "is_manual_override": e.is_manual_override,
+            "classification_reason": e.classification_reason,
+            "series_override_id": so.id if so else None,
+            "series_override_is_live": so.is_live_music if so else None,
+        })
+    return {"events": out, "count": len(out)}
+
+
+@router.post("/api/events/{event_id}/override", dependencies=[Depends(require_admin)])
+async def set_override(
+    event_id: int,
+    body: OverrideBody,
+    session: AsyncSession = Depends(get_session),
+) -> dict:
+    """Force a single event's flag. Marked as a manual override so re-scrapes keep it."""
+    event = await session.get(Event, event_id)
+    if not event:
+        raise HTTPException(status_code=404, detail="Event not found")
+    event.is_live_music = body.is_live_music
+    event.is_manual_override = True
+    event.classification_reason = "manual"
+    await session.commit()
+    return {"ok": True, "id": event_id, "is_live_music": body.is_live_music}
+
+
+@router.post("/api/events/{event_id}/clear-override", dependencies=[Depends(require_admin)])
+async def clear_override(
+    event_id: int,
+    session: AsyncSession = Depends(get_session),
+) -> dict:
+    """Drop a per-event override and recompute automatic/series/venue classification."""
+    event = await session.get(Event, event_id)
+    if not event:
+        raise HTTPException(status_code=404, detail="Event not found")
+    event.is_manual_override = False
+    await session.commit()
+    # Recompute now so the UI reflects the automatic result immediately.
+    await ScrapeManager(session).reclassify_all()
+    return {"ok": True, "id": event_id}
+
+
+@router.get("/api/series", dependencies=[Depends(require_admin)])
+async def list_series(session: AsyncSession = Depends(get_session)) -> dict:
+    """List all series-level overrides with their venue name."""
+    result = await session.execute(
+        select(SeriesOverride, Venue)
+        .join(Venue, SeriesOverride.venue_id == Venue.id)
+        .order_by(SeriesOverride.created_at.desc())
+    )
+    return {"series": [{
+        "id": so.id,
+        "venue_id": so.venue_id,
+        "venue_name": venue.name,
+        "normalized_name": so.normalized_name,
+        "display_name": so.display_name,
+        "is_live_music": so.is_live_music,
+        "note": so.note,
+    } for so, venue in result.all()]}
+
+
+@router.post("/api/series", dependencies=[Depends(require_admin)])
+async def upsert_series(
+    body: SeriesBody,
+    session: AsyncSession = Depends(get_session),
+) -> dict:
+    """Create/update a series override from an example event, then reclassify so all
+    matching instances (present and future) pick it up."""
+    event = await session.get(Event, body.event_id)
+    if not event:
+        raise HTTPException(status_code=404, detail="Event not found")
+
+    normalized = normalize_series_name(event.name)
+    existing = (await session.execute(
+        select(SeriesOverride).where(
+            SeriesOverride.venue_id == event.venue_id,
+            SeriesOverride.normalized_name == normalized,
+        )
+    )).scalar_one_or_none()
+
+    if existing:
+        existing.is_live_music = body.is_live_music
+        existing.note = body.note
+        existing.display_name = event.name
+    else:
+        session.add(SeriesOverride(
+            venue_id=event.venue_id,
+            normalized_name=normalized,
+            display_name=event.name,
+            is_live_music=body.is_live_music,
+            note=body.note,
+        ))
+    await session.commit()
+    await ScrapeManager(session).reclassify_all()
+    return {"ok": True}
+
+
+@router.delete("/api/series/{series_id}", dependencies=[Depends(require_admin)])
+async def delete_series(
+    series_id: int,
+    session: AsyncSession = Depends(get_session),
+) -> dict:
+    """Remove a series override, then reclassify so its events revert to automatic."""
+    override = await session.get(SeriesOverride, series_id)
+    if not override:
+        raise HTTPException(status_code=404, detail="Series override not found")
+    await session.delete(override)
+    await session.commit()
+    await ScrapeManager(session).reclassify_all()
+    return {"ok": True}

--- a/backend/app/api/admin.py
+++ b/backend/app/api/admin.py
@@ -11,21 +11,21 @@ main.py so these routes take priority over the catch-all.
 Requires: async PostgreSQL session, app.classifier, app.scrapers.manager, itsdangerous.
 """
 import secrets
-from datetime import date
+from datetime import date, datetime
 from typing import Optional
 
 from fastapi import APIRouter, Depends, HTTPException, Request, Query
 from fastapi.responses import HTMLResponse, JSONResponse, RedirectResponse
 from itsdangerous import URLSafeTimedSerializer, BadSignature, SignatureExpired
 from pydantic import BaseModel
-from sqlalchemy import select, and_, or_
+from sqlalchemy import select, and_, or_, func
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import joinedload
 
 from app.config import settings
 from app.database import get_session
 from app.models import Event, Venue, SeriesOverride
-from app.classifier import normalize_series_name, criteria_summary
+from app.classifier import normalize_series_name, criteria_summary, reclassify_floor
 from app.scrapers.manager import ScrapeManager
 from app.admin_ui import LOGIN_HTML, ADMIN_HTML
 
@@ -139,18 +139,34 @@ async def admin_rules() -> dict:
 async def admin_events(
     filter: str = Query("non_live", pattern="^(non_live|live|all)$"),
     search: Optional[str] = None,
-    limit: int = Query(200, ge=1, le=1000),
+    future_only: bool = Query(False, description="Hide events before today"),
+    show_approved: bool = Query(False, description="Include events already reviewed"),
+    limit: int = Query(1000, ge=1, le=5000),
     session: AsyncSession = Depends(get_session),
 ) -> dict:
-    """List upcoming events with classification + override state for moderation."""
-    conditions = [Event.date >= date.today()]
+    """List events with classification + override state for moderation.
+
+    Defaults to the same floor reclassification uses, so a series row shows every
+    event a series action will actually affect — listing only future dates would
+    understate scope. future_only narrows the view to today onward; it does not
+    change what a series action touches.
+    """
+    floor = date.today() if future_only else reclassify_floor()
+
+    # Split so the approved filter can be counted separately: `base` is everything the
+    # user asked for, `conditions` adds the approved exclusion actually applied.
+    base = [Event.date >= floor]
     if filter == "non_live":
-        conditions.append(Event.is_live_music.is_(False))
+        base.append(Event.is_live_music.is_(False))
     elif filter == "live":
-        conditions.append(Event.is_live_music.is_(True))
+        base.append(Event.is_live_music.is_(True))
     if search:
         term = f"%{search}%"
-        conditions.append(or_(Event.name.ilike(term), Event.artist.ilike(term)))
+        base.append(or_(Event.name.ilike(term), Event.artist.ilike(term)))
+
+    conditions = list(base)
+    if not show_approved:
+        conditions.append(Event.approved_at.is_(None))
 
     result = await session.execute(
         select(Event)
@@ -161,13 +177,47 @@ async def admin_events(
     )
     events = result.unique().scalars().all()
 
+    # Total matching rows, ignoring `limit`. Without this the response could only
+    # report how many rows came back, so a truncated page was indistinguishable from
+    # a complete one — the UI would say "1000 event(s)" whether that was all of them
+    # or the first 1000 of several thousand.
+    total = (
+        await session.execute(
+            select(func.count()).select_from(Event).where(and_(*conditions))
+        )
+    ).scalar_one()
+
+    # How many rows the approved filter is holding back, so that omission is visible
+    # too rather than silently shrinking the queue.
+    approved_hidden = 0
+    if not show_approved:
+        approved_hidden = (
+            await session.execute(
+                select(func.count()).select_from(Event)
+                .where(and_(*base, Event.approved_at.is_not(None)))
+            )
+        ).scalar_one()
+
     # Annotate each event with any matching series override.
     so_result = await session.execute(select(SeriesOverride))
     series = {(s.venue_id, s.normalized_name): s for s in so_result.scalars().all()}
 
+    # Series sizes across the whole reclassify range, deliberately ignoring both
+    # `future_only` and `limit`: a series action reaches every matching event, so the
+    # button label must count them all or it understates its own blast radius.
+    # Grouping happens in Python because normalize_series_name has no SQL equivalent.
+    span_rows = await session.execute(
+        select(Event.venue_id, Event.name).where(Event.date >= reclassify_floor())
+    )
+    series_sizes: dict[tuple[int, str], int] = {}
+    for venue_id, name in span_rows.all():
+        key = (venue_id, normalize_series_name(name))
+        series_sizes[key] = series_sizes.get(key, 0) + 1
+
     out = []
     for e in events:
-        so = series.get((e.venue_id, normalize_series_name(e.name)))
+        series_key = normalize_series_name(e.name)
+        so = series.get((e.venue_id, series_key))
         out.append({
             "id": e.id,
             "name": e.name,
@@ -178,10 +228,28 @@ async def admin_events(
             "is_live_music": e.is_live_music,
             "is_manual_override": e.is_manual_override,
             "classification_reason": e.classification_reason,
+            "is_approved": e.approved_at is not None,
+            # Detail shown when a row is expanded, to judge live-vs-not by hand.
+            # Descriptions are sparse (~10% of events), so the ticket link is often
+            # the only way to settle an ambiguous one.
+            "description": e.description,
+            "genre": e.genre,
+            "ticket_url": e.ticket_url,
+            "age_restriction": e.age_restriction,
+            # Exposed so the dashboard can collapse a series into one row using the
+            # same key a series override matches on — group and override stay in sync.
+            "series_key": series_key,
+            # How many events a series action on this row would actually affect.
+            "series_size": series_sizes.get((e.venue_id, series_key), 1),
             "series_override_id": so.id if so else None,
             "series_override_is_live": so.is_live_music if so else None,
         })
-    return {"events": out, "count": len(out)}
+    return {
+        "events": out,
+        "count": len(out),
+        "total": total,
+        "approved_hidden": approved_hidden,
+    }
 
 
 @router.post("/api/events/{event_id}/override", dependencies=[Depends(require_admin)])
@@ -197,6 +265,9 @@ async def set_override(
     event.is_live_music = body.is_live_music
     event.is_manual_override = True
     event.classification_reason = "manual"
+    # Setting the flag by hand *is* the review, so approve it too rather than asking
+    # the admin to confirm a decision they just made.
+    event.approved_at = datetime.utcnow()
     await session.commit()
     return {"ok": True, "id": event_id, "is_live_music": body.is_live_music}
 
@@ -211,10 +282,85 @@ async def clear_override(
     if not event:
         raise HTTPException(status_code=404, detail="Event not found")
     event.is_manual_override = False
+    # Dropping the override returns the event to unreviewed automatic classification,
+    # so the approval that came with the override goes too.
+    event.approved_at = None
     await session.commit()
     # Recompute now so the UI reflects the automatic result immediately.
     await ScrapeManager(session).reclassify_all()
     return {"ok": True, "id": event_id}
+
+
+@router.post("/api/events/{event_id}/approve", dependencies=[Depends(require_admin)])
+async def approve_event(
+    event_id: int,
+    series: bool = Query(False, description="Approve every event in this event's series"),
+    session: AsyncSession = Depends(get_session),
+) -> dict:
+    """Mark a classification as reviewed and correct, hiding it from the default queue.
+
+    With series=true the event acts as a sample: every event sharing its venue and
+    normalized name is approved too. Classification is largely per-series, so
+    approving 20-odd recurring dates one at a time would be punishing.
+    """
+    event = await session.get(Event, event_id)
+    if not event:
+        raise HTTPException(status_code=404, detail="Event not found")
+
+    now = datetime.utcnow()
+    if not series:
+        event.approved_at = now
+        await session.commit()
+        return {"ok": True, "id": event_id, "approved": 1}
+
+    # Same key the series overrides and the dashboard's grouping use, so "approve
+    # series" covers exactly the rows the group row displays.
+    key = normalize_series_name(event.name)
+    rows = (await session.execute(
+        select(Event).where(
+            Event.venue_id == event.venue_id,
+            Event.date >= reclassify_floor(),
+        )
+    )).scalars().all()
+    approved = 0
+    for ev in rows:
+        if normalize_series_name(ev.name) == key and ev.approved_at is None:
+            ev.approved_at = now
+            approved += 1
+    await session.commit()
+    return {"ok": True, "id": event_id, "approved": approved}
+
+
+@router.post("/api/events/{event_id}/unapprove", dependencies=[Depends(require_admin)])
+async def unapprove_event(
+    event_id: int,
+    series: bool = Query(False, description="Un-approve every event in this event's series"),
+    session: AsyncSession = Depends(get_session),
+) -> dict:
+    """Return an event (or its whole series) to the review queue."""
+    event = await session.get(Event, event_id)
+    if not event:
+        raise HTTPException(status_code=404, detail="Event not found")
+
+    if not series:
+        event.approved_at = None
+        await session.commit()
+        return {"ok": True, "id": event_id, "unapproved": 1}
+
+    key = normalize_series_name(event.name)
+    rows = (await session.execute(
+        select(Event).where(
+            Event.venue_id == event.venue_id,
+            Event.date >= reclassify_floor(),
+        )
+    )).scalars().all()
+    unapproved = 0
+    for ev in rows:
+        if normalize_series_name(ev.name) == key and ev.approved_at is not None:
+            ev.approved_at = None
+            unapproved += 1
+    await session.commit()
+    return {"ok": True, "id": event_id, "unapproved": unapproved}
 
 
 @router.get("/api/series", dependencies=[Depends(require_admin)])

--- a/backend/app/api/admin.py
+++ b/backend/app/api/admin.py
@@ -106,7 +106,16 @@ async def login_page() -> HTMLResponse:
 async def login_submit(body: LoginBody):
     # compare_digest guards against timing attacks; also fails closed when no
     # password is configured (compare against "" would otherwise accept "").
-    if _admin_enabled() and secrets.compare_digest(body.password, settings.ADMIN_PASSWORD):
+    #
+    # Both operands are encoded to bytes because compare_digest rejects a str containing
+    # any non-ASCII character, raising TypeError rather than returning False. Passed
+    # strings directly, a password with an accented character turned a wrong-password
+    # attempt into a 500 instead of a clean 401 — and, since the message differs, told the
+    # caller something about the configured password. UTF-8 on both sides compares the
+    # same bytes the client sent.
+    if _admin_enabled() and secrets.compare_digest(
+        body.password.encode("utf-8"), settings.ADMIN_PASSWORD.encode("utf-8")
+    ):
         response = JSONResponse({"ok": True})
         _issue_cookie(response)
         return response

--- a/backend/app/api/events.py
+++ b/backend/app/api/events.py
@@ -61,6 +61,7 @@ def _event_to_response(event: Event) -> EventResponse:
         age_restriction=event.age_restriction,
         description=event.description,
         source=event.source,
+        is_live_music=event.is_live_music,
         venue_name=event.venue.name if event.venue else None,
         venue_slug=event.venue.slug if event.venue else None,
         venue_city=event.venue.city if event.venue else None,
@@ -199,6 +200,8 @@ async def get_fullcalendar_events(
                 "status": event.status,
                 "age_restriction": event.age_restriction,
                 "description": event.description,
+                # Drives the client-side "Include non-live music?" toggle (filters.js).
+                "is_live_music": event.is_live_music,
             },
         })
 

--- a/backend/app/api/events.py
+++ b/backend/app/api/events.py
@@ -28,12 +28,28 @@ router = APIRouter(prefix="/api/events", tags=["events"])
 # --- Helpers ---
 
 def _completeness(event: Event) -> tuple:
-    """Rank two listings of the same show: richer record wins, then most recently scraped.
+    """Rank two listings of the same show, most authoritative key first.
+
+    Classification comes before metadata richness, because this guard runs before any
+    live-music filtering and so decides which row's verdict the calendar sees. Two rows for
+    one show can classify differently — most plausibly when an admin has hand-set one of
+    them, or when the dedup key and the recurrence key normalize a name differently. Ranking
+    only on field counts let the richer row win and silently discard the other's verdict,
+    which could drop a real show off the default calendar.
+
+    1. is_manual_override — an admin looked at this row and decided; that outranks anything
+       computed.
+    2. is_live_music — between two automatic verdicts, prefer the visible one. Consistent
+       with the feature's chosen failure direction: showing something that should have been
+       hidden is recoverable, hiding a real show is what users never see.
+    3. field count, then recency, then id — the original ordering, now as tiebreakers.
 
     Every component is total and the id breaks the last tie, so the winner does not depend
     on the order the database returned rows in.
     """
     return (
+        bool(getattr(event, "is_manual_override", False)),
+        bool(event.is_live_music),
         bool(event.image_url) + bool(event.ticket_url) + (event.price_min is not None),
         event.updated_at or datetime.min,
         event.id,
@@ -223,21 +239,24 @@ async def get_event(
     return _event_to_response(event)
 
 
-@router.get("")
-async def list_events(
-    start: Optional[str] = Query(None),
-    end: Optional[str] = Query(None),
-    search: Optional[str] = Query(None),
-    genre: Optional[str] = Query(None),
-    status: Optional[str] = Query(None),
-    page: int = Query(1, ge=1),
-    per_page: int = Query(50, ge=1, le=200),
-    session: AsyncSession = Depends(get_session),
-) -> EventListResponse:
-    """List events with filters and pagination."""
-    query = select(Event).options(joinedload(Event.venue)).order_by(Event.date)
-    count_query = select(func.count(Event.id))
+def _list_conditions(
+    *,
+    start: Optional[str] = None,
+    end: Optional[str] = None,
+    search: Optional[str] = None,
+    genre: Optional[str] = None,
+    status: Optional[str] = None,
+    include_non_music: bool = False,
+) -> list:
+    """Build the WHERE clauses for the events list, as data.
 
+    Split out of list_events so the filtering can be tested without a database. Declaring
+    the query parameter and then failing to apply it is a silent bug — the endpoint keeps
+    answering, just with the wrong rows — and an endpoint-level test cannot catch it
+    without Postgres.
+
+    Malformed dates are ignored rather than rejected, matching the previous behavior.
+    """
     conditions = []
 
     if start:
@@ -260,6 +279,45 @@ async def list_events(
         conditions.append(Event.genre.ilike(f"%{genre}%"))
     if status:
         conditions.append(Event.status == status)
+    # Default to live music only, so this endpoint stops being the one place the filter does
+    # not apply. /feeds/events.ics already behaves this way; the FullCalendar endpoint
+    # deliberately still returns everything, because filters.js toggles visibility in the
+    # browser without refetching, and filtering there server-side would empty the calendar
+    # when the toggle is switched on.
+    if not include_non_music:
+        conditions.append(Event.is_live_music.is_(True))
+
+    return conditions
+
+
+@router.get("")
+async def list_events(
+    start: Optional[str] = Query(None),
+    end: Optional[str] = Query(None),
+    search: Optional[str] = Query(None),
+    genre: Optional[str] = Query(None),
+    status: Optional[str] = Query(None),
+    include_non_music: bool = Query(
+        False,
+        description="Include non-live-music events (karaoke, trivia, theme nights, etc.). "
+                    "Off by default, matching /feeds/events.ics and the on-site calendar.",
+    ),
+    page: int = Query(1, ge=1),
+    per_page: int = Query(50, ge=1, le=200),
+    session: AsyncSession = Depends(get_session),
+) -> EventListResponse:
+    """List events with filters and pagination."""
+    query = select(Event).options(joinedload(Event.venue)).order_by(Event.date)
+    count_query = select(func.count(Event.id))
+
+    conditions = _list_conditions(
+        start=start,
+        end=end,
+        search=search,
+        genre=genre,
+        status=status,
+        include_non_music=include_non_music,
+    )
 
     if conditions:
         query = query.where(and_(*conditions))

--- a/backend/app/api/feeds.py
+++ b/backend/app/api/feeds.py
@@ -33,6 +33,11 @@ router = APIRouter(prefix="/feeds", tags=["feeds"])
 @router.get("/events.ics", response_class=Response)
 async def get_ical_feed(
     venue: Optional[str] = Query(None, description="Comma-separated venue slugs. Omit for all venues."),
+    include_non_music: bool = Query(
+        False,
+        description="Include non-live-music events (karaoke, trivia, theme nights, etc.). "
+                    "Off by default so subscribers get live music only.",
+    ),
     session: AsyncSession = Depends(get_session),
 ) -> Response:
     """Live iCal subscription feed. Add to Apple Calendar, Google Calendar, or Outlook once;
@@ -41,6 +46,9 @@ async def get_ical_feed(
     today = date.today()
     # Only include upcoming events — no historical clutter in subscribers' calendars
     conditions = [Event.date >= today]
+    # Mirror the on-site calendar: hide non-live-music events unless opted in.
+    if not include_non_music:
+        conditions.append(Event.is_live_music.is_(True))
 
     needs_join = bool(venue)
     if venue:

--- a/backend/app/classifier.py
+++ b/backend/app/classifier.py
@@ -11,10 +11,12 @@ the caller, so nothing here can clobber a manual decision. Pure Python — no DB
 network access — so it is cheap to run and trivial to unit-test.
 
 Detection criteria, in priority order (highest wins):
-  1. Recurrence — a name that repeats on >= RECURRENCE_THRESHOLD future dates at
-     the same venue is treated as a recurring series (weekly karaoke, trivia, DJ
+  1. Recurrence — a name that repeats on >= RECURRENCE_THRESHOLD separate occasions
+     at the same venue is treated as a recurring series (weekly karaoke, trivia, DJ
      nights, etc.) and flagged non-live. This is the strongest signal per the
-     product decision, so it wins over keywords and genre.
+     product decision, so it wins over keywords and genre. Dates within
+     RUN_GAP_DAYS of each other count as one occasion, so a multi-night residency
+     stays live music instead of reading as a series.
   2. Keywords — the event name matches a known non-music keyword, OR a
      "<word> night" phrase (any word except days-of-week / NIGHT_EXCEPTIONS, so
      "Emo Night" and "Hyperpop Night" match but "Saturday Night" does not), OR a
@@ -37,9 +39,21 @@ from typing import Iterable, Optional
 
 # --- Tunable criteria ---
 
-# An event whose (venue, name) repeats on at least this many distinct future
-# dates is treated as a recurring, non-live series.
+# An event whose (venue, name) repeats on at least this many separate occasions at
+# the same venue is treated as a recurring, non-live series.
 RECURRENCE_THRESHOLD = 3
+
+# Dates within this many days of each other count as ONE occasion, not several.
+#
+# Without this, recurrence cannot tell a weekly karaoke night from a band booked for
+# a three-night run — both produce three distinct dates at one venue. A residency is
+# exactly what someone opens the calendar to find, so counting raw dates hid the
+# site's best listings. Grouping nearby dates collapses a run to a single occasion
+# while leaving a weekly series at one occasion per week.
+#
+# 2 days keeps a Fri/Sat/Sun run together, and a Fri/Sun booking with Saturday off,
+# while still splitting anything on a weekly-or-sparser cadence.
+RUN_GAP_DAYS = 2
 
 # How far into the past reclassification and admin moderation reach. The calendar can
 # be scrolled back into recent past dates, and those events carry is_live_music too, so
@@ -181,6 +195,23 @@ def _normalize_for_grouping(name: str) -> str:
     return re.sub(r"[^a-z]", "", (name or "").lower())
 
 
+def _count_occasions(dates: Iterable[date], gap_days: int = RUN_GAP_DAYS) -> int:
+    """Collapse dates into separate occasions, merging any that form one run.
+
+    Sorts the distinct dates and starts a new occasion whenever the gap from the
+    previous date exceeds `gap_days`. A three-night residency returns 1; a weekly
+    series returns one per week. See RUN_GAP_DAYS for why this matters.
+    """
+    ordered = sorted(set(dates))
+    if not ordered:
+        return 0
+    occasions = 1
+    for previous, current in zip(ordered, ordered[1:]):
+        if (current - previous).days > gap_days:
+            occasions += 1
+    return occasions
+
+
 def _match_non_music_genre(genre: Optional[str], subgenre: Optional[str]) -> Optional[str]:
     """Return the matched non-music genre token, or None."""
     haystack = " ".join(filter(None, [genre, subgenre])).lower()
@@ -245,8 +276,13 @@ def find_recurring_event_ids(
     """Identify events that belong to a recurring series.
 
     events: iterable of objects with `id`, `venue_id`, `name`, and `date`.
-    Returns {event_id: occurrence_count} for every event whose (venue, name) key
-    appears on at least `threshold` distinct dates.
+    Returns {event_id: date_count} for every event whose (venue, name) key recurs on
+    at least `threshold` separate occasions.
+
+    The threshold is applied to occasions, not raw dates — consecutive dates are one
+    run, not a series (see RUN_GAP_DAYS). The returned count is still the number of
+    distinct dates, because that is what the admin UI and classification_reason
+    report and it is the more useful number to read.
     """
     dates_by_key: dict = defaultdict(set)
     ids_by_key: dict = defaultdict(list)
@@ -257,9 +293,21 @@ def find_recurring_event_ids(
 
     recurring: dict = {}
     for key, dates in dates_by_key.items():
-        if len(dates) >= threshold:
-            for event_id in ids_by_key[key]:
-                recurring[event_id] = len(dates)
+        _venue_id, normalized_name = key
+
+        # An empty key means the name normalized away entirely — an event with no
+        # name, or one named only in digits and punctuation ("2/14", "$5"). Those are
+        # unrelated events sharing an empty key, not a series, and a broken scraper
+        # emits them in bunches: three at one venue was enough to flag all three as
+        # recurring and hide them. See the malformed Squarespace records in #35.
+        if not normalized_name:
+            continue
+
+        if _count_occasions(dates) < threshold:
+            continue
+
+        for event_id in ids_by_key[key]:
+            recurring[event_id] = len(dates)
     return recurring
 
 
@@ -346,6 +394,12 @@ def criteria_summary() -> dict:
     """
     return {
         "recurrence_threshold": RECURRENCE_THRESHOLD,
+        "run_gap_days": RUN_GAP_DAYS,
+        "recurrence_rule": (
+            f"a name repeating on {RECURRENCE_THRESHOLD}+ separate occasions at one "
+            f"venue is a series; dates within {RUN_GAP_DAYS} days of each other count "
+            "as one occasion, so a multi-night run stays live music"
+        ),
         "always_live_venues": sorted(ALWAYS_LIVE_VENUE_SLUGS),
         "keywords": list(NON_MUSIC_KEYWORDS),
         "night_rule": "'<word> night' is non-live unless <word> is a day of the "

--- a/backend/app/classifier.py
+++ b/backend/app/classifier.py
@@ -351,7 +351,8 @@ def classification_updates(
     mapping — a series-level rule that overrides automatic classification for every
     event whose (venue, name) key matches.
     exempt_venue_ids: optional set of venue ids assumed to be entirely live music
-    (see ALWAYS_LIVE_VENUE_SLUGS, e.g. DPAC) — forced live, skipping auto/series.
+    (see ALWAYS_LIVE_VENUE_SLUGS, e.g. DPAC) — forced live unless a series override says
+    otherwise, so the exemption is a default rather than an absolute.
 
     Returns {event_id: (is_live_music, reason)} for every event EXCEPT those with
     is_manual_override=True, which are omitted so a re-scrape never overwrites a
@@ -359,8 +360,8 @@ def classification_updates(
 
     Precedence, most specific first:
       1. per-event manual override  -> omitted here (caller leaves the row untouched)
-      2. always-live venue exemption -> forced live music
-      3. series override            -> forces the series value
+      2. series override            -> forces the series value
+      3. always-live venue exemption -> forced live music
       4. automatic classification   -> recurrence / keyword / genre
     This is the pure decision function behind ScrapeManager.reclassify_all().
     """
@@ -373,14 +374,19 @@ def classification_updates(
     for ev in events:
         if getattr(ev, "is_manual_override", False):
             continue  # per-event override wins; leave the hand-set value in place
-        if ev.venue_id in exempt_venue_ids:
-            updates[ev.id] = (True, "venue: always live music")
-            continue
+
+        # Series override is consulted before the venue exemption, so the exemption acts
+        # as a default rather than as an absolute. The other order made an exempt venue's
+        # series impossible to mark non-live through the series UI, on every future
+        # instance, forever — and DPAC, the only exempt venue, hosts Broadway and comedy
+        # alongside music, which is exactly the case the series UI is for.
         key = (ev.venue_id, normalize_series_name(ev.name))
         if key in series_overrides:
             is_live, _note = series_overrides[key]
             label = "live music" if is_live else "non-live"
             updates[ev.id] = (is_live, f"series override: {label}")
+        elif ev.venue_id in exempt_venue_ids:
+            updates[ev.id] = (True, "venue: always live music")
         else:
             updates[ev.id] = classified[ev.id]
     return updates

--- a/backend/app/classifier.py
+++ b/backend/app/classifier.py
@@ -31,6 +31,7 @@ surfaced verbatim to the admin UI via criteria_summary().
 # --- Imports ---
 import re
 from collections import defaultdict
+from datetime import date, timedelta
 from typing import Iterable, Optional
 
 
@@ -39,6 +40,21 @@ from typing import Iterable, Optional
 # An event whose (venue, name) repeats on at least this many distinct future
 # dates is treated as a recurring, non-live series.
 RECURRENCE_THRESHOLD = 3
+
+# How far into the past reclassification and admin moderation reach. The calendar can
+# be scrolled back into recent past dates, and those events carry is_live_music too, so
+# they need to respond to live/non-live changes rather than staying frozen at whatever
+# they were last set to. Older events are settled and left alone.
+#
+# Note this also widens the recurrence window: instances just behind today now count
+# toward RECURRENCE_THRESHOLD, so a series is recognised sooner than it would be from
+# future dates alone.
+RECLASSIFY_PAST_DAYS = 30
+
+
+def reclassify_floor(today: Optional[date] = None) -> date:
+    """Earliest event date that reclassification and admin moderation still touch."""
+    return (today or date.today()) - timedelta(days=RECLASSIFY_PAST_DAYS)
 
 # Venues assumed to be entirely live music — exempt from non-live flagging.
 # DPAC hosts touring concerts/Broadway/comedy, but per product decision it is

--- a/backend/app/classifier.py
+++ b/backend/app/classifier.py
@@ -1,0 +1,344 @@
+"""
+Live-music classifier — decides whether an event is live music or something else
+(karaoke, trivia, theme nights, comedy, film screenings, ...). This module is the
+single source of truth for the detection criteria used to declutter the public
+calendar.
+
+Role: Called by ScrapeManager.reclassify_all() after every scrape to (re)compute
+each event's `is_live_music` flag and a human-readable `classification_reason`.
+Events an admin has manually overridden (is_manual_override=True) are skipped by
+the caller, so nothing here can clobber a manual decision. Pure Python — no DB or
+network access — so it is cheap to run and trivial to unit-test.
+
+Detection criteria, in priority order (highest wins):
+  1. Recurrence — a name that repeats on >= RECURRENCE_THRESHOLD future dates at
+     the same venue is treated as a recurring series (weekly karaoke, trivia, DJ
+     nights, etc.) and flagged non-live. This is the strongest signal per the
+     product decision, so it wins over keywords and genre.
+  2. Keywords — the event name matches a known non-music keyword, OR a
+     "<word> night" phrase (any word except days-of-week / NIGHT_EXCEPTIONS, so
+     "Emo Night" and "Hyperpop Night" match but "Saturday Night" does not), OR a
+     "<theme> party" phrase whose leading word is in the PARTY_THEMES allowlist
+     (see PARTY_THEMES for why "party" is allowlisted rather than matched bare).
+  3. Genre — where the source provides one (currently only the Ticketmaster
+     scraper), a non-music genre (Comedy, Theatre, Film, Sports, ...) flags it.
+Anything matching none of these is assumed to be live music.
+
+To tune detection, edit the lists below — they are intentionally readable and are
+surfaced verbatim to the admin UI via criteria_summary().
+"""
+
+# --- Imports ---
+import re
+from collections import defaultdict
+from typing import Iterable, Optional
+
+
+# --- Tunable criteria ---
+
+# An event whose (venue, name) repeats on at least this many distinct future
+# dates is treated as a recurring, non-live series.
+RECURRENCE_THRESHOLD = 3
+
+# Venues assumed to be entirely live music — exempt from non-live flagging.
+# DPAC hosts touring concerts/Broadway/comedy, but per product decision it is
+# treated as all live music and excluded from the filter pass entirely.
+ALWAYS_LIVE_VENUE_SLUGS = {"dpac"}
+
+# Whole-word matches anywhere in the event name flag it as non-live music.
+# Word-boundary matched, case-insensitive (so "class" does not match "classic").
+# Note: "<theme> night" and "<theme> party" are handled by their own broader
+# patterns below, not this list.
+NON_MUSIC_KEYWORDS = [
+    "karaoke",
+    "trivia",
+    "bingo",
+    "quizzo",
+    "quiz",
+    "open mic",
+    "open-mic",
+    "open decks",
+    "comedy",
+    "stand-up",
+    "standup",
+    "improv",
+    "drag",
+    "burlesque",
+    "silent disco",
+    "screening",
+    "film screening",
+    "movie",
+    "market",
+    "pop-up",
+    "popup",
+    "yoga",
+    "brunch",
+    "book club",
+    "poetry",
+    "spoken word",
+    "workshop",
+    "meetup",
+    "networking",
+    "speed dating",
+    "sing-along",
+    "singalong",
+]
+
+# "<word> night" (or "nights") is treated as a themed DJ/dance/recurring night —
+# a strong non-live signal — for ANY preceding word EXCEPT these. Days of the week
+# and a few common phrases ("Last Night", "One Night Only", "A Hard Day's Night")
+# are excluded so real show titles aren't caught. Single-letter matches (e.g. the
+# "s" left by a possessive like "Day's Night") are ignored in classify_one().
+NIGHT_EXCEPTIONS = {
+    "monday",
+    "tuesday",
+    "wednesday",
+    "thursday",
+    "friday",
+    "saturday",
+    "sunday",
+    "last",
+    "one",
+    "good",
+    "hard",
+}
+
+# "<theme> party" (or "parties") — listening/release/album parties, etc. This is an
+# allowlist rather than "any word" because band names contain "party" (e.g. the
+# band Bloc Party), so a bare "party" match would produce false positives.
+PARTY_THEMES = [
+    "listening",
+    "release",
+    "album",
+    "single",
+    "launch",
+    "block",
+    "dance",
+    "watch",
+    "viewing",
+    "after",
+    "silent",
+]
+
+# Substrings of a source-provided genre/subgenre that indicate non-music.
+# Kept conservative: "Dance/Electronic" is a legitimate live-music genre, so
+# "dance" is NOT listed here (only "dance party"/"dance night" via keywords).
+NON_MUSIC_GENRES = [
+    "comedy",
+    "theatre",
+    "theater",
+    "film",
+    "sports",
+    "family",
+    "magic",
+    "illusion",
+    "spoken word",
+]
+
+
+# --- Compiled matchers (built once at import) ---
+
+_KEYWORD_PATTERNS = [
+    (kw, re.compile(r"\b" + re.escape(kw) + r"\b", re.IGNORECASE))
+    for kw in NON_MUSIC_KEYWORDS
+]
+
+# Broad "<word> night(s)"; the word is filtered against NIGHT_EXCEPTIONS in code.
+_NIGHT_PATTERN = re.compile(r"\b(\w+)\s+nights?\b", re.IGNORECASE)
+
+# "<theme> party" / "<theme> parties" for an allowlisted set of themes.
+_PARTY_PATTERN = re.compile(
+    r"\b(" + "|".join(re.escape(t) for t in PARTY_THEMES) + r")\s+part(?:y|ies)\b",
+    re.IGNORECASE,
+)
+
+
+# --- Helpers ---
+
+def _normalize_for_grouping(name: str) -> str:
+    """Collapse a name to a comparison key for recurrence grouping.
+
+    Lowercases and strips punctuation, whitespace, AND digits so that dated
+    variants of the same series collapse together (e.g. "Trivia Night 7/8" and
+    "Trivia Night 7/15" both become "trivianight").
+    """
+    return re.sub(r"[^a-z]", "", (name or "").lower())
+
+
+def _match_non_music_genre(genre: Optional[str], subgenre: Optional[str]) -> Optional[str]:
+    """Return the matched non-music genre token, or None."""
+    haystack = " ".join(filter(None, [genre, subgenre])).lower()
+    if not haystack:
+        return None
+    for token in NON_MUSIC_GENRES:
+        if token in haystack:
+            return token
+    return None
+
+
+# --- Public API ---
+
+def normalize_series_name(name: str) -> str:
+    """Public series key for a name — the value stored in SeriesOverride.normalized_name.
+
+    Must stay identical to the grouping used by recurrence detection so an admin's
+    series override matches the same events the detector groups together.
+    """
+    return _normalize_for_grouping(name)
+
+
+def classify_one(
+    name: str,
+    genre: Optional[str] = None,
+    subgenre: Optional[str] = None,
+) -> tuple[bool, Optional[str]]:
+    """Classify a single event by name + genre (no recurrence context).
+
+    Returns (is_live_music, reason). `reason` is None when the event is treated as
+    live music; otherwise it is a short human-readable explanation.
+    """
+    text = name or ""
+
+    for kw, pattern in _KEYWORD_PATTERNS:
+        if pattern.search(text):
+            return False, f"keyword: {kw}"
+
+    party = _PARTY_PATTERN.search(text)
+    if party:
+        return False, f"keyword: {party.group(1).lower()} party"
+
+    # "<word> night" for any word that isn't a day-of-week / excepted phrase.
+    # finditer (not search) so a leading excepted match doesn't mask a later
+    # real one, e.g. "Saturday Night: Emo Night".
+    for m in _NIGHT_PATTERN.finditer(text):
+        word = m.group(1).lower()
+        if len(word) >= 2 and word not in NIGHT_EXCEPTIONS:
+            return False, f"keyword: {word} night"
+
+    genre_hit = _match_non_music_genre(genre, subgenre)
+    if genre_hit:
+        return False, f"genre: {genre_hit}"
+
+    return True, None
+
+
+def find_recurring_event_ids(
+    events: Iterable,
+    threshold: int = RECURRENCE_THRESHOLD,
+) -> dict:
+    """Identify events that belong to a recurring series.
+
+    events: iterable of objects with `id`, `venue_id`, `name`, and `date`.
+    Returns {event_id: occurrence_count} for every event whose (venue, name) key
+    appears on at least `threshold` distinct dates.
+    """
+    dates_by_key: dict = defaultdict(set)
+    ids_by_key: dict = defaultdict(list)
+    for ev in events:
+        key = (ev.venue_id, _normalize_for_grouping(ev.name))
+        dates_by_key[key].add(ev.date)
+        ids_by_key[key].append(ev.id)
+
+    recurring: dict = {}
+    for key, dates in dates_by_key.items():
+        if len(dates) >= threshold:
+            for event_id in ids_by_key[key]:
+                recurring[event_id] = len(dates)
+    return recurring
+
+
+def classify_batch(
+    events: Iterable,
+    threshold: int = RECURRENCE_THRESHOLD,
+) -> dict:
+    """Classify a batch of events, applying recurrence + keyword + genre signals.
+
+    events: iterable of objects with `id`, `venue_id`, `name`, `date`, and
+    optionally `genre`/`subgenre`. Returns {event_id: (is_live_music, reason)}.
+    """
+    events = list(events)
+    recurring = find_recurring_event_ids(events, threshold)
+
+    results: dict = {}
+    for ev in events:
+        count = recurring.get(ev.id)
+        if count is not None:
+            results[ev.id] = (False, f"recurring: {count} dates")
+            continue
+        results[ev.id] = classify_one(
+            ev.name,
+            getattr(ev, "genre", None),
+            getattr(ev, "subgenre", None),
+        )
+    return results
+
+
+def classification_updates(
+    events: Iterable,
+    series_overrides: Optional[dict] = None,
+    exempt_venue_ids: Optional[set] = None,
+    threshold: int = RECURRENCE_THRESHOLD,
+) -> dict:
+    """Compute the classification values to persist, honoring all override layers.
+
+    events: iterable of objects with the classify_batch attributes plus
+    `is_manual_override`.
+    series_overrides: optional {(venue_id, normalized_name): (is_live_music, note)}
+    mapping — a series-level rule that overrides automatic classification for every
+    event whose (venue, name) key matches.
+    exempt_venue_ids: optional set of venue ids assumed to be entirely live music
+    (see ALWAYS_LIVE_VENUE_SLUGS, e.g. DPAC) — forced live, skipping auto/series.
+
+    Returns {event_id: (is_live_music, reason)} for every event EXCEPT those with
+    is_manual_override=True, which are omitted so a re-scrape never overwrites a
+    decision an admin made on a single instance.
+
+    Precedence, most specific first:
+      1. per-event manual override  -> omitted here (caller leaves the row untouched)
+      2. always-live venue exemption -> forced live music
+      3. series override            -> forces the series value
+      4. automatic classification   -> recurrence / keyword / genre
+    This is the pure decision function behind ScrapeManager.reclassify_all().
+    """
+    events = list(events)
+    series_overrides = series_overrides or {}
+    exempt_venue_ids = exempt_venue_ids or set()
+    classified = classify_batch(events, threshold)
+
+    updates: dict = {}
+    for ev in events:
+        if getattr(ev, "is_manual_override", False):
+            continue  # per-event override wins; leave the hand-set value in place
+        if ev.venue_id in exempt_venue_ids:
+            updates[ev.id] = (True, "venue: always live music")
+            continue
+        key = (ev.venue_id, normalize_series_name(ev.name))
+        if key in series_overrides:
+            is_live, _note = series_overrides[key]
+            label = "live music" if is_live else "non-live"
+            updates[ev.id] = (is_live, f"series override: {label}")
+        else:
+            updates[ev.id] = classified[ev.id]
+    return updates
+
+
+def criteria_summary() -> dict:
+    """Machine-readable snapshot of the current detection criteria.
+
+    Surfaced to the admin UI (GET /admin/api/rules) so the rules can be reviewed
+    without reading the source.
+    """
+    return {
+        "recurrence_threshold": RECURRENCE_THRESHOLD,
+        "always_live_venues": sorted(ALWAYS_LIVE_VENUE_SLUGS),
+        "keywords": list(NON_MUSIC_KEYWORDS),
+        "night_rule": "'<word> night' is non-live unless <word> is a day of the "
+                      "week or listed in night_exceptions",
+        "night_exceptions": sorted(NIGHT_EXCEPTIONS),
+        "party_rule": "'<theme> party' (or 'parties') is non-live only when the word "
+                      "immediately before 'party' is one of party_themes. This is an "
+                      "allowlist (not any word) on purpose: a bare 'party' match would "
+                      "flag band names like 'Bloc Party', so only these themes count.",
+        "party_themes": list(PARTY_THEMES),
+        "non_music_genres": list(NON_MUSIC_GENRES),
+    }

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -42,6 +42,13 @@ class Settings(BaseSettings):
     SCRAPE_ALLOWED_SERVICE_ACCOUNTS: str = ""  # comma-separated service-account emails
     SCRAPE_OIDC_AUDIENCE: str = ""  # optional; the audience configured on the scheduler job
 
+    # Admin subsite (/admin). Both must be set for the admin to be reachable —
+    # if ADMIN_PASSWORD is blank, the admin login is disabled (fails closed).
+    ADMIN_PASSWORD: str = ""       # shared password exchanged for a session cookie
+    SESSION_SECRET: str = ""       # signs the admin session cookie; MUST be set in
+                                   # production so cookies validate across instances
+                                   # (a random per-process key is used if left blank)
+
     model_config = {"env_file": ".env", "env_file_encoding": "utf-8"}
 
 

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -25,7 +25,7 @@ from app.config import settings
 from app.database import async_session
 from app.seed import seed_venues
 from app.scheduler import scheduler, configure_scheduler
-from app.api import events, venues, health, feeds
+from app.api import events, venues, health, feeds, admin
 from app import tokens
 
 # --- Logging setup ---
@@ -189,6 +189,9 @@ app.include_router(events.router)
 app.include_router(venues.router)
 app.include_router(health.router)
 app.include_router(feeds.router)
+# Admin subsite — must be registered before the "/" static mount below so its
+# routes take priority over the catch-all StaticFiles handler.
+app.include_router(admin.router)
 
 # --- Origin enforcement on POST /api/scrape ---
 

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -10,7 +10,7 @@ Requires: app.database (Base), PostgreSQL via asyncpg/SQLAlchemy async.
 
 from datetime import datetime, date, time
 from typing import Optional
-from sqlalchemy import String, Integer, Float, Text, Date, Time, DateTime, ForeignKey, JSON
+from sqlalchemy import String, Integer, Float, Text, Date, Time, DateTime, ForeignKey, JSON, Boolean, UniqueConstraint
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 import enum
 
@@ -83,6 +83,16 @@ class Event(Base):
     source: Mapped[str] = mapped_column(String(50))  # scraper name that produced this event, e.g. "ticketmaster"
     source_url: Mapped[Optional[str]] = mapped_column(String(1000), nullable=True)
     hash: Mapped[str] = mapped_column(String(64), unique=True, index=True)  # SHA-256 of key fields; used by manager.py to deduplicate on upsert
+
+    # --- Live-music classification (see app/classifier.py) ---
+    # Effective flag the calendar and iCal feeds filter on. Materialized (not computed
+    # on read) so filtering is a simple `WHERE is_live_music = true`. Recomputed after
+    # every scrape by ScrapeManager.reclassify_all() — except on rows an admin has
+    # manually overridden (is_manual_override=True), which are left untouched.
+    is_live_music: Mapped[bool] = mapped_column(Boolean, default=True, index=True)
+    is_manual_override: Mapped[bool] = mapped_column(Boolean, default=False)  # True once an admin sets the flag by hand
+    classification_reason: Mapped[Optional[str]] = mapped_column(String(200), nullable=True)  # human-readable why, e.g. "recurring: 6 dates", "keyword: trivia", "manual"
+
     created_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow)
     updated_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow, onupdate=datetime.utcnow)
 
@@ -106,3 +116,34 @@ class ScrapeLog(Base):
     duration_seconds: Mapped[Optional[float]] = mapped_column(Float, nullable=True)
 
     venue: Mapped["Venue"] = relationship(back_populates="scrape_logs")
+
+
+class SeriesOverride(Base):
+    """An admin decision that applies to a whole recurring series, not one event.
+
+    A recurring series (weekly karaoke, a standing jazz jam, a monthly comedy
+    showcase, ...) produces many Event rows over time, and new ones appear on each
+    scrape. A per-event override can't cover future instances, so a series-level
+    rule is keyed by (venue_id, normalized_name) — the same key the recurrence
+    detector groups on (see app.classifier.normalize_series_name). During
+    ScrapeManager.reclassify_all(), a matching rule forces is_live_music for every
+    event in the series, including instances scraped later.
+
+    Precedence, most specific first: a per-event Event.is_manual_override wins over
+    a SeriesOverride, which in turn wins over automatic classification.
+    """
+    __tablename__ = "series_overrides"
+
+    id: Mapped[int] = mapped_column(primary_key=True)
+    venue_id: Mapped[int] = mapped_column(ForeignKey("venues.id"), index=True)
+    normalized_name: Mapped[str] = mapped_column(String(200))  # matches app.classifier.normalize_series_name(event.name)
+    display_name: Mapped[Optional[str]] = mapped_column(String(500), nullable=True)  # a readable example name for the admin UI
+    is_live_music: Mapped[bool] = mapped_column(Boolean)  # the value forced onto every event in the series
+    note: Mapped[Optional[str]] = mapped_column(String(500), nullable=True)  # optional admin note explaining the decision
+    created_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow)
+    updated_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow, onupdate=datetime.utcnow)
+
+    # One rule per (venue, series name); the admin endpoint upserts on this key.
+    __table_args__ = (
+        UniqueConstraint("venue_id", "normalized_name", name="uq_series_override_key"),
+    )

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -92,6 +92,11 @@ class Event(Base):
     is_live_music: Mapped[bool] = mapped_column(Boolean, default=True, index=True)
     is_manual_override: Mapped[bool] = mapped_column(Boolean, default=False)  # True once an admin sets the flag by hand
     classification_reason: Mapped[Optional[str]] = mapped_column(String(200), nullable=True)  # human-readable why, e.g. "recurring: 6 dates", "keyword: trivia", "manual"
+    # Set when an admin confirms the current classification is correct; the admin list
+    # hides approved events by default. Records agreement with a *verdict*, not the
+    # event: reclassify_all() clears this whenever it changes is_live_music, so a
+    # re-classified event returns to the review queue rather than staying hidden.
+    approved_at: Mapped[Optional[datetime]] = mapped_column(DateTime, nullable=True, index=True)
 
     created_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow)
     updated_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow, onupdate=datetime.utcnow)

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -56,6 +56,14 @@ class Venue(Base):
 
     events: Mapped[list["Event"]] = relationship(back_populates="venue", cascade="all, delete-orphan")
     scrape_logs: Mapped[list["ScrapeLog"]] = relationship(back_populates="venue", cascade="all, delete-orphan")
+    # Retiring a venue must not be blocked by its series rules. seed_venues() deletes
+    # venues listed in REMOVED_SLUGS on every startup via session.delete(), which cascades
+    # only through relationships SQLAlchemy knows about — so without this, the first
+    # retirement of a venue holding a series override raises ForeignKeyViolation inside the
+    # lifespan handler and the container never becomes healthy.
+    series_overrides: Mapped[list["SeriesOverride"]] = relationship(
+        back_populates="venue", cascade="all, delete-orphan"
+    )
 
 
 class Event(Base):
@@ -140,13 +148,20 @@ class SeriesOverride(Base):
     __tablename__ = "series_overrides"
 
     id: Mapped[int] = mapped_column(primary_key=True)
-    venue_id: Mapped[int] = mapped_column(ForeignKey("venues.id"), index=True)
+    # ondelete="CASCADE" as well as the ORM relationship on Venue: the relationship covers
+    # session.delete(), the database constraint covers everything else (a manual DELETE, a
+    # future bulk query that bypasses the ORM's cascade).
+    venue_id: Mapped[int] = mapped_column(
+        ForeignKey("venues.id", ondelete="CASCADE"), index=True
+    )
     normalized_name: Mapped[str] = mapped_column(String(200))  # matches app.classifier.normalize_series_name(event.name)
     display_name: Mapped[Optional[str]] = mapped_column(String(500), nullable=True)  # a readable example name for the admin UI
     is_live_music: Mapped[bool] = mapped_column(Boolean)  # the value forced onto every event in the series
     note: Mapped[Optional[str]] = mapped_column(String(500), nullable=True)  # optional admin note explaining the decision
     created_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow)
     updated_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow, onupdate=datetime.utcnow)
+
+    venue: Mapped["Venue"] = relationship(back_populates="series_overrides")
 
     # One rule per (venue, series name); the admin endpoint upserts on this key.
     __table_args__ = (

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -55,6 +55,7 @@ class EventResponse(BaseModel):
     age_restriction: Optional[str] = None
     description: Optional[str] = None
     source: str
+    is_live_music: bool = True  # False => karaoke/trivia/theme night/comedy/etc. (see app/classifier.py)
 
     # Denormalized venue fields — joined in the query so clients don't need
     # a separate /api/venues request to display venue info alongside events

--- a/backend/app/scrapers/manager.py
+++ b/backend/app/scrapers/manager.py
@@ -26,7 +26,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.dialects.postgresql import insert as pg_insert
 
 from app.config import settings
-from app.classifier import classification_updates, ALWAYS_LIVE_VENUE_SLUGS
+from app.classifier import classification_updates, reclassify_floor, ALWAYS_LIVE_VENUE_SLUGS
 from app.models import Venue, Event, ScrapeLog, SeriesOverride
 from app.scrapers.base import BaseScraper, ScrapedEvent
 from app.scrapers.ticketmaster import TicketmasterScraper
@@ -409,18 +409,20 @@ class ScrapeManager:
     # --- Classification ---
 
     async def reclassify_all(self) -> dict:
-        """Recompute is_live_music for all upcoming events.
+        """Recompute is_live_music for upcoming events and the recent past.
 
         Runs after every bulk scrape. Recurrence is a cross-event signal, so this
-        always considers the full set of future events regardless of which venues
+        always considers the full set of events in range regardless of which venues
         were just scraped. Admin decisions are respected: per-event manual overrides
         (is_manual_override=True) are left untouched, and series-level overrides are
         applied to every matching event — including instances scraped later.
-        Returns {events, changed} counts.
+
+        The range reaches RECLASSIFY_PAST_DAYS behind today, not just forward: the
+        calendar can be scrolled back into recent dates, and those events need to
+        respond to live/non-live changes too. Returns {events, changed} counts.
         """
-        today = date.today()
         result = await self.session.execute(
-            select(Event).where(Event.date >= today)
+            select(Event).where(Event.date >= reclassify_floor())
         )
         events = result.scalars().all()
 
@@ -446,21 +448,30 @@ class ScrapeManager:
         )
 
         changed = 0
+        unapproved = 0
         for ev in events:
             if ev.id not in updates:
                 continue
             is_live, reason = updates[ev.id]
             if ev.is_live_music != is_live or ev.classification_reason != reason:
+                # An approval records agreement with a specific verdict. If the verdict
+                # itself moves, that approval is stale — clear it so the event returns
+                # to the review queue instead of staying hidden behind an old decision.
+                # Only a change of is_live_music counts; a reworded reason is not a
+                # different answer and should not resurface work already reviewed.
+                if ev.is_live_music != is_live and ev.approved_at is not None:
+                    ev.approved_at = None
+                    unapproved += 1
                 ev.is_live_music = is_live
                 ev.classification_reason = reason
                 changed += 1
 
         await self.session.commit()
         logger.info(
-            f"Reclassified {len(events)} upcoming events; {changed} changed "
-            f"(manual overrides preserved)"
+            f"Reclassified {len(events)} events in range; {changed} changed, "
+            f"{unapproved} approvals cleared (manual overrides preserved)"
         )
-        return {"events": len(events), "changed": changed}
+        return {"events": len(events), "changed": changed, "unapproved": unapproved}
 
     # --- Bulk scrape entry points ---
 

--- a/backend/app/scrapers/manager.py
+++ b/backend/app/scrapers/manager.py
@@ -26,7 +26,8 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.dialects.postgresql import insert as pg_insert
 
 from app.config import settings
-from app.models import Venue, Event, ScrapeLog
+from app.classifier import classification_updates, ALWAYS_LIVE_VENUE_SLUGS
+from app.models import Venue, Event, ScrapeLog, SeriesOverride
 from app.scrapers.base import BaseScraper, ScrapedEvent
 from app.scrapers.ticketmaster import TicketmasterScraper
 
@@ -405,6 +406,62 @@ class ScrapeManager:
             "expired": len(plan.expired),
         }
 
+    # --- Classification ---
+
+    async def reclassify_all(self) -> dict:
+        """Recompute is_live_music for all upcoming events.
+
+        Runs after every bulk scrape. Recurrence is a cross-event signal, so this
+        always considers the full set of future events regardless of which venues
+        were just scraped. Admin decisions are respected: per-event manual overrides
+        (is_manual_override=True) are left untouched, and series-level overrides are
+        applied to every matching event — including instances scraped later.
+        Returns {events, changed} counts.
+        """
+        today = date.today()
+        result = await self.session.execute(
+            select(Event).where(Event.date >= today)
+        )
+        events = result.scalars().all()
+
+        # Load series-level overrides, keyed to match classifier.normalize_series_name.
+        so_result = await self.session.execute(select(SeriesOverride))
+        series_overrides = {
+            (so.venue_id, so.normalized_name): (so.is_live_music, so.note)
+            for so in so_result.scalars().all()
+        }
+
+        # Resolve always-live venues (e.g. DPAC) to their ids for the exemption.
+        venue_rows = await self.session.execute(select(Venue.id, Venue.slug))
+        exempt_venue_ids = {
+            vid for vid, slug in venue_rows.all() if slug in ALWAYS_LIVE_VENUE_SLUGS
+        }
+
+        # classification_updates omits manually-overridden rows (those flags survive),
+        # forces always-live venues, and applies series overrides above auto.
+        updates = classification_updates(
+            events,
+            series_overrides=series_overrides,
+            exempt_venue_ids=exempt_venue_ids,
+        )
+
+        changed = 0
+        for ev in events:
+            if ev.id not in updates:
+                continue
+            is_live, reason = updates[ev.id]
+            if ev.is_live_music != is_live or ev.classification_reason != reason:
+                ev.is_live_music = is_live
+                ev.classification_reason = reason
+                changed += 1
+
+        await self.session.commit()
+        logger.info(
+            f"Reclassified {len(events)} upcoming events; {changed} changed "
+            f"(manual overrides preserved)"
+        )
+        return {"events": len(events), "changed": changed}
+
     # --- Bulk scrape entry points ---
 
     async def scrape_all(self, scraper_types: Optional[list[str]] = None) -> list[dict]:
@@ -422,6 +479,9 @@ class ScrapeManager:
             r = await self.scrape_venue(venue)
             results.append(r)
 
+        # Recompute live-music flags across all upcoming events now that new data is in.
+        await self.reclassify_all()
+
         return results
 
     async def scrape_ticketmaster(self) -> list[dict]:
@@ -438,4 +498,8 @@ class ScrapeManager:
         for venue in venues:
             r = await self.scrape_venue(venue)
             results.append(r)
+
+        # Recompute live-music flags across all upcoming events now that new data is in.
+        await self.reclassify_all()
+
         return results

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -12,6 +12,7 @@ apscheduler==3.10.4
 tzlocal==5.2
 python-dotenv==1.0.1
 icalendar==6.1.3
+itsdangerous==2.2.0
 # Verifies the Cloudflare Access and Google OIDC tokens that gate /admin and
 # POST /api/scrape (see app/tokens.py). The [crypto] extra pulls in `cryptography`,
 # which is what supports the RS256 signatures both issuers use.

--- a/backend/tests/test_admin_login.py
+++ b/backend/tests/test_admin_login.py
@@ -1,0 +1,106 @@
+"""
+Tests for the admin login check — review item #12.
+
+secrets.compare_digest raises TypeError when handed a str containing any non-ASCII
+character, rather than returning False. So a password with an accented character turned a
+wrong-password attempt into a 500. Two problems with that: the endpoint stops failing
+cleanly, and because the response differs from the normal 401 it tells an unauthenticated
+caller something about the configured password.
+
+No database is touched — the login route only compares a string and sets a cookie.
+"""
+
+from fastapi.testclient import TestClient
+
+import pytest
+
+from app.config import settings
+from app.main import app
+
+
+ASCII_PASSWORD = "s3cret-ascii-only"
+ACCENTED_PASSWORD = "contraseña-café"
+
+
+@pytest.fixture
+def client():
+    return TestClient(app)
+
+
+@pytest.fixture(autouse=True)
+def gates_off(monkeypatch):
+    """The origin gate would 403 /admin before the login handler ever ran."""
+    monkeypatch.setattr(settings, "CF_ACCESS_TEAM_DOMAIN", "")
+    monkeypatch.setattr(settings, "CF_ACCESS_AUD", "")
+
+
+def _configure(monkeypatch, password):
+    monkeypatch.setattr(settings, "ADMIN_PASSWORD", password)
+    monkeypatch.setattr(settings, "SESSION_SECRET", "test-signing-key")
+
+
+class TestNonAsciiPasswords:
+    def test_a_wrong_guess_against_an_accented_password_is_a_clean_401(
+        self, client, monkeypatch
+    ):
+        """The regression: this raised TypeError inside compare_digest and returned 500."""
+        _configure(monkeypatch, ACCENTED_PASSWORD)
+
+        response = client.post("/admin/login", json={"password": "wrong"})
+
+        assert response.status_code == 401
+        assert response.json()["ok"] is False
+
+    def test_an_accented_guess_against_an_ascii_password_is_a_clean_401(
+        self, client, monkeypatch
+    ):
+        """The other direction — the non-ASCII operand can arrive from the client."""
+        _configure(monkeypatch, ASCII_PASSWORD)
+
+        response = client.post("/admin/login", json={"password": ACCENTED_PASSWORD})
+
+        assert response.status_code == 401
+
+    def test_the_correct_accented_password_still_authenticates(self, client, monkeypatch):
+        """Encoding both sides must not break the passwords it was meant to support."""
+        _configure(monkeypatch, ACCENTED_PASSWORD)
+
+        response = client.post("/admin/login", json={"password": ACCENTED_PASSWORD})
+
+        assert response.status_code == 200
+        assert response.json()["ok"] is True
+
+    def test_wrong_and_right_are_indistinguishable_apart_from_the_verdict(
+        self, client, monkeypatch
+    ):
+        """The reason a 500 mattered: a differing failure mode is an oracle. Both a wrong
+        ASCII guess and a wrong non-ASCII guess must produce the same 401 shape."""
+        _configure(monkeypatch, ACCENTED_PASSWORD)
+
+        ascii_guess = client.post("/admin/login", json={"password": "wrong"})
+        unicode_guess = client.post("/admin/login", json={"password": "wröng"})
+
+        assert ascii_guess.status_code == unicode_guess.status_code == 401
+        assert ascii_guess.json() == unicode_guess.json()
+
+
+class TestOrdinaryCases:
+    def test_the_correct_ascii_password_authenticates(self, client, monkeypatch):
+        _configure(monkeypatch, ASCII_PASSWORD)
+
+        response = client.post("/admin/login", json={"password": ASCII_PASSWORD})
+
+        assert response.status_code == 200
+
+    def test_an_empty_guess_is_rejected(self, client, monkeypatch):
+        _configure(monkeypatch, ASCII_PASSWORD)
+
+        assert client.post("/admin/login", json={"password": ""}).status_code == 401
+
+    def test_login_is_disabled_when_no_password_is_configured(self, client, monkeypatch):
+        """Fails closed. Notably an empty guess must not match an empty configured
+        password — _admin_enabled() is what prevents compare_digest("", "") succeeding."""
+        _configure(monkeypatch, "")
+
+        assert client.post("/admin/login", json={"password": ""}).status_code == 401
+        assert client.post("/admin/login", json={"password": "anything"}).status_code == 401

--- a/backend/tests/test_classifier.py
+++ b/backend/tests/test_classifier.py
@@ -6,7 +6,7 @@ false-positive guard, recurrence grouping, the manual-override skip that
 protects admin decisions from being overwritten on re-scrape, and series-level
 overrides (including keeping a recurring series as live music).
 
-Run from the backend/ directory:  python -m pytest tests/test_classifier.py
+Run from the backend/ directory:  pytest tests/test_classifier.py
 The classifier is pure stdlib, so no DB or fixtures are needed.
 
 NOT COVERED — known gaps, all requiring a database session:
@@ -31,16 +31,11 @@ session fixture against a throwaway database. The CI workflow already stands up 
 Postgres service container, so that is the natural place to hang it.
 """
 
-import sys
 from dataclasses import dataclass, field
 from datetime import date, timedelta
-from pathlib import Path
 from typing import Optional
 
-# Make `app` importable when running pytest from backend/.
-sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
-
-from app.classifier import (  # noqa: E402
+from app.classifier import (
     classify_one,
     find_recurring_event_ids,
     classify_batch,

--- a/backend/tests/test_classifier.py
+++ b/backend/tests/test_classifier.py
@@ -1,0 +1,312 @@
+"""
+Unit tests for app.classifier — the live-music detection logic.
+
+Covers the three signals (keyword, themed-night phrase, genre), the "night"
+false-positive guard, recurrence grouping, the manual-override skip that
+protects admin decisions from being overwritten on re-scrape, and series-level
+overrides (including keeping a recurring series as live music).
+
+Run from the backend/ directory:  python -m pytest tests/test_classifier.py
+The classifier is pure stdlib, so no DB or fixtures are needed.
+"""
+
+import sys
+from dataclasses import dataclass, field
+from datetime import date, timedelta
+from pathlib import Path
+from typing import Optional
+
+# Make `app` importable when running pytest from backend/.
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from app.classifier import (  # noqa: E402
+    classify_one,
+    find_recurring_event_ids,
+    classify_batch,
+    classification_updates,
+    normalize_series_name,
+    criteria_summary,
+)
+
+
+@dataclass
+class FakeEvent:
+    """Lightweight stand-in for an ORM Event with just the attributes the
+    classifier reads."""
+    id: int
+    venue_id: int
+    name: str
+    date: date
+    genre: Optional[str] = None
+    subgenre: Optional[str] = None
+    is_manual_override: bool = False
+
+
+D0 = date(2026, 8, 1)
+
+
+def _weekly(n: int, start: date = D0) -> list[date]:
+    return [start + timedelta(days=7 * i) for i in range(n)]
+
+
+# --- classify_one: keywords ---
+
+def test_keyword_karaoke_flagged():
+    is_live, reason = classify_one("Tuesday Karaoke")
+    assert is_live is False
+    assert reason == "keyword: karaoke"
+
+
+def test_keyword_trivia_flagged():
+    is_live, reason = classify_one("Pub Trivia")
+    assert is_live is False
+    assert "trivia" in reason
+
+
+def test_keyword_comedy_flagged():
+    is_live, _ = classify_one("Stand-Up Comedy Showcase")
+    assert is_live is False
+
+
+def test_keyword_matches_are_word_bounded():
+    # "class" must not match inside "classic"
+    is_live, reason = classify_one("Classic Rock Tribute")
+    assert is_live is True
+    assert reason is None
+
+
+def test_plain_band_name_is_live():
+    is_live, reason = classify_one("The Mountain Goats")
+    assert is_live is True
+    assert reason is None
+
+
+# --- classify_one: the "night" guard ---
+
+def test_themed_night_flagged():
+    is_live, reason = classify_one("Emo Night")
+    assert is_live is False
+    assert reason == "keyword: emo night"
+
+
+def test_decade_night_flagged():
+    is_live, _ = classify_one("80s Night Dance Party")
+    assert is_live is False
+
+
+def test_bare_night_not_flagged():
+    # Day-of-week / song-title uses of "night" must stay live music.
+    for title in ("Saturday Night Fever Tribute", "Last Night", "A Hard Day's Night",
+                  "One Night Only"):
+        is_live, reason = classify_one(title)
+        assert is_live is True, f"{title!r} was wrongly flagged ({reason})"
+
+
+def test_broad_night_flags_arbitrary_theme_words():
+    # Broadened "<word> night" — any non-excepted word before "night" is flagged.
+    cases = {
+        "Monday Jazz Night!": "jazz night",                      # word before night = jazz
+        "CLUB XCX : CHARLI XCX + HYPERPOP NIGHT": "hyperpop night",
+        "Funk Night": "funk night",
+        "Reggae Nights": "reggae night",                          # plural
+    }
+    for title, expected in cases.items():
+        is_live, reason = classify_one(title)
+        assert is_live is False, f"{title!r} should be flagged"
+        assert reason == f"keyword: {expected}", f"{title!r} -> {reason}"
+
+
+# --- classify_one: "<theme> party" ---
+
+def test_party_themes_flagged():
+    for title, theme in (("Album Listening Party", "listening"),
+                         ("New Release Party", "release"),
+                         ("Block Party", "block")):
+        is_live, reason = classify_one(title)
+        assert is_live is False, f"{title!r} should be flagged"
+        assert reason == f"keyword: {theme} party"
+
+
+def test_band_named_party_not_flagged():
+    # "Bloc Party" (the band) must stay live — bare "party" is never matched.
+    is_live, reason = classify_one("Bloc Party")
+    assert is_live is True
+    assert reason is None
+
+
+# --- classify_one: genre ---
+
+def test_genre_comedy_flagged():
+    is_live, reason = classify_one("An Evening With Someone", genre="Comedy")
+    assert is_live is False
+    assert reason == "genre: comedy"
+
+
+def test_genre_theatre_flagged_via_substring():
+    is_live, _ = classify_one("The Nutcracker", genre="Children's Theatre")
+    assert is_live is False
+
+
+def test_music_genre_stays_live():
+    is_live, reason = classify_one("Some Band", genre="Rock", subgenre="Indie Rock")
+    assert is_live is True
+    assert reason is None
+
+
+def test_dance_electronic_genre_is_live():
+    # "Dance/Electronic" is real live music — must not be caught as non-music.
+    is_live, _ = classify_one("Big DJ Live Set", genre="Dance/Electronic")
+    assert is_live is True
+
+
+# --- recurrence ---
+
+def test_recurring_series_detected():
+    events = [FakeEvent(i, 1, "The Regulars", d) for i, d in enumerate(_weekly(4))]
+    recurring = find_recurring_event_ids(events)
+    assert set(recurring) == {0, 1, 2, 3}
+    assert all(count == 4 for count in recurring.values())
+
+
+def test_below_threshold_not_recurring():
+    events = [FakeEvent(i, 1, "The Regulars", d) for i, d in enumerate(_weekly(2))]
+    assert find_recurring_event_ids(events) == {}
+
+
+def test_recurrence_is_per_venue():
+    # Same name at two venues, twice each -> neither hits the threshold of 3.
+    events = [
+        FakeEvent(1, 1, "House Band", D0),
+        FakeEvent(2, 1, "House Band", D0 + timedelta(days=7)),
+        FakeEvent(3, 2, "House Band", D0),
+        FakeEvent(4, 2, "House Band", D0 + timedelta(days=7)),
+    ]
+    assert find_recurring_event_ids(events) == {}
+
+
+def test_recurrence_groups_dated_name_variants():
+    # Digit-stripping normalization collapses "... 8/1", "... 8/8", "... 8/15".
+    events = [
+        FakeEvent(1, 1, "Open Turntables 8/1", D0),
+        FakeEvent(2, 1, "Open Turntables 8/8", D0 + timedelta(days=7)),
+        FakeEvent(3, 1, "Open Turntables 8/15", D0 + timedelta(days=14)),
+    ]
+    assert set(find_recurring_event_ids(events)) == {1, 2, 3}
+
+
+# --- classify_batch: signal priority ---
+
+def test_recurrence_overrides_a_keyword_miss():
+    # No keyword in the name, but it recurs weekly -> non-live via recurrence.
+    events = [FakeEvent(i, 1, "The Regulars", d) for i, d in enumerate(_weekly(3))]
+    result = classify_batch(events)
+    for eid in (0, 1, 2):
+        is_live, reason = result[eid]
+        assert is_live is False
+        assert reason == "recurring: 3 dates"
+
+
+def test_batch_keeps_one_off_show_live():
+    events = [FakeEvent(1, 1, "Waxahatchee", D0)]
+    is_live, reason = classify_batch(events)[1]
+    assert is_live is True
+    assert reason is None
+
+
+# --- override durability (the pure function behind reclassify_all) ---
+
+def test_manual_override_is_excluded_from_updates():
+    events = [
+        FakeEvent(1, 1, "Karaoke", D0, is_manual_override=True),   # admin forced a value
+        FakeEvent(2, 1, "Trivia", D0, is_manual_override=False),
+    ]
+    updates = classification_updates(events)
+    assert 1 not in updates          # overridden row is left untouched
+    assert updates[2] == (False, "keyword: trivia")
+
+
+# --- series-level overrides ---
+
+def _series_key(venue_id: int, name: str) -> tuple:
+    return (venue_id, normalize_series_name(name))
+
+
+def test_series_override_keeps_recurring_series_live():
+    # A weekly jazz jam that recurrence would flag non-live, but the admin has
+    # marked the whole series as live music.
+    events = [FakeEvent(i, 1, "Wednesday Night Jazz Jam", d)
+              for i, d in enumerate(_weekly(4))]
+    overrides = {_series_key(1, "Wednesday Night Jazz Jam"): (True, "house jazz band")}
+    updates = classification_updates(events, series_overrides=overrides)
+    for eid in range(4):
+        assert updates[eid] == (True, "series override: live music")
+
+
+def test_series_override_can_force_non_live():
+    # A one-off name recurrence wouldn't catch, but the admin wants it hidden.
+    events = [FakeEvent(1, 2, "Vinyl Social", D0)]
+    overrides = {_series_key(2, "Vinyl Social"): (False, "just records, no band")}
+    updates = classification_updates(events, series_overrides=overrides)
+    assert updates[1] == (False, "series override: non-live")
+
+
+def test_series_override_is_venue_scoped():
+    # Same series name at a different venue is unaffected by the override.
+    events = [
+        FakeEvent(1, 1, "Open Turntables", D0),  # overridden venue
+        FakeEvent(2, 2, "Open Turntables", D0),  # different venue
+    ]
+    overrides = {_series_key(1, "Open Turntables"): (True, None)}
+    updates = classification_updates(events, series_overrides=overrides)
+    assert updates[1] == (True, "series override: live music")
+    # Venue 2 falls through to automatic classification (a single date -> live).
+    assert updates[2] == (True, None)
+
+
+def test_per_event_override_beats_series_override():
+    # The specific instance is manually overridden, so it is left untouched even
+    # though a series override also matches it.
+    events = [FakeEvent(1, 1, "Karaoke", D0, is_manual_override=True)]
+    overrides = {_series_key(1, "Karaoke"): (True, None)}
+    updates = classification_updates(events, series_overrides=overrides)
+    assert 1 not in updates  # reclassify leaves the hand-set value in place
+
+
+def test_series_key_matches_dated_name_variants():
+    # The admin keys off one instance; other dated instances of the series match.
+    assert (normalize_series_name("Trivia Night 8/1")
+            == normalize_series_name("Trivia Night 8/8"))
+
+
+# --- always-live venue exemption (e.g. DPAC) ---
+
+def test_exempt_venue_forced_live_over_auto_and_series():
+    # Venue 9 is exempt. Even a recurring, keyword-y name at that venue stays live;
+    # a series override on it is also ignored (venue is out of the filter pass).
+    events = [FakeEvent(i, 9, "Karaoke Night", d) for i, d in enumerate(_weekly(4))]
+    overrides = {_series_key(9, "Karaoke Night"): (False, None)}
+    updates = classification_updates(
+        events, series_overrides=overrides, exempt_venue_ids={9}
+    )
+    for eid in range(4):
+        assert updates[eid] == (True, "venue: always live music")
+
+
+def test_exempt_venue_still_respects_per_event_override():
+    # A hand-set instance at an exempt venue is still left untouched.
+    events = [FakeEvent(1, 9, "Comedy", D0, is_manual_override=True)]
+    updates = classification_updates(events, exempt_venue_ids={9})
+    assert 1 not in updates
+
+
+# --- criteria surface ---
+
+def test_criteria_summary_shape():
+    summary = criteria_summary()
+    assert summary["recurrence_threshold"] == 3
+    assert "karaoke" in summary["keywords"]
+    assert "listening" in summary["party_themes"]
+    assert "allowlist" in summary["party_rule"]  # explains why "party" isn't matched bare
+    assert "saturday" in summary["night_exceptions"]
+    assert "dpac" in summary["always_live_venues"]
+    assert "comedy" in summary["non_music_genres"]

--- a/backend/tests/test_classifier.py
+++ b/backend/tests/test_classifier.py
@@ -26,6 +26,8 @@ from app.classifier import (  # noqa: E402
     classification_updates,
     normalize_series_name,
     criteria_summary,
+    reclassify_floor,
+    RECLASSIFY_PAST_DAYS,
 )
 
 
@@ -310,3 +312,28 @@ def test_criteria_summary_shape():
     assert "saturday" in summary["night_exceptions"]
     assert "dpac" in summary["always_live_venues"]
     assert "comedy" in summary["non_music_genres"]
+
+
+# --- reclassify_floor ---
+
+def test_reclassify_floor_reaches_into_the_past():
+    """The window must extend behind today, not just forward.
+
+    The calendar can be scrolled back into recent dates, and those events carry
+    is_live_music too — if the floor were today, past events would freeze at whatever
+    they were last set to and stop responding to series rules.
+    """
+    today = date(2026, 8, 27)
+    assert reclassify_floor(today) < today
+    assert reclassify_floor(today) == today - timedelta(days=RECLASSIFY_PAST_DAYS)
+
+
+def test_reclassify_floor_window_is_about_a_month():
+    """Guards the constant itself. Widening it changes the blast radius of every
+    series action and of the admin queue, so a change here should be deliberate."""
+    assert RECLASSIFY_PAST_DAYS == 30
+
+
+def test_reclassify_floor_defaults_to_today():
+    """Called with no argument in production code paths, so the default must work."""
+    assert reclassify_floor() == date.today() - timedelta(days=RECLASSIFY_PAST_DAYS)

--- a/backend/tests/test_classifier.py
+++ b/backend/tests/test_classifier.py
@@ -385,16 +385,60 @@ def test_series_key_matches_dated_name_variants():
 
 # --- always-live venue exemption (e.g. DPAC) ---
 
-def test_exempt_venue_forced_live_over_auto_and_series():
-    # Venue 9 is exempt. Even a recurring, keyword-y name at that venue stays live;
-    # a series override on it is also ignored (venue is out of the filter pass).
+def test_exempt_venue_forced_live_over_automatic_classification():
+    # Venue 9 is exempt, so a recurring, keyword-y name there stays live music instead of
+    # being flagged as a series.
+    events = [FakeEvent(i, 9, "Karaoke Night", d) for i, d in enumerate(_weekly(4))]
+    updates = classification_updates(events, exempt_venue_ids={9})
+    for eid in range(4):
+        assert updates[eid] == (True, "venue: always live music")
+
+
+def test_series_override_beats_the_venue_exemption():
+    """Review item #6. This assertion is the reverse of what it was.
+
+    The exemption used to return before series overrides were consulted, which made an
+    exempt venue's series impossible to mark non-live through the series UI — on every
+    future instance, permanently. DPAC is the only exempt venue and it hosts Broadway and
+    comedy alongside music, so that is precisely the case the series UI exists for. The
+    exemption is now a default that a deliberate series decision can override.
+    """
     events = [FakeEvent(i, 9, "Karaoke Night", d) for i, d in enumerate(_weekly(4))]
     overrides = {_series_key(9, "Karaoke Night"): (False, None)}
+
     updates = classification_updates(
         events, series_overrides=overrides, exempt_venue_ids={9}
     )
+
     for eid in range(4):
-        assert updates[eid] == (True, "venue: always live music")
+        assert updates[eid] == (False, "series override: non-live")
+
+
+def test_a_series_override_can_also_keep_an_exempt_venues_series_live():
+    """The override wins in both directions — it is not a special case for hiding."""
+    events = [FakeEvent(i, 9, "Karaoke Night", d) for i, d in enumerate(_weekly(4))]
+    overrides = {_series_key(9, "Karaoke Night"): (True, None)}
+
+    updates = classification_updates(
+        events, series_overrides=overrides, exempt_venue_ids={9}
+    )
+
+    for eid in range(4):
+        assert updates[eid] == (True, "series override: live music")
+
+
+def test_an_unrelated_series_at_an_exempt_venue_still_gets_the_exemption():
+    """Only the overridden series changes; the rest of the venue keeps its default."""
+    events = [FakeEvent(i, 9, "Karaoke Night", d) for i, d in enumerate(_weekly(4))]
+    events += [FakeEvent(100 + i, 9, "Trivia Night", d) for i, d in enumerate(_weekly(4))]
+    overrides = {_series_key(9, "Karaoke Night"): (False, None)}
+
+    updates = classification_updates(
+        events, series_overrides=overrides, exempt_venue_ids={9}
+    )
+
+    assert updates[0] == (False, "series override: non-live")
+    assert updates[100] == (True, "venue: always live music")
 
 
 def test_exempt_venue_still_respects_per_event_override():

--- a/backend/tests/test_classifier.py
+++ b/backend/tests/test_classifier.py
@@ -49,6 +49,8 @@ from app.classifier import (  # noqa: E402
     criteria_summary,
     reclassify_floor,
     RECLASSIFY_PAST_DAYS,
+    RECURRENCE_THRESHOLD,
+    RUN_GAP_DAYS,
 )
 
 
@@ -70,6 +72,11 @@ D0 = date(2026, 8, 1)
 
 def _weekly(n: int, start: date = D0) -> list[date]:
     return [start + timedelta(days=7 * i) for i in range(n)]
+
+
+def _consecutive(n: int, start: date = D0) -> list[date]:
+    """n back-to-back nights — a residency, not a series."""
+    return [start + timedelta(days=i) for i in range(n)]
 
 
 # --- classify_one: keywords ---
@@ -217,6 +224,86 @@ def test_recurrence_groups_dated_name_variants():
     assert set(find_recurring_event_ids(events)) == {1, 2, 3}
 
 
+# --- recurrence: a run is not a series (review item #1) ---
+
+def test_multi_night_residency_is_not_a_series():
+    """A band booked three consecutive nights is the marquee listing, not karaoke."""
+    events = [FakeEvent(i, 1, "Hiss Golden Messenger", d)
+              for i, d in enumerate(_consecutive(3))]
+    assert find_recurring_event_ids(events) == {}
+
+
+def test_long_residency_is_not_a_series():
+    """DPAC-style eight-night Broadway runs must survive even without the exemption."""
+    events = [FakeEvent(i, 1, "Death Becomes Her", d)
+              for i, d in enumerate(_consecutive(8))]
+    assert find_recurring_event_ids(events) == {}
+
+
+def test_a_gap_within_the_run_window_stays_one_occasion():
+    """Fri and Sun with Saturday off is still one booking."""
+    dates = [D0, D0 + timedelta(days=RUN_GAP_DAYS), D0 + timedelta(days=2 * RUN_GAP_DAYS)]
+    events = [FakeEvent(i, 1, "Weekend Stand", d) for i, d in enumerate(dates)]
+    assert find_recurring_event_ids(events) == {}
+
+
+def test_weekly_series_is_still_detected():
+    """The behavior the feature exists for must be unaffected by the run rule."""
+    events = [FakeEvent(i, 1, "Tuesday Karaoke", d)
+              for i, d in enumerate(_weekly(RECURRENCE_THRESHOLD))]
+    assert len(find_recurring_event_ids(events)) == RECURRENCE_THRESHOLD
+
+
+def test_repeating_two_night_run_is_a_series():
+    """Fri+Sat every week is a series — three occasions, six dates."""
+    dates = []
+    for week in range(3):
+        dates.append(D0 + timedelta(days=7 * week))
+        dates.append(D0 + timedelta(days=7 * week + 1))
+    events = [FakeEvent(i, 1, "Emo Weekend", d) for i, d in enumerate(dates)]
+
+    recurring = find_recurring_event_ids(events)
+
+    assert len(recurring) == 6
+    assert all(count == 6 for count in recurring.values()), "count reports dates, not occasions"
+
+
+def test_monthly_series_is_detected():
+    """Sparse cadences are series too — the run rule must not swallow them."""
+    dates = [D0, D0 + timedelta(days=30), D0 + timedelta(days=60)]
+    events = [FakeEvent(i, 1, "First Friday Market", d) for i, d in enumerate(dates)]
+    assert len(find_recurring_event_ids(events)) == 3
+
+
+# --- recurrence: unnamed events are not a series (review item #3) ---
+
+def test_empty_names_do_not_form_a_series():
+    """A scraper emitting nameless records must not hide them as a phantom series."""
+    events = [FakeEvent(i, 1, "", d) for i, d in enumerate(_weekly(4))]
+    assert find_recurring_event_ids(events) == {}
+
+
+def test_digit_only_names_do_not_form_a_series():
+    """These normalize to '' and are unrelated events, not one series."""
+    events = [
+        FakeEvent(1, 1, "2/14", D0),
+        FakeEvent(2, 1, "$5", D0 + timedelta(days=7)),
+        FakeEvent(3, 1, "7/8 - 9", D0 + timedelta(days=14)),
+    ]
+    assert find_recurring_event_ids(events) == {}
+
+
+def test_unnamed_events_do_not_drag_in_named_ones():
+    """The empty-key group must stay separate from a real series at the same venue."""
+    events = [FakeEvent(i, 1, "", d) for i, d in enumerate(_weekly(3))]
+    events += [FakeEvent(10 + i, 1, "Tuesday Karaoke", d)
+               for i, d in enumerate(_weekly(3, start=D0 + timedelta(days=3)))]
+
+    recurring = find_recurring_event_ids(events)
+
+    assert set(recurring) == {10, 11, 12}
+
+
 # --- classify_batch: signal priority ---
 
 def test_recurrence_overrides_a_keyword_miss():
@@ -327,6 +414,8 @@ def test_exempt_venue_still_respects_per_event_override():
 def test_criteria_summary_shape():
     summary = criteria_summary()
     assert summary["recurrence_threshold"] == 3
+    assert summary["run_gap_days"] == RUN_GAP_DAYS
+    assert "occasion" in summary["recurrence_rule"]
     assert "karaoke" in summary["keywords"]
     assert "listening" in summary["party_themes"]
     assert "allowlist" in summary["party_rule"]  # explains why "party" isn't matched bare

--- a/backend/tests/test_classifier.py
+++ b/backend/tests/test_classifier.py
@@ -8,6 +8,27 @@ overrides (including keeping a recurring series as live music).
 
 Run from the backend/ directory:  python -m pytest tests/test_classifier.py
 The classifier is pure stdlib, so no DB or fixtures are needed.
+
+NOT COVERED — known gaps, all requiring a database session:
+
+  * ScrapeManager.reclassify_all() clearing Event.approved_at when a verdict
+    changes. This is the subtlest contract in the feature: the condition checks
+    `is_live_music` specifically, NOT the broader `changed` flag used on the
+    surrounding lines, because a reworded classification_reason is not a
+    different answer. "Simplifying" it to match its neighbours would silently
+    empty the admin review queue on every scrape — no error, just an
+    inexplicably empty page. Verified by hand against real data (22 approvals
+    cleared on a flip, 22 preserved across a no-op reclassify) but nothing here
+    would catch a regression.
+  * The series-scoped approve/unapprove endpoints, which group by
+    normalize_series_name and must match what the dashboard shows collapsed.
+  * The admin list endpoint's honest-count fields — total, approved_hidden and
+    series_size — each of which exists specifically to stop the UI understating
+    what it is showing or what a series action affects.
+
+Closing these needs pytest-asyncio (not currently in requirements-dev.txt) and a
+session fixture against a throwaway database. The CI workflow already stands up a
+Postgres service container, so that is the natural place to hang it.
 """
 
 import sys

--- a/backend/tests/test_events_api.py
+++ b/backend/tests/test_events_api.py
@@ -1,0 +1,172 @@
+"""
+Tests for two review items in app.api.events — #4 (dedup ranking) and #5 (list filtering).
+
+#4 is a pure function, so it is tested directly. #5 builds a SQL WHERE clause and would
+need a database to exercise end to end; what is asserted here is the parameter contract,
+with the gap stated plainly rather than papered over. See the note on TestListFiltering.
+"""
+
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Optional
+
+from fastapi.testclient import TestClient
+
+import pytest
+
+from app.api.events import _completeness, _list_conditions
+from app.main import app
+
+
+@dataclass
+class Row:
+    """Stand-in for an ORM Event with only the attributes _completeness reads."""
+
+    id: int
+    is_live_music: bool = True
+    is_manual_override: bool = False
+    image_url: Optional[str] = None
+    ticket_url: Optional[str] = None
+    price_min: Optional[float] = None
+    updated_at: Optional[datetime] = None
+
+
+def _winner(a: Row, b: Row) -> Row:
+    """Whichever row the display-time dedup would keep, order-independently."""
+    forward = a if _completeness(a) > _completeness(b) else b
+    backward = b if _completeness(b) > _completeness(a) else a
+    assert forward is backward, "ranking depends on comparison order — not a total order"
+    return forward
+
+
+# --- #4: dedup must not discard the visible copy ---
+
+class TestDedupRanking:
+    def test_a_live_row_beats_a_non_live_row_with_richer_metadata(self):
+        """The regression. Ranking on field counts alone let the richer row win, and if
+        that row was classified non-live the show vanished from the default calendar."""
+        live_but_sparse = Row(id=1, is_live_music=True)
+        non_live_but_rich = Row(
+            id=2, is_live_music=False, image_url="x", ticket_url="y", price_min=10.0
+        )
+
+        assert _winner(live_but_sparse, non_live_but_rich).id == 1
+
+    def test_an_admin_override_beats_an_automatic_live_verdict(self):
+        """An admin looked at this row and decided; that outranks anything computed —
+        including a computed verdict that happens to be more permissive."""
+        hand_set_hidden = Row(id=1, is_live_music=False, is_manual_override=True)
+        auto_live = Row(id=2, is_live_music=True, image_url="x", ticket_url="y")
+
+        assert _winner(hand_set_hidden, auto_live).id == 1
+
+    def test_metadata_still_decides_between_two_equal_verdicts(self):
+        """The original behavior survives as a tiebreaker rather than being replaced."""
+        sparse = Row(id=1, is_live_music=True)
+        rich = Row(id=2, is_live_music=True, image_url="x", ticket_url="y", price_min=5.0)
+
+        assert _winner(sparse, rich).id == 2
+
+    def test_recency_breaks_a_tie_on_metadata(self):
+        older = Row(id=1, image_url="x", updated_at=datetime(2026, 1, 1))
+        newer = Row(id=2, image_url="y", updated_at=datetime(2026, 6, 1))
+
+        assert _winner(older, newer).id == 2
+
+    def test_id_breaks_a_total_tie(self):
+        """Without a final total key the winner would depend on row order from the
+        database, which is how the earlier version picked a surviving venue at random."""
+        assert _winner(Row(id=1), Row(id=2)).id == 2
+
+    def test_a_missing_updated_at_does_not_raise(self):
+        """Rows inserted but never re-scraped have updated_at unset."""
+        assert _winner(Row(id=1, updated_at=None), Row(id=2, updated_at=None)).id == 2
+
+    def test_is_manual_override_absent_is_treated_as_false(self):
+        """_completeness reads it with getattr, so a stand-in or a partially loaded row
+        lacking the attribute must rank as not-overridden rather than blow up."""
+
+        class NoOverrideAttr:
+            id = 1
+            is_live_music = True
+            image_url = ticket_url = None
+            price_min = None
+            updated_at = None
+
+        assert _completeness(NoOverrideAttr())[0] is False
+
+
+# --- #5: the list endpoint gains the opt-in the other consumers already have ---
+
+class TestListConditions:
+    """The clauses themselves, via _list_conditions.
+
+    An earlier version of this file only checked the OpenAPI parameter contract below.
+    Mutation-testing showed that was not enough: deleting the line that appends the
+    live-music clause left every assertion passing, because a declared-but-unused query
+    parameter still appears in the schema. That is exactly the bug worth catching, so the
+    clause building was split out of the endpoint to make it reachable without Postgres.
+    """
+
+    @staticmethod
+    def _sql(conditions) -> str:
+        return " ".join(str(c) for c in conditions)
+
+    def test_live_music_is_filtered_by_default(self):
+        assert "is_live_music" in self._sql(_list_conditions())
+
+    def test_opting_in_removes_the_filter(self):
+        assert "is_live_music" not in self._sql(_list_conditions(include_non_music=True))
+
+    def test_the_filter_is_added_alongside_other_filters(self):
+        """Regression shape: an early return or an if/elif could drop it whenever another
+        filter was supplied."""
+        sql = self._sql(_list_conditions(search="band", genre="rock", status="onsale"))
+        assert "is_live_music" in sql
+
+    def test_other_filters_are_unaffected_by_the_opt_in(self):
+        """Opting in drops only the live-music clause, not the caller's own filters."""
+        opted_in = self._sql(_list_conditions(search="band", include_non_music=True))
+        assert "events.name" in opted_in and "events.artist" in opted_in
+        assert "is_live_music" not in opted_in
+
+    def test_a_malformed_date_is_ignored_rather_than_raising(self):
+        """Pre-existing behavior, preserved through the extraction."""
+        conditions = _list_conditions(start="not-a-date", include_non_music=True)
+        assert conditions == []
+
+
+class TestListFiltering:
+    """The parameter contract, as it appears to callers."""
+
+    @pytest.fixture
+    def schema(self):
+        return TestClient(app).get("/openapi.json").json()
+
+    def _params(self, schema, path):
+        return {p["name"]: p for p in schema["paths"][path]["get"]["parameters"]}
+
+    def test_the_list_endpoint_offers_the_opt_in(self, schema):
+        assert "include_non_music" in self._params(schema, "/api/events")
+
+    def test_it_defaults_to_live_music_only(self, schema):
+        """Default off is the point: before this, the list endpoint was the one consumer
+        that served the events the feature exists to hide."""
+        param = self._params(schema, "/api/events")["include_non_music"]
+        assert param["schema"]["default"] is False
+
+    def test_it_matches_the_ical_feed_by_name_and_default(self, schema):
+        """Review item #5 is about consistency across consumers, so the two endpoints
+        agreeing is the property worth pinning — a rename of one would break this."""
+        events = self._params(schema, "/api/events")["include_non_music"]
+        feed = self._params(schema, "/feeds/events.ics")["include_non_music"]
+
+        assert events["schema"]["default"] == feed["schema"]["default"] is False
+
+    def test_the_fullcalendar_endpoint_deliberately_has_no_such_parameter(self, schema):
+        """Left returning everything on purpose: filters.js toggles visibility in the
+        browser without refetching, so filtering server-side would empty the calendar the
+        moment someone switched the toggle on. Asserted so the omission reads as a decision
+        rather than as an oversight."""
+        params = self._params(schema, "/api/events/fullcalendar")
+        assert "include_non_music" not in params

--- a/backend/tests/test_migrations.py
+++ b/backend/tests/test_migrations.py
@@ -1,0 +1,151 @@
+"""
+Integration cover for the concurrent-migration race (review item #7).
+
+Migrations run from the FastAPI lifespan handler rather than as a deploy step, so two
+Cloud Run containers booting together both call `upgrade head` against the same
+database. Before the advisory lock in alembic/env.py, the loser of that race failed on
+an object the winner had just created and never became healthy.
+
+These tests need a real database — they create and drop a scratch one — and skip
+cleanly when there isn't a reachable server, so a local `pytest` without Postgres
+still passes. CI stands up a Postgres service container, so they do run there.
+
+Note this is a race, so the concurrent test is not guaranteed to fail if the lock is
+removed — it failed on every one of several attempts, but timing decides. What it does
+guarantee is the other direction: that the lock never makes concurrent upgrades fail.
+"""
+
+import os
+import subprocess
+import sys
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+from urllib.parse import urlsplit, urlunsplit
+
+import pytest
+
+BACKEND = Path(__file__).resolve().parent.parent
+SCRATCH_DB = "alembic_race_test"
+RUNNERS = 3
+
+
+# --- Helpers ---
+
+def _sync_url(url: str) -> str:
+    """Convert to a sync driver URL for psycopg2's own use here.
+
+    DATABASE_URL itself must keep the `+asyncpg` form when handed to a subprocess:
+    alembic/env.py imports app.database, which builds an async engine from it and
+    rejects a sync driver. env.py does its own conversion for alembic internally.
+    """
+    return url.replace("postgresql+asyncpg://", "postgresql://").replace(
+        "ssl=require", "sslmode=require"
+    )
+
+
+def _with_database(url: str, dbname: str) -> str:
+    return urlunsplit(urlsplit(url)._replace(path=f"/{dbname}"))
+
+
+def _alembic(url: str, *args: str) -> subprocess.CompletedProcess:
+    """Run the alembic CLI the way the app and CI do, against `url`."""
+    return subprocess.run(
+        [sys.executable, "-m", "alembic", *args],
+        cwd=BACKEND,
+        env={**os.environ, "DATABASE_URL": url},
+        capture_output=True,
+        text=True,
+        timeout=180,
+    )
+
+
+@pytest.fixture
+def scratch_db():
+    """Yield a URL for an empty throwaway database, dropped afterwards."""
+    url = os.getenv("DATABASE_URL")
+    if not url:
+        pytest.skip("DATABASE_URL is not set")
+
+    try:
+        import psycopg2
+    except ImportError:
+        pytest.skip("psycopg2 is not installed")
+
+    admin_url = _with_database(_sync_url(url), "postgres")
+    try:
+        conn = psycopg2.connect(admin_url, connect_timeout=5)
+    except Exception as exc:  # no server, wrong credentials, not listening
+        pytest.skip(f"no reachable database: {exc}")
+
+    conn.autocommit = True  # CREATE/DROP DATABASE cannot run inside a transaction
+    try:
+        with conn.cursor() as cur:
+            cur.execute(f"DROP DATABASE IF EXISTS {SCRATCH_DB} WITH (FORCE)")
+            cur.execute(f"CREATE DATABASE {SCRATCH_DB}")
+        # Async form on purpose — this is passed through as DATABASE_URL.
+        yield _with_database(url, SCRATCH_DB)
+    finally:
+        with conn.cursor() as cur:
+            # FORCE so a leaked connection from a failed run cannot block cleanup.
+            cur.execute(f"DROP DATABASE IF EXISTS {SCRATCH_DB} WITH (FORCE)")
+        conn.close()
+
+
+def _describe(results) -> str:
+    return "\n\n".join(
+        f"--- runner {i} (exit {r.returncode}) ---\n{r.stdout}\n{r.stderr}"
+        for i, r in enumerate(results)
+    )
+
+
+# --- Tests ---
+
+def test_concurrent_upgrades_all_succeed(scratch_db):
+    """The regression: without the lock, one runner dies on the winner's objects."""
+    with ThreadPoolExecutor(max_workers=RUNNERS) as pool:
+        results = [f.result() for f in
+                   [pool.submit(_alembic, scratch_db, "upgrade", "head")
+                    for _ in range(RUNNERS)]]
+
+    failed = [i for i, r in enumerate(results) if r.returncode != 0]
+    assert not failed, f"runners {failed} failed:\n{_describe(results)}"
+
+
+def test_concurrent_upgrades_leave_the_schema_at_head(scratch_db):
+    """Serializing must still apply the migrations, not just avoid the crash."""
+    with ThreadPoolExecutor(max_workers=RUNNERS) as pool:
+        [f.result() for f in
+         [pool.submit(_alembic, scratch_db, "upgrade", "head") for _ in range(RUNNERS)]]
+
+    current = _alembic(scratch_db, "current")
+    assert current.returncode == 0, current.stderr
+    assert "(head)" in current.stdout, f"not at head:\n{current.stdout}\n{current.stderr}"
+
+
+def test_upgrade_is_idempotent(scratch_db):
+    """A container booting against an already-migrated database must no-op, not fail."""
+    first = _alembic(scratch_db, "upgrade", "head")
+    assert first.returncode == 0, first.stderr
+
+    second = _alembic(scratch_db, "upgrade", "head")
+    assert second.returncode == 0, f"re-running at head failed:\n{second.stderr}"
+
+
+def test_the_lock_is_transaction_scoped(scratch_db):
+    """pg_advisory_xact_lock, not pg_advisory_lock.
+
+    A session-scoped lock would survive a crashed migration and wedge every later
+    boot, and would be invisible across Neon's transaction-mode pooler. Asserting no
+    advisory lock outlives the upgrade is the observable form of that requirement.
+    """
+    import psycopg2
+
+    assert _alembic(scratch_db, "upgrade", "head").returncode == 0
+
+    conn = psycopg2.connect(_sync_url(scratch_db), connect_timeout=5)
+    try:
+        with conn.cursor() as cur:
+            cur.execute("SELECT count(*) FROM pg_locks WHERE locktype = 'advisory'")
+            assert cur.fetchone()[0] == 0, "an advisory lock outlived the migration"
+    finally:
+        conn.close()

--- a/backend/tests/test_series_override_cascade.py
+++ b/backend/tests/test_series_override_cascade.py
@@ -1,0 +1,77 @@
+"""
+Tests that retiring a venue cannot be blocked by its series rules — review item #9.
+
+seed_venues() deletes venues named in REMOVED_SLUGS on every startup, via
+session.delete(). That cascades only through relationships SQLAlchemy knows about. Venue
+had them for events and scrape_logs but not for series_overrides, and the foreign key had
+no ON DELETE, so the first retirement of a venue holding a series override would raise
+ForeignKeyViolation inside the lifespan handler — and the container would never become
+healthy. REMOVED_SLUGS is [""] today, which is why nothing has broken yet.
+
+The fix has two halves and this file checks both, because either alone leaves a hole:
+
+  * an ORM relationship with delete-orphan, which covers session.delete()
+  * ON DELETE CASCADE on the constraint, which covers anything bypassing the ORM
+
+Asserted against mapper metadata and the migration source rather than a live database.
+The model being right while the migration is wrong is the realistic drift — the model
+governs nothing at runtime, since the table is created by the migration — so the migration
+is checked too. Neither check needs Postgres.
+"""
+
+import pathlib
+import re
+
+from app.models import SeriesOverride, Venue
+
+
+MIGRATION = (
+    pathlib.Path(__file__).resolve().parent.parent
+    / "alembic" / "versions" / "0004_add_series_overrides.py"
+)
+
+
+class TestOrmCascade:
+    """Covers session.delete(venue), which is how seed_venues() retires a venue."""
+
+    def test_venue_has_a_series_overrides_relationship(self):
+        assert "series_overrides" in Venue.__mapper__.relationships
+
+    def test_it_cascades_deletes_like_events_and_scrape_logs(self):
+        rel = Venue.__mapper__.relationships["series_overrides"]
+        assert rel.cascade.delete
+        assert rel.cascade.delete_orphan
+
+    def test_it_matches_the_cascade_on_the_other_two_collections(self):
+        """Consistency is the point — a venue's dependents should not have three different
+        deletion behaviors depending on which was added when."""
+        cascades = {
+            name: (Venue.__mapper__.relationships[name].cascade.delete,
+                   Venue.__mapper__.relationships[name].cascade.delete_orphan)
+            for name in ("events", "scrape_logs", "series_overrides")
+        }
+        assert len(set(cascades.values())) == 1, cascades
+
+    def test_the_reverse_relationship_is_wired(self):
+        """back_populates on Venue requires the matching attribute here, or SQLAlchemy
+        raises at mapper configuration time."""
+        assert "venue" in SeriesOverride.__mapper__.relationships
+
+
+class TestDatabaseConstraint:
+    """Covers deletions that never pass through the ORM's cascade."""
+
+    def test_the_model_declares_on_delete_cascade(self):
+        fks = list(SeriesOverride.__table__.c.venue_id.foreign_keys)
+        assert len(fks) == 1
+        assert fks[0].ondelete == "CASCADE"
+
+    def test_the_migration_declares_it_too(self):
+        """The migration, not the model, is what creates the constraint in the database.
+        A model-only fix would look correct here and change nothing in production."""
+        source = MIGRATION.read_text(encoding="utf-8")
+        fk = re.search(
+            r"ForeignKeyConstraint\(\s*\['venue_id'\][^)]*\)", source, re.DOTALL
+        )
+        assert fk is not None, "venue_id foreign key not found in 0004"
+        assert "ondelete='CASCADE'" in fk.group(0) or 'ondelete="CASCADE"' in fk.group(0)

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -12,6 +12,12 @@
 #      gcloud secrets create triangle-shows-tm-api-key \
 #        --data-file=- <<< "your_ticketmaster_api_key"
 #
+#      # Admin subsite (/admin) — REQUIRED before enabling the admin secrets in the
+#      # deploy step below, or the deploy will fail on a missing secret:
+#      gcloud secrets create triangle-shows-admin-password \
+#        --data-file=- <<< "a-strong-admin-password"
+#      openssl rand -base64 32 | gcloud secrets create triangle-shows-session-secret --data-file=-
+#
 #   3. Grant the Cloud Build service account permission to deploy to Cloud Run
 #      and access secrets (in IAM Console, or):
 #      PROJECT_NUM=$(gcloud projects describe $PROJECT_ID --format='value(projectNumber)')
@@ -101,6 +107,11 @@ steps:
       - --set-env-vars=APP_ENV=production,ENABLE_SCHEDULER=false,LOG_LEVEL=INFO
       - --update-secrets=DATABASE_URL=triangle-shows-db-url:latest
       - --update-secrets=TICKETMASTER_API_KEY=triangle-shows-tm-api-key:latest
+      # Admin subsite — uncomment BOTH lines only after creating the two secrets
+      # above (see step 2). Without them the /admin login is disabled (fails closed),
+      # so leaving these commented is safe; the rest of the site is unaffected.
+      # - --update-secrets=ADMIN_PASSWORD=triangle-shows-admin-password:latest
+      # - --update-secrets=SESSION_SECRET=triangle-shows-session-secret:latest
 
 images:
   - $_REGION-docker.pkg.dev/$PROJECT_ID/$_REPO/api:$COMMIT_SHA

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,6 +20,10 @@ services:
       DATABASE_URL: postgresql+asyncpg://postgres:postgres@db:5432/triangle_shows
       ENABLE_SCHEDULER: "false"
       LOG_LEVEL: INFO
+      # Local-only admin credentials (the /admin subsite). Not secrets — production
+      # uses Secret Manager. Log in at http://localhost:8000/admin with this password.
+      ADMIN_PASSWORD: devpassword
+      SESSION_SECRET: local-dev-session-secret
     volumes:
       - ./backend:/app
       - ./frontend:/frontend

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,6 +14,10 @@ services:
     build:
       context: .
       dockerfile: Dockerfile
+      # Dev stage adds requirements-dev.txt (pytest), so the test suite runs in the
+      # container without a manual install after every rebuild. Cloud Build takes the
+      # untargeted default, which is the lean prod stage.
+      target: dev
     ports:
       - "8000:8000"
     environment:

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -77,6 +77,15 @@
         <p class="subscribe-hint">new shows will appear automatically!</p>
       </div>
 
+      <!-- Live-music filter -->
+      <div class="filter-section">
+        <div class="filter-label">Show</div>
+        <div class="chip-group">
+          <button class="chip" id="chip-non-music" onclick="toggleNonMusic()">include non-live music</button>
+        </div>
+        <p class="subscribe-hint">karaoke, trivia, theme nights &amp; other recurring events are hidden by default</p>
+      </div>
+
       <!-- Friends & Feeds -->
       <div class="filter-section">
         <div class="filter-label">Friends &amp; Feeds</div>

--- a/frontend/js/filters.js
+++ b/frontend/js/filters.js
@@ -3,9 +3,15 @@
 // filter params are sent. Venue, city, and search filters are applied locally.
 
 let venues = [];
+
+// Persisted toggle: hide non-live-music events (karaoke, trivia, theme nights,
+// recurring series) unless the visitor opts in. Default off = filtered.
+const INCLUDE_NON_MUSIC_KEY = "triangle-shows-include-non-music";
+
 let activeFilters = {
   search: "",
   forYou: false,
+  includeNonMusic: localStorage.getItem(INCLUDE_NON_MUSIC_KEY) === "1",
 };
 
 // Cache of all events from the API (plain JS objects). Populated once on initial
@@ -170,16 +176,30 @@ function toggleForYou() {
   applyAllFilters();
 }
 
+// Toggle whether non-live-music events (karaoke/trivia/theme nights/etc.) are shown.
+// Choice is persisted so it sticks across visits. Default (chip inactive) hides them.
+function toggleNonMusic() {
+  activeFilters.includeNonMusic = !activeFilters.includeNonMusic;
+  localStorage.setItem(INCLUDE_NON_MUSIC_KEY, activeFilters.includeNonMusic ? "1" : "0");
+  const chip = document.getElementById("chip-non-music");
+  if (chip) chip.classList.toggle("active", activeFilters.includeNonMusic);
+  applyAllFilters();
+}
+
 // Generate a webcal:// subscription URL from the currently-checked venues
 // and redirect to it, triggering the native Add Subscription dialog.
 function subscribeToVenues() {
   const allCbs  = [...document.querySelectorAll(".venue-checkbox input[type=checkbox]")];
   const checked = allCbs.filter(cb => cb.checked);
-  let path = "/feeds/events.ics";
+  const params = new URLSearchParams();
   if (checked.length > 0 && checked.length < allCbs.length) {
-    path += "?venue=" + checked.map(cb => cb.dataset.venue).join(",");
+    params.set("venue", checked.map(cb => cb.dataset.venue).join(","));
   }
-  window.location.href = `webcal://${window.location.host}${path}`;
+  // Match the feed to what the visitor is viewing: if they've opted into
+  // non-live-music events, include them in the subscription too.
+  if (activeFilters.includeNonMusic) params.set("include_non_music", "1");
+  const qs = params.toString();
+  window.location.href = `webcal://${window.location.host}/feeds/events.ics${qs ? "?" + qs : ""}`;
 }
 
 // Returns true if an event should be visible given the current filter state.
@@ -191,6 +211,11 @@ function _checkEventVisible(ev, venueMap) {
   // the locked city. Non-locked-city venues have no sidebar checkbox, so they
   // wouldn't be in venueMap and would otherwise pass through unchecked.
   if (SITE_CONFIG.city && props.venue_city !== SITE_CONFIG.city) return false;
+
+  // Non-live-music events (karaoke, trivia, theme nights, recurring series) are
+  // hidden unless the visitor opts in via the toggle. Only an explicit `false`
+  // hides — missing/true always shows, so unclassified data is never dropped.
+  if (!activeFilters.includeNonMusic && props.is_live_music === false) return false;
 
   // "For you" mode: show only Spotify-matched events, ignoring venue filters.
   if (activeFilters.forYou) {
@@ -389,6 +414,13 @@ function toggleSidebar() {
   sidebar.classList.toggle("open");
   if (backdrop) backdrop.classList.toggle("active");
 }
+
+// Reflect the persisted non-live-music toggle state on the (static) chip.
+// Scripts load with `defer`, so the DOM is ready when this runs.
+(function initNonMusicChip() {
+  const chip = document.getElementById("chip-non-music");
+  if (chip) chip.classList.toggle("active", activeFilters.includeNonMusic);
+})();
 
 // Initialize
 loadVenues();


### PR DESCRIPTION
Declutters the calendar by hiding recurring and non-live-music events (karaoke, trivia, theme/DJ nights, comedy, parties, film) by default, with a toggle to show them and an admin subsite to correct classifications.

Closes #4.

## Backend classification

- `Event.is_live_music` / `is_manual_override` / `classification_reason` (migration `0003`)
- `classifier.py` — recurrence (≥3 dates) + keyword + `<word> night` (day-of-week exceptions) + `<theme> party` allowlist + non-music genre. DPAC exempted as always-live. Criteria surfaced to the admin UI via `criteria_summary()`
- `ScrapeManager.reclassify_all()` runs after every scrape; manual and series overrides survive re-scrapes

## Series overrides

Migration `0004` adds `series_overrides`. A venue + normalized-name rule forces a whole recurring series live or non-live, covering instances scraped later.

## Public filter

- The fullcalendar feed exposes `is_live_music`; an "include non-live music" sidebar toggle persists in localStorage
- `/feeds/events.ics` defaults to live-only, with `?include_non_music=1` to opt in

## Admin subsite (`/admin`)

- Shared-password login → itsdangerous-signed cookie; `require_admin` guards the JSON API
- Per-event override/clear, series CRUD, detection-rules view
- Config: `ADMIN_PASSWORD` / `SESSION_SECRET`, both fail closed if unset

## Tests

`backend/tests/test_classifier.py` — 30 cases covering all signals, overrides, exemptions, and the criteria surface.

## Deploying this

Migrations run on app startup, not as a build step, so deploying the image migrates the database on first container boot. Both migrations are additive and existing rows backfill to visible, so nothing disappears from the calendar until the first post-deploy scrape reclassifies.

The two admin secrets are still commented out in `cloudbuild.yaml`, which means `/admin` fails closed in production — see the review comment below for that and other pre-merge items.
