### PR TITLE
Fix deploy watcher hanging silently on Cloudflare 403

### DIFF
--- a/tools/wait_for_deploy.py
+++ b/tools/wait_for_deploy.py
@@ -11,6 +11,9 @@ Usage:
     python tools/wait_for_deploy.py
     python tools/wait_for_deploy.py --url http://localhost:8000
     python tools/wait_for_deploy.py --interval 15
+    python tools/wait_for_deploy.py --timeout 300   # give up sooner
+
+Exits 0 when the deployed SHA matches local HEAD, 1 if the timeout passes first.
 """
 
 # --- Imports ---
@@ -28,6 +31,11 @@ from datetime import datetime
 
 BASE_URL = "https://triangle-shows.net"
 DEFAULT_INTERVAL = 20  # seconds between health-check polls
+DEFAULT_TIMEOUT = 900  # give up after 15 minutes rather than polling forever
+
+# Cloudflare fronts triangle-shows.net and rejects urllib's default
+# "Python-urllib/x.y" agent with a 403. Any identifiable agent gets through.
+USER_AGENT = "triangle-shows-deploy-watcher/1.0 (+https://github.com/ty-fi/triangle-shows)"
 
 
 # --- Helpers ---
@@ -48,11 +56,16 @@ def get_local_sha():
 def get_deployed_version(url):
     """Fetch the 'version' field from /api/health, returning an error string on failure."""
     try:
-        req = urllib.request.Request(f"{url}/api/health")
+        req = urllib.request.Request(
+            f"{url}/api/health", headers={"User-Agent": USER_AGENT}
+        )
         with urllib.request.urlopen(req, timeout=10) as resp:
             data = json.loads(resp.read())
             # The health endpoint embeds the deployed git SHA as "version"
             return data.get("version", "unknown")
+    except urllib.error.HTTPError as e:
+        # Must precede URLError — HTTPError subclasses it, and the status code matters
+        return f"(http {e.code} {e.reason})"
     except urllib.error.URLError as e:
         # App is still coming up or unreachable — not a fatal error, just keep polling
         return f"(unreachable: {e.reason})"
@@ -66,36 +79,45 @@ def main():
     parser = argparse.ArgumentParser(description="Poll until deployed version matches local HEAD")
     parser.add_argument("--url", default=BASE_URL, help=f"Base URL (default: {BASE_URL})")
     parser.add_argument("--interval", type=int, default=DEFAULT_INTERVAL, help=f"Poll interval in seconds (default: {DEFAULT_INTERVAL})")
+    parser.add_argument("--timeout", type=int, default=DEFAULT_TIMEOUT, help=f"Give up after this many seconds (default: {DEFAULT_TIMEOUT})")
     args = parser.parse_args()
 
     local_sha = get_local_sha()
     short = local_sha[:7]  # abbreviated SHA for display
 
-    print(f"Waiting for deploy of {short} to {args.url}")
-    print(f"Polling every {args.interval}s — Ctrl+C to cancel\n")
+    # flush on every print: stdout is block-buffered when redirected to a file,
+    # so without this a backgrounded run shows no output until it exits.
+    print(f"Waiting for deploy of {short} to {args.url}", flush=True)
+    print(f"Polling every {args.interval}s, giving up after {args.timeout}s — Ctrl+C to cancel\n", flush=True)
 
     start = datetime.now()
-    attempt = 0
 
     while True:
-        attempt += 1
         deployed = get_deployed_version(args.url)
         elapsed = (datetime.now() - start).total_seconds()
         ts = datetime.now().strftime("%H:%M:%S")
 
         # Compare with startswith in both directions to handle full vs. short SHA mismatches
         if deployed.startswith(local_sha) or local_sha.startswith(deployed):
-            print(f"[{ts}] DEPLOYED  version={deployed[:7]}  ({elapsed:.0f}s)")
-            break
-        else:
-            print(f"[{ts}] waiting   deployed={deployed[:7]}  want={short}  ({elapsed:.0f}s)")
+            print(f"[{ts}] DEPLOYED  version={deployed[:7]}  ({elapsed:.0f}s)", flush=True)
+            return 0
+
+        # Failures are returned parenthesized — show them whole instead of truncating
+        # to 7 characters, which used to turn "(http 403 Forbidden)" into "(http 4".
+        shown = deployed if deployed.startswith("(") else deployed[:7]
+        print(f"[{ts}] waiting   deployed={shown}  want={short}  ({elapsed:.0f}s)", flush=True)
+
+        if elapsed + args.interval > args.timeout:
+            print(f"\nGave up after {elapsed:.0f}s. Last status: {deployed}", file=sys.stderr, flush=True)
+            print("The build may have failed, or the health endpoint may be unreachable.", file=sys.stderr, flush=True)
+            return 1
 
         try:
             time.sleep(args.interval)
         except KeyboardInterrupt:
-            print("\nCancelled.")
-            sys.exit(0)
+            print("\nCancelled.", flush=True)
+            return 0
 
 
 if __name__ == "__main__":
-    main()
+    sys.exit(main())


### PR DESCRIPTION
`tools/wait_for_deploy.py` never completes against the live site. Cloudflare
rejects urllib's default `Python-urllib/x.y` user agent with a 403, so the
script never sees a matching version and polls indefinitely — while producing
no visible output, because Python block-buffers stdout when redirected.

Found when a `/deploy` run appeared to hang for 13 minutes after a promotion
that had in fact succeeded.

## Changes

- **User-Agent header.** Verified against the live endpoint: the default agent
  gets 403; any identifiable agent gets 200.
- **`HTTPError` handled before `URLError`.** It's a subclass, so the status code
  was being swallowed into a generic "unreachable".
- **`--timeout`, default 900s.** The loop had no exit but success, so a permanent
  failure was indistinguishable from a slow build. Now exits 1.
- **`flush=True` on prints**, and error strings are no longer truncated to 7
  characters — which had turned `(http 403 Forbidden)` into `(http 4`.

## Testing

Both paths exercised against production:

- Success: matches `prod` HEAD immediately, exits 0
- Timeout: `--interval 3 --timeout 5` against an undeployed SHA prints polls, reports the last status, exits 1
