### PR TITLE
Add CI workflow, fix deploy watcher, and improve health checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,7 @@ name: CI
 
 on:
   pull_request:
-    branches: [main]
-  push:
-    branches: [main]
+    branches: [main, prod]
 
 jobs:
   smoke-test:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,66 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+jobs:
+  smoke-test:
+    name: Migrations + API smoke test
+    runs-on: ubuntu-latest
+
+    services:
+      postgres:
+        image: postgres:16-alpine
+        env:
+          POSTGRES_DB: triangle_shows
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 5
+
+    env:
+      DATABASE_URL: postgresql+asyncpg://postgres:postgres@localhost:5432/triangle_shows
+      ENABLE_SCHEDULER: "false"
+      ENABLE_STARTUP_SCRAPE: "false"
+      TICKETMASTER_API_KEY: ""
+      APP_ENV: ci
+      LOG_LEVEL: INFO
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: pip
+          cache-dependency-path: backend/requirements.txt
+
+      - name: Install dependencies
+        run: pip install -r backend/requirements.txt
+
+      - name: Run migrations
+        working-directory: backend
+        run: alembic upgrade head
+
+      - name: Start API server
+        working-directory: backend
+        run: uvicorn app.main:app --host 0.0.0.0 --port 8000 &
+
+      - name: Wait for API and check health
+        run: |
+          curl \
+            --retry 15 \
+            --retry-delay 1 \
+            --retry-connrefused \
+            --fail \
+            --silent \
+            --show-error \
+            http://localhost:8000/api/health

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ frontend/
     favorites.js    # Heart, hide, restore, and export logic
 tools/              # Dev utilities (see below)
   mockups/          # Static HTML design explorations
-docs/               # Self-hosting guide
+docs/               # Architecture and self-hosting guides
 ```
 
 ### Developer tools
@@ -131,6 +131,8 @@ The authoritative source is [`backend/app/seed.py`](backend/app/seed.py) — eac
 | Frontend | Vanilla JS, FullCalendar v6 |
 | Scheduling | APScheduler (local) / Google Cloud Scheduler (production) |
 | Deployment | Google Cloud Run + Neon PostgreSQL + Cloudflare |
+
+See [ARCHITECTURE.md](docs/ARCHITECTURE.md) for how a request reaches the app and how a commit becomes a deploy.
 
 ---
 

--- a/backend/app/api/health.py
+++ b/backend/app/api/health.py
@@ -5,17 +5,32 @@ Role: Lightweight liveness/readiness probe consumed by Cloud Run, uptime monitor
       the /deploy skill to confirm a new revision is live. Also exposes scrape freshness
       so operators can tell at a glance whether data is up to date.
 Requires: async DB session (app.database), Event/Venue/ScrapeLog models, HealthResponse
-          schema, and the GIT_COMMIT env var (injected at build time by Cloud Build).
+          schema, the GIT_COMMIT env var (injected at build time by Cloud Build), and
+          settings.APP_ENV to decide whether freshness is enforced.
+
+Returns 503 in production when scrape data has gone stale, so an uptime monitor catches
+silently-stopped scraping as well as an outright outage. The body is unchanged, so
+callers that only want the deployed SHA can still read it from a 503 response.
 """
 # --- Imports ---
 import os
-from fastapi import APIRouter, Depends
+from datetime import datetime, timedelta
+
+from fastapi import APIRouter, Depends, Response, status
 from sqlalchemy import select, func
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.config import settings
 from app.database import get_session
 from app.models import Event, Venue, ScrapeLog
 from app.schemas import HealthResponse
+
+# --- Config ---
+
+# Cloud Scheduler runs scrapes every 6 hours (0 */6 * * *). Allow two missed cycles
+# plus an hour of slack before reporting stale, so one slow or failed run doesn't
+# raise an alert on its own.
+STALE_AFTER = timedelta(hours=13)
 
 # --- Router ---
 router = APIRouter(prefix="/api/health", tags=["health"])
@@ -24,8 +39,14 @@ router = APIRouter(prefix="/api/health", tags=["health"])
 # --- Endpoint ---
 
 @router.get("", response_model=HealthResponse)
-async def health_check(session: AsyncSession = Depends(get_session)):
-    """Health check with event count and last scrape info."""
+async def health_check(response: Response, session: AsyncSession = Depends(get_session)):
+    """Health check with event count and last scrape info.
+
+    Reports 503 with status="stale" when the most recent successful scrape is older
+    than STALE_AFTER. Freshness is only enforced in production: CI and local runs
+    disable scraping on purpose, so an empty or old ScrapeLog is expected there and
+    must not fail the CI smoke test.
+    """
     event_count = (await session.execute(select(func.count(Event.id)))).scalar()
     venue_count = (await session.execute(select(func.count(Venue.id)))).scalar()
 
@@ -38,8 +59,16 @@ async def health_check(session: AsyncSession = Depends(get_session)):
     )
     last_scrape = last_scrape_result.scalar_one_or_none()
 
+    # finished_at is stored naive in UTC (models use datetime.utcnow), so compare
+    # against utcnow() — an aware value here would raise on subtraction.
+    is_stale = settings.APP_ENV == "production" and (
+        last_scrape is None or (datetime.utcnow() - last_scrape) > STALE_AFTER
+    )
+    if is_stale:
+        response.status_code = status.HTTP_503_SERVICE_UNAVAILABLE
+
     return HealthResponse(
-        status="ok",
+        status="stale" if is_stale else "ok",
         event_count=event_count,
         venue_count=venue_count,
         last_scrape=last_scrape,

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -21,6 +21,7 @@ class Settings(BaseSettings):
     DATABASE_URL: str = "postgresql+asyncpg://postgres:postgres@localhost:5432/triangle_shows"
     TICKETMASTER_API_KEY: str = ""
     ENABLE_SCHEDULER: bool = False  # Set to True in production to run scrapes on a cron schedule
+    ENABLE_STARTUP_SCRAPE: bool = True  # Set to False in CI/testing to skip the on-boot scrape
     APP_ENV: str = "development"
     LOG_LEVEL: str = "INFO"
 

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -77,9 +77,10 @@ async def lifespan(app: FastAPI):
     await seed_venues()
     logger.info("Venues seeded")
 
-    # Kick off a scrape immediately in the background
-    asyncio.create_task(_startup_scrape())
-    logger.info("Startup scrape scheduled")
+    # Kick off a scrape immediately in the background (disabled in CI via ENABLE_STARTUP_SCRAPE=false)
+    if settings.ENABLE_STARTUP_SCRAPE:
+        asyncio.create_task(_startup_scrape())
+        logger.info("Startup scrape scheduled")
 
     # Start scheduler if enabled
     if settings.ENABLE_SCHEDULER:

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -158,6 +158,26 @@ because only `prod` deploys. Migrations execute against real data at deploy time
 earlier — see the Database & migrations section of
 [CONTRIBUTING.md](../.github/CONTRIBUTING.md) for what that implies about writing them.
 
+## Monitoring
+
+`/api/health` is the endpoint to watch. It queries the database for its counts, so a 200
+response proves the app is up *and* Neon is reachable — more than a check against `/` would
+tell you.
+
+It also reports **503 with `status: "stale"`** when the most recent successful scrape is older
+than 13 hours (two scheduler cycles plus slack). That turns silently-stopped scraping into
+something a plain uptime monitor can catch, rather than a failure that looks healthy until
+someone notices the listings are old. The response body is identical either way, so tools that
+only want the deployed SHA can still read it from a 503.
+
+Freshness is enforced only when `APP_ENV=production`. CI and local runs disable scraping on
+purpose, so an empty `ScrapeLog` is expected there and must not fail the smoke test.
+
+**Point any monitor at `https://triangle-shows.net/api/health`, not the `.run.app` URL.** The
+Cloudflare Worker is the component whose failure takes the public site down while Cloud Run
+stays healthy — a check against the origin would report all-clear through exactly that outage.
+Allow a generous timeout (~30s) for cold starts, and alert only after two consecutive failures.
+
 ## If something breaks
 
 | Symptom | Likely cause |

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,0 +1,184 @@
+# Architecture
+
+How a request reaches the app, and how a commit becomes a deploy. Values here were verified
+against the live infrastructure on 2026-08-26.
+
+For the branch and release workflow see [CONTRIBUTING.md](../.github/CONTRIBUTING.md).
+For running the app on your own machine see [SELF-HOSTING.md](SELF-HOSTING.md).
+
+## The pieces
+
+| Component | Role | Configured in |
+|-----------|------|---------------|
+| **Cloudflare** | DNS, SSL, and a Worker that proxies to Cloud Run | Cloudflare dashboard (free plan) |
+| **Cloud Run** | Runs the container; scales to zero when idle | `cloudbuild.yaml` deploy step |
+| **Cloud Build** | Builds the image and deploys it on push to `prod` | `cloudbuild.yaml` + a console trigger |
+| **Artifact Registry** | Stores built Docker images | GCP, repo `triangle-shows` |
+| **Secret Manager** | Holds the DB URL and Ticketmaster API key | GCP, injected as env vars at deploy |
+| **Cloud Scheduler** | Calls `/api/scrape` every 6 hours | GCP, job `triangle-shows-scrape` |
+| **Neon** | Managed PostgreSQL, the only stateful component | Neon dashboard; URL stored in Secret Manager |
+
+GCP project is `triangle-shows`, everything in `us-east1`.
+
+## Request path
+
+```
+Browser
+  │
+  ├── triangle-shows.org ──► Cloudflare ──► 301 redirect ──► triangle-shows.net
+  │                          (never reaches an origin server)
+  │
+  └── triangle-shows.net ──► Cloudflare DNS (proxied)
+                               │
+                               ├─ SSL terminated here (Full mode, free managed cert)
+                               │
+                               ▼
+                             Worker: triangle-shows-proxy
+                               │  rewrites the Host header
+                               ▼
+                             Cloud Run: triangle-shows (us-east1)
+                               │
+                               ▼
+                             uvicorn ──► FastAPI
+                               │
+                               ├─ serves the static frontend
+                               └─ /api/* ──► SQLAlchemy ──► Neon PostgreSQL
+```
+
+**Why the Worker exists.** Cloud Run routes requests by their `Host` header and only recognizes
+its own `.run.app` hostname — a request arriving with `Host: triangle-shows.net` gets a 404.
+Cloudflare's Transform Rules cannot rewrite `host` (it's a protected header), so a small Worker
+does it instead:
+
+```javascript
+export default {
+  async fetch(request) {
+    const url = new URL(request.url);
+    url.hostname = 'triangle-shows-bs2va6mvba-ue.a.run.app';
+    return fetch(new Request(url.toString(), request));
+  }
+}
+```
+
+It is routed to `triangle-shows.net/*`. If this Worker is removed or misconfigured, the whole
+site returns 404 while Cloud Run itself stays perfectly healthy — worth knowing before debugging
+the app.
+
+**The `.org` domain** has a deliberately fake `A` record pointing at `192.0.2.1`, an address
+reserved for documentation that never carries traffic. It exists only so Cloudflare has something
+to attach a proxied record to; a Redirect Rule issues the 301 at the edge, so no origin is ever
+contacted.
+
+### DNS
+
+| Domain | Type | Name | Target | Proxied |
+|---|---|---|---|---|
+| triangle-shows.net | CNAME | `@` | `triangle-shows-bs2va6mvba-ue.a.run.app` | Yes |
+| triangle-shows.net | CNAME | `www` | `triangle-shows-bs2va6mvba-ue.a.run.app` | Yes |
+| triangle-shows.org | A | `@` | `192.0.2.1` (dummy) | Yes |
+
+SSL mode is **Full**, with Always Use HTTPS on. Full works because the `.run.app` origin carries
+a valid Google-managed certificate.
+
+### Two Cloud Run URLs
+
+The service answers on both of these, and both are in active use:
+
+```
+https://triangle-shows-bs2va6mvba-ue.a.run.app        ← Cloudflare Worker and CNAMEs
+https://triangle-shows-178508749672.us-east1.run.app  ← Cloud Scheduler
+```
+
+Cloud Run issues the second, project-number form for newer services and keeps the older hashed
+form working. They are the same service. This matters only when changing the hostname: the Worker
+hardcodes the first, so updating one without the other breaks the site.
+
+## Deploy path
+
+```
+PR merged into prod
+  │
+  ▼
+Cloud Build trigger  auto-deploy-git-pushes-to-prod  (branch regex ^prod$)
+  │
+  ├─ 1. docker build       (Dockerfile, GIT_COMMIT baked in as $COMMIT_SHA)
+  ├─ 2. docker push        (Artifact Registry: us-east1-docker.pkg.dev/triangle-shows/triangle-shows/api)
+  └─ 3. gcloud run deploy  (new Cloud Run revision, secrets attached)
+        │
+        ▼
+      Container starts, uvicorn boots FastAPI
+        │
+        ▼
+      Startup lifespan runs `alembic upgrade head` against Neon
+        │
+        ▼
+      Revision serves traffic; /api/health reports the new SHA
+```
+
+Only pushes to `prod` build anything. Pushes to `main` and feature branches do nothing, which is
+what keeps un-shipped work away from the production database.
+
+The image is tagged twice — `:$COMMIT_SHA` and `:latest`. The commit SHA is also baked into the
+image as the `GIT_COMMIT` build argument, which is how `/api/health` can report exactly which
+commit is live. That's what [`tools/wait_for_deploy.py`](../tools/wait_for_deploy.py) polls for.
+
+### Runtime configuration
+
+| Setting | Value | Why |
+|---|---|---|
+| min instances | 0 | Scales to zero when idle; costs ~$0 at rest, ~2–3s cold start |
+| max instances | 2 | Caps runaway cost |
+| memory / CPU | 512Mi / 1 | |
+| request timeout | 300s | Scrape requests can be slow |
+| `APP_ENV` | `production` | |
+| `ENABLE_SCHEDULER` | `false` | Scraping is driven externally by Cloud Scheduler, not in-process |
+| `LOG_LEVEL` | `INFO` | |
+| `DATABASE_URL` | secret `triangle-shows-db-url` | |
+| `TICKETMASTER_API_KEY` | secret `triangle-shows-tm-api-key` | |
+
+The admin subsite (`/admin`) is **disabled**. It requires `ADMIN_PASSWORD` and `SESSION_SECRET`,
+neither of which exists in Secret Manager, and the corresponding lines in `cloudbuild.yaml` are
+commented out. It fails closed, so the rest of the site is unaffected. Create both secrets
+*before* uncommenting, or the deploy fails on a missing secret.
+
+## Scheduled scraping
+
+Cloud Scheduler job `triangle-shows-scrape` posts to `/api/scrape` on `0 */6 * * *` (UTC), using
+the project-number Cloud Run URL and OIDC authentication. This is why `ENABLE_SCHEDULER` is
+`false` in the container — the schedule lives outside the app, so a scaled-to-zero service still
+gets scraped, and two running instances don't scrape twice.
+
+## Data
+
+Neon is managed PostgreSQL, running in AWS `us-east-1` and reached through its pooler endpoint.
+The app connects with SQLAlchemy's async driver, so the URL is in `postgresql+asyncpg://` form.
+
+**There is one database and no staging copy.** Feature branches and `main` never touch it,
+because only `prod` deploys. Migrations execute against real data at deploy time and nowhere
+earlier — see the Database & migrations section of
+[CONTRIBUTING.md](../.github/CONTRIBUTING.md) for what that implies about writing them.
+
+## If something breaks
+
+| Symptom | Likely cause |
+|---|---|
+| Whole site 404s, but the `.run.app` URL works | Cloudflare Worker missing or pointing at the wrong hostname |
+| Site unreachable, `.run.app` fine | Cloudflare DNS or proxy status |
+| Deploy never goes live | Check Cloud Build history — the trigger only fires on `prod` |
+| `/api/health` reports an old SHA | The new revision failed to start; check Cloud Run logs for a migration error |
+| Scrapes stopped | Cloud Scheduler job disabled, or its OIDC service account lost permission |
+
+Recovery notes: the Cloud Run service itself needs no manual recreation — `gcloud run deploy`
+creates it if absent, so a push to `prod` rebuilds it from nothing. The pieces that are *not*
+reproducible from this repo are the Cloudflare configuration above, the Secret Manager values,
+and Neon itself.
+
+## Cost
+
+Roughly $3–4/month, nearly all of it Neon and Artifact Registry storage. Cloud Run is ~$0 at
+`min-instances=0`, and the Cloudflare free plan covers DNS, SSL, and the Worker.
+
+This was ~$20/month until 2026-05-22, when a GCP HTTPS Load Balancer was replaced by Cloudflare.
+Forwarding rules alone billed $0.025/hr each regardless of traffic. Historical detail on that
+migration, including the exact resources deleted, lives in the internal repo's
+`guides/hosting.md`.

--- a/tools/wait_for_deploy.py
+++ b/tools/wait_for_deploy.py
@@ -11,6 +11,9 @@ Usage:
     python tools/wait_for_deploy.py
     python tools/wait_for_deploy.py --url http://localhost:8000
     python tools/wait_for_deploy.py --interval 15
+    python tools/wait_for_deploy.py --timeout 300   # give up sooner
+
+Exits 0 when the deployed SHA matches local HEAD, 1 if the timeout passes first.
 """
 
 # --- Imports ---
@@ -28,6 +31,11 @@ from datetime import datetime
 
 BASE_URL = "https://triangle-shows.net"
 DEFAULT_INTERVAL = 20  # seconds between health-check polls
+DEFAULT_TIMEOUT = 900  # give up after 15 minutes rather than polling forever
+
+# Cloudflare fronts triangle-shows.net and rejects urllib's default
+# "Python-urllib/x.y" agent with a 403. Any identifiable agent gets through.
+USER_AGENT = "triangle-shows-deploy-watcher/1.0 (+https://github.com/ty-fi/triangle-shows)"
 
 
 # --- Helpers ---
@@ -48,11 +56,16 @@ def get_local_sha():
 def get_deployed_version(url):
     """Fetch the 'version' field from /api/health, returning an error string on failure."""
     try:
-        req = urllib.request.Request(f"{url}/api/health")
+        req = urllib.request.Request(
+            f"{url}/api/health", headers={"User-Agent": USER_AGENT}
+        )
         with urllib.request.urlopen(req, timeout=10) as resp:
             data = json.loads(resp.read())
             # The health endpoint embeds the deployed git SHA as "version"
             return data.get("version", "unknown")
+    except urllib.error.HTTPError as e:
+        # Must precede URLError — HTTPError subclasses it, and the status code matters
+        return f"(http {e.code} {e.reason})"
     except urllib.error.URLError as e:
         # App is still coming up or unreachable — not a fatal error, just keep polling
         return f"(unreachable: {e.reason})"
@@ -66,36 +79,45 @@ def main():
     parser = argparse.ArgumentParser(description="Poll until deployed version matches local HEAD")
     parser.add_argument("--url", default=BASE_URL, help=f"Base URL (default: {BASE_URL})")
     parser.add_argument("--interval", type=int, default=DEFAULT_INTERVAL, help=f"Poll interval in seconds (default: {DEFAULT_INTERVAL})")
+    parser.add_argument("--timeout", type=int, default=DEFAULT_TIMEOUT, help=f"Give up after this many seconds (default: {DEFAULT_TIMEOUT})")
     args = parser.parse_args()
 
     local_sha = get_local_sha()
     short = local_sha[:7]  # abbreviated SHA for display
 
-    print(f"Waiting for deploy of {short} to {args.url}")
-    print(f"Polling every {args.interval}s — Ctrl+C to cancel\n")
+    # flush on every print: stdout is block-buffered when redirected to a file,
+    # so without this a backgrounded run shows no output until it exits.
+    print(f"Waiting for deploy of {short} to {args.url}", flush=True)
+    print(f"Polling every {args.interval}s, giving up after {args.timeout}s — Ctrl+C to cancel\n", flush=True)
 
     start = datetime.now()
-    attempt = 0
 
     while True:
-        attempt += 1
         deployed = get_deployed_version(args.url)
         elapsed = (datetime.now() - start).total_seconds()
         ts = datetime.now().strftime("%H:%M:%S")
 
         # Compare with startswith in both directions to handle full vs. short SHA mismatches
         if deployed.startswith(local_sha) or local_sha.startswith(deployed):
-            print(f"[{ts}] DEPLOYED  version={deployed[:7]}  ({elapsed:.0f}s)")
-            break
-        else:
-            print(f"[{ts}] waiting   deployed={deployed[:7]}  want={short}  ({elapsed:.0f}s)")
+            print(f"[{ts}] DEPLOYED  version={deployed[:7]}  ({elapsed:.0f}s)", flush=True)
+            return 0
+
+        # Failures are returned parenthesized — show them whole instead of truncating
+        # to 7 characters, which used to turn "(http 403 Forbidden)" into "(http 4".
+        shown = deployed if deployed.startswith("(") else deployed[:7]
+        print(f"[{ts}] waiting   deployed={shown}  want={short}  ({elapsed:.0f}s)", flush=True)
+
+        if elapsed + args.interval > args.timeout:
+            print(f"\nGave up after {elapsed:.0f}s. Last status: {deployed}", file=sys.stderr, flush=True)
+            print("The build may have failed, or the health endpoint may be unreachable.", file=sys.stderr, flush=True)
+            return 1
 
         try:
             time.sleep(args.interval)
         except KeyboardInterrupt:
-            print("\nCancelled.")
-            sys.exit(0)
+            print("\nCancelled.", flush=True)
+            return 0
 
 
 if __name__ == "__main__":
-    main()
+    sys.exit(main())

--- a/tools/wait_for_deploy.py
+++ b/tools/wait_for_deploy.py
@@ -64,7 +64,15 @@ def get_deployed_version(url):
             # The health endpoint embeds the deployed git SHA as "version"
             return data.get("version", "unknown")
     except urllib.error.HTTPError as e:
-        # Must precede URLError — HTTPError subclasses it, and the status code matters
+        # Must precede URLError — HTTPError subclasses it, and the status code matters.
+        # A 503 from the stale-data check still carries the deployed SHA in its body,
+        # so read it rather than reporting the revision as unreachable.
+        try:
+            version = json.loads(e.read()).get("version")
+            if version:
+                return version
+        except Exception:
+            pass
         return f"(http {e.code} {e.reason})"
     except urllib.error.URLError as e:
         # App is still coming up or unreachable — not a fatal error, just keep polling


### PR DESCRIPTION
This pull request introduces a new CI workflow, improves deployment monitoring, and enhances documentation for both architecture and operations. The main updates are the addition of a GitHub Actions workflow for CI, stricter health checks for production, improvements to the deployment watcher script, and expanded documentation on architecture and deployment processes.

**CI/CD and Health Monitoring Improvements:**

* **New GitHub Actions Workflow:** Adds `.github/workflows/ci.yml` to run migrations and an API smoke test on pull requests to `main` and `prod`, using a real PostgreSQL service and ensuring the API is healthy before merging.
* **Stricter Health Endpoint in Production:** The `/api/health` endpoint now returns a 503 status with `status="stale"` if scrape data is older than 13 hours, but only enforces this in production (`APP_ENV=production`). This ensures uptime monitors catch stale data issues in production without breaking CI or local tests. [[1]](diffhunk://#diff-30ea22c7947d375f155cb8d3096fe92d9b0d44c8dd8a0a5179e4d21a66473413L8-R49) [[2]](diffhunk://#diff-30ea22c7947d375f155cb8d3096fe92d9b0d44c8dd8a0a5179e4d21a66473413R62-R71)
* **Configurable Startup Scrape:** Introduces `ENABLE_STARTUP_SCRAPE` to skip the initial scrape in CI/testing, preventing unnecessary failures during automated tests. [[1]](diffhunk://#diff-91d704eebe9288029281dfdd5f9656f85cc4c563292c8721107be54754dc359fR24) [[2]](diffhunk://#diff-82608d38c4441937a3cfb9ff7da1bed9dd59292dec62308de75bfaa2809419a3L80-R81)

**Deployment Monitoring Enhancements:**

* **Improved `wait_for_deploy.py`:** The deployment watcher script now uses a custom User-Agent to avoid 403s from Cloudflare, handles 503 responses by extracting the deployed SHA, supports a `--timeout` option to exit early, and flushes output for better logging in CI. [[1]](diffhunk://#diff-0541a8fda0bca3efdf9281679c6937290e6d80d9e401a8559add4eb76e31aaecR14-R16) [[2]](diffhunk://#diff-0541a8fda0bca3efdf9281679c6937290e6d80d9e401a8559add4eb76e31aaecR34-R38) [[3]](diffhunk://#diff-0541a8fda0bca3efdf9281679c6937290e6d80d9e401a8559add4eb76e31aaecL51-R76) [[4]](diffhunk://#diff-0541a8fda0bca3efdf9281679c6937290e6d80d9e401a8559add4eb76e31aaecR90-R131)

**Documentation Updates:**

* **Architecture and Self-Hosting Docs:** Adds `docs/ARCHITECTURE.md` detailing infrastructure, request/deploy paths, scheduled scraping, and monitoring strategies. Updates `frontend/README.md` to reference the new docs. [[1]](diffhunk://#diff-ff21b6b9a3a33e9d9056ac96882cc348d7077612b5931068f7459707b21eb3d1R1-R204) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L83-R83) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R135-R136)