### PR TITLE
Report 503 from /api/health when scrape data is stale

### DIFF
--- a/backend/app/api/health.py
+++ b/backend/app/api/health.py
@@ -5,17 +5,32 @@ Role: Lightweight liveness/readiness probe consumed by Cloud Run, uptime monitor
       the /deploy skill to confirm a new revision is live. Also exposes scrape freshness
       so operators can tell at a glance whether data is up to date.
 Requires: async DB session (app.database), Event/Venue/ScrapeLog models, HealthResponse
-          schema, and the GIT_COMMIT env var (injected at build time by Cloud Build).
+          schema, the GIT_COMMIT env var (injected at build time by Cloud Build), and
+          settings.APP_ENV to decide whether freshness is enforced.
+
+Returns 503 in production when scrape data has gone stale, so an uptime monitor catches
+silently-stopped scraping as well as an outright outage. The body is unchanged, so
+callers that only want the deployed SHA can still read it from a 503 response.
 """
 # --- Imports ---
 import os
-from fastapi import APIRouter, Depends
+from datetime import datetime, timedelta
+
+from fastapi import APIRouter, Depends, Response, status
 from sqlalchemy import select, func
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.config import settings
 from app.database import get_session
 from app.models import Event, Venue, ScrapeLog
 from app.schemas import HealthResponse
+
+# --- Config ---
+
+# Cloud Scheduler runs scrapes every 6 hours (0 */6 * * *). Allow two missed cycles
+# plus an hour of slack before reporting stale, so one slow or failed run doesn't
+# raise an alert on its own.
+STALE_AFTER = timedelta(hours=13)
 
 # --- Router ---
 router = APIRouter(prefix="/api/health", tags=["health"])
@@ -24,8 +39,14 @@ router = APIRouter(prefix="/api/health", tags=["health"])
 # --- Endpoint ---
 
 @router.get("", response_model=HealthResponse)
-async def health_check(session: AsyncSession = Depends(get_session)):
-    """Health check with event count and last scrape info."""
+async def health_check(response: Response, session: AsyncSession = Depends(get_session)):
+    """Health check with event count and last scrape info.
+
+    Reports 503 with status="stale" when the most recent successful scrape is older
+    than STALE_AFTER. Freshness is only enforced in production: CI and local runs
+    disable scraping on purpose, so an empty or old ScrapeLog is expected there and
+    must not fail the CI smoke test.
+    """
     event_count = (await session.execute(select(func.count(Event.id)))).scalar()
     venue_count = (await session.execute(select(func.count(Venue.id)))).scalar()
 
@@ -38,8 +59,16 @@ async def health_check(session: AsyncSession = Depends(get_session)):
     )
     last_scrape = last_scrape_result.scalar_one_or_none()
 
+    # finished_at is stored naive in UTC (models use datetime.utcnow), so compare
+    # against utcnow() — an aware value here would raise on subtraction.
+    is_stale = settings.APP_ENV == "production" and (
+        last_scrape is None or (datetime.utcnow() - last_scrape) > STALE_AFTER
+    )
+    if is_stale:
+        response.status_code = status.HTTP_503_SERVICE_UNAVAILABLE
+
     return HealthResponse(
-        status="ok",
+        status="stale" if is_stale else "ok",
         event_count=event_count,
         venue_count=venue_count,
         last_scrape=last_scrape,

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -158,6 +158,26 @@ because only `prod` deploys. Migrations execute against real data at deploy time
 earlier — see the Database & migrations section of
 [CONTRIBUTING.md](../.github/CONTRIBUTING.md) for what that implies about writing them.
 
+## Monitoring
+
+`/api/health` is the endpoint to watch. It queries the database for its counts, so a 200
+response proves the app is up *and* Neon is reachable — more than a check against `/` would
+tell you.
+
+It also reports **503 with `status: "stale"`** when the most recent successful scrape is older
+than 13 hours (two scheduler cycles plus slack). That turns silently-stopped scraping into
+something a plain uptime monitor can catch, rather than a failure that looks healthy until
+someone notices the listings are old. The response body is identical either way, so tools that
+only want the deployed SHA can still read it from a 503.
+
+Freshness is enforced only when `APP_ENV=production`. CI and local runs disable scraping on
+purpose, so an empty `ScrapeLog` is expected there and must not fail the smoke test.
+
+**Point any monitor at `https://triangle-shows.net/api/health`, not the `.run.app` URL.** The
+Cloudflare Worker is the component whose failure takes the public site down while Cloud Run
+stays healthy — a check against the origin would report all-clear through exactly that outage.
+Allow a generous timeout (~30s) for cold starts, and alert only after two consecutive failures.
+
 ## If something breaks
 
 | Symptom | Likely cause |

--- a/tools/wait_for_deploy.py
+++ b/tools/wait_for_deploy.py
@@ -64,7 +64,15 @@ def get_deployed_version(url):
             # The health endpoint embeds the deployed git SHA as "version"
             return data.get("version", "unknown")
     except urllib.error.HTTPError as e:
-        # Must precede URLError — HTTPError subclasses it, and the status code matters
+        # Must precede URLError — HTTPError subclasses it, and the status code matters.
+        # A 503 from the stale-data check still carries the deployed SHA in its body,
+        # so read it rather than reporting the revision as unreachable.
+        try:
+            version = json.loads(e.read()).get("version")
+            if version:
+                return version
+        except Exception:
+            pass
         return f"(http {e.code} {e.reason})"
     except urllib.error.URLError as e:
         # App is still coming up or unreachable — not a fatal error, just keep polling


### PR DESCRIPTION
An uptime monitor can only tell you the site responds. If scraping silently stopped,
`/api/health` kept returning 200 with an ever-older `last_scrape`, and nothing looked
wrong until someone noticed the listings were out of date.

## Changes

- **`/api/health` returns 503 with `status: "stale"`** when the most recent successful
  scrape is older than 13 hours — two 6-hour scheduler cycles plus slack, so one slow or
  failed run doesn't alert on its own. The response body is unchanged.
- **Only enforced when `APP_ENV=production`.** See below.
- **`wait_for_deploy.py` reads the version from a 503 body**, so a stale-data response
  isn't mistaken for a failed deploy.
- `docs/ARCHITECTURE.md` gains a Monitoring section.

## Two things that would have bitten

**CI would have failed, and blocked deploys.** The smoke test sets
`ENABLE_STARTUP_SCRAPE: "false"`, so `last_scrape` is always `None` there. Without the
production gate, health would 503, `curl --fail` would exit nonzero, and the job would
fail — and since it's now a required status check on `prod`, that would block every
promotion. The `APP_ENV` gate is what keeps CI green; this PR's own run is the proof.

**Timezone mismatch.** `ScrapeLog.finished_at` is a naive `DateTime` populated with
`datetime.utcnow`, so the comparison uses `utcnow()`. A timezone-aware value would raise
`TypeError` on subtraction.

## Verified

- Cloud Run's startup probe is a TCP check on port 8000 with no liveness probe, so a 503
  on this path cannot cause the revision to be killed
- `wait_for_deploy.get_deployed_version()` tested against a local endpoint returning 503
  with a JSON body — recovers the SHA correctly
