### PR TITLE
Keep Squarespace events whose description is empty, and make descriptions human-readable

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,11 @@ jobs:
           cache-dependency-path: backend/requirements.txt
 
       - name: Install dependencies
-        run: pip install -r backend/requirements.txt
+        run: pip install -r backend/requirements-dev.txt
+
+      - name: Run unit tests
+        working-directory: backend
+        run: python -m pytest tests -q
 
       - name: Run migrations
         working-directory: backend

--- a/backend/app/scrapers/html_text.py
+++ b/backend/app/scrapers/html_text.py
@@ -1,0 +1,84 @@
+"""
+Turns an HTML description fragment into human-readable plain text.
+
+Role: Shared by scrapers whose source hands back a marked-up description - MEC's
+JSON-LD `description` field and Squarespace's `excerpt`/`body` fields. Kept out of
+scrapers/base.py, which is pure-stdlib by design; this needs BeautifulSoup, but only
+the two scrapers that actually have HTML to clean need to import it.
+Requires: beautifulsoup4, lxml (both already required by every scraper that produces
+HTML in the first place).
+"""
+
+import html
+import re
+from typing import Optional
+
+from bs4 import BeautifulSoup
+
+# \xa0 is U+00A0 NO-BREAK SPACE, what &nbsp; decodes to. Not a plain space, and not
+# matched by \s in every regex flavor, so it needs to be named explicitly.
+_WHITESPACE_RUN = re.compile(r"[ \t\xa0]+")
+
+
+def clean_html_text(
+    raw: Optional[str],
+    *,
+    drop_first_paragraph_if: Optional[str] = None,
+    limit: Optional[int] = None,
+) -> Optional[str]:
+    """Decode entities, strip tags, and return readable multi-paragraph text.
+
+    Every source this has been checked against (MEC's JSON-LD description; Squarespace's
+    excerpt and Post Body content) uses `<p>` as its only block-level element -- `<strong>`,
+    `<a>`, and `<em>` appear only inline. So paragraphs are read from `<p>` tags
+    specifically, joined with a blank line, rather than every block-level tag: selecting
+    `<div>` as well would double-count text, since BeautifulSoup's find_all matches an
+    outer container and the paragraphs nested inside it as separate results. `<br>` is
+    converted to a newline before extraction, since it carries no text of its own.
+    Falls back to reading the whole fragment as one block when there are no `<p>` tags
+    at all, so plain, already-markup-free text is not silently dropped.
+
+    raw can itself be HTML-escaped HTML -- MEC's JSON-LD field stores markup as a string
+    that has ALSO been through an HTML-entity pass, e.g. the literal text
+    '&lt;p&gt;&lt;strong&gt;...' rather than an actual '<p>' tag. `html.unescape` runs
+    first so BeautifulSoup sees real tags either way; it is a no-op on already-plain HTML.
+
+    drop_first_paragraph_if: if the first paragraph case-insensitively equals this string
+    once both are stripped, drop it. Squarespace's Post Body editor always repeats the
+    event's own title as the first paragraph of `body` -- never of `excerpt`, which is a
+    genuinely separate summary field -- so pass the event title from `body`-sourced content
+    and leave it unset for `excerpt`. Real description text is never exactly the event's
+    own title, so this cannot discard a paragraph that happens to be genuine content.
+
+    limit: truncate the CLEANED text to this many characters. Truncating before cleaning
+    can cut mid-tag or mid-entity and leave a stray fragment on the visible card.
+
+    Returns None for empty or unparseable input -- same convention as pulling an optional
+    field straight off a dict -- so callers can pass it directly into the description slot.
+    """
+    if not raw:
+        return None
+
+    text = html.unescape(raw)
+    soup = BeautifulSoup(text, "lxml")
+    for br in soup.find_all("br"):
+        br.replace_with("\n")
+
+    paragraphs = [_WHITESPACE_RUN.sub(" ", p.get_text()).strip() for p in soup.find_all("p")]
+    paragraphs = [p for p in paragraphs if p]
+
+    if not paragraphs:
+        whole = _WHITESPACE_RUN.sub(" ", soup.get_text()).strip()
+        paragraphs = [whole] if whole else []
+
+    if (
+        drop_first_paragraph_if
+        and paragraphs
+        and paragraphs[0].casefold() == drop_first_paragraph_if.strip().casefold()
+    ):
+        paragraphs = paragraphs[1:]
+
+    cleaned = "\n\n".join(paragraphs).strip()
+    if not cleaned:
+        return None
+    return cleaned[:limit] if limit else cleaned

--- a/backend/app/scrapers/mec.py
+++ b/backend/app/scrapers/mec.py
@@ -17,6 +17,7 @@ import httpx
 from bs4 import BeautifulSoup
 
 from app.scrapers.base import BaseScraper, ScrapedEvent, BROWSER_HEADERS
+from app.scrapers.html_text import clean_html_text
 
 # --- Module-level setup ---
 logger = logging.getLogger(__name__)
@@ -206,10 +207,12 @@ class MECScraper(BaseScraper):
                 image = image.get("url", "")
             image_url = image or None
 
-            # Description
-            description = data.get("description", "") or None
-            if description:
-                description = description[:500]  # Truncate to avoid oversized records
+            # Description — MEC's JSON-LD field stores markup that has itself been through
+            # an HTML-entity pass, e.g. the literal text '&lt;p&gt;&lt;strong&gt;...'
+            # rather than an actual '<p>' tag, so it needs both an entity-decode and a
+            # tag-strip before it is readable (#13). Truncated after cleaning — truncating
+            # the raw markup first risks cutting mid-tag or mid-entity.
+            description = clean_html_text(data.get("description"), limit=500)
 
             # Status — derive from schema eventStatus or price
             event_status = data.get("eventStatus", "")

--- a/backend/app/scrapers/squarespace.py
+++ b/backend/app/scrapers/squarespace.py
@@ -49,8 +49,7 @@ class SquarespaceScraper(BaseScraper):
                 logger.warning(f"[Squarespace] Non-JSON response from {url}")
                 return []
 
-            # Squarespace can return events under different keys
-            items = data.get("items", data.get("upcoming", data.get("events", [])))
+            items = self._select_items(data)
 
             for item in items:
                 parsed = self._parse_event(item)
@@ -59,6 +58,20 @@ class SquarespaceScraper(BaseScraper):
 
         logger.info(f"[Squarespace] Found {len(events)} events for {self.venue_slug}")
         return events
+
+    @staticmethod
+    def _select_items(data: dict) -> list:
+        """Pick the event list out of a Squarespace JSON payload.
+
+        Which key holds the events depends on the site's template — Neptune's Parlour
+        uses "items", Boom Club uses "upcoming".
+
+        Chained with `or` rather than nested get() defaults on purpose: a default only
+        applies when the key is ABSENT, so a feed carrying "items": [] would take that
+        empty list and stop, never reaching the "upcoming" key holding its events. The
+        venue would silently report zero events with no error anywhere.
+        """
+        return data.get("items") or data.get("upcoming") or data.get("events") or []
 
     def _extract_description(self, item: dict) -> str:
         """Pull a plain-text description out of a Squarespace event body.

--- a/backend/app/scrapers/squarespace.py
+++ b/backend/app/scrapers/squarespace.py
@@ -60,6 +60,37 @@ class SquarespaceScraper(BaseScraper):
         logger.info(f"[Squarespace] Found {len(events)} events for {self.venue_slug}")
         return events
 
+    def _extract_description(self, item: dict) -> str:
+        """Pull a plain-text description out of a Squarespace event body.
+
+        Squarespace nests the post body in a `div.sqs-html-content` block whose first
+        child repeats the event title, so the walk starts at the second child and takes
+        the text of each remaining one — the raw HTML must not reach the database (#17).
+
+        Returns '' when there is nothing to read. A venue that leaves an event body
+        empty gets layout scaffolding with no `sqs-html-content` block at all, and an
+        empty description is never a reason to discard the event (#35).
+        """
+        raw = item.get("excerpt") or item.get("body") or ""
+        if not raw:
+            return ''
+
+        try:
+            body = BeautifulSoup(raw, "lxml").select_one("div.sqs-html-content")
+            if body is None:
+                return ''
+            # select_one rather than select()[0]: an absent block returns None instead of
+            # raising IndexError, which is what used to take the whole event down.
+            return ''.join(child.text + "\r\n" for child in list(body.contents)[1:])
+        except Exception as e:
+            # Description is optional metadata. Losing it must never lose the event, so
+            # this stays outside the caller's try block for the required fields.
+            logger.warning(
+                f"[Squarespace] {self.venue_slug}: could not read description for "
+                f"{item.get('title', '?')!r}: {e}"
+            )
+            return ''
+
     def _parse_event(self, item: dict) -> Optional[ScrapedEvent]:
         """Parse a single Squarespace event dict into a ScrapedEvent, returning None on failure."""
         try:
@@ -90,13 +121,7 @@ class SquarespaceScraper(BaseScraper):
             # End date (usually same day)
             end_ts = item.get("endDate")
 
-            # Extract body/description — fall back to raw body if no excerpt
-            soup = BeautifulSoup(item.get("excerpt", "") or item.get("body", ""), "lxml")
-            description = ''
-            html_content = soup.select("div.sqs-html-content")
-            # start at 1 bc [0] is just the title again
-            for index in range(1, len(html_content[0].contents)):
-                description += html_content[0].contents[index].text + "\r\n"
+            description = self._extract_description(item)
             # Image
             image_url = None
             if item.get("assetUrl"):
@@ -147,5 +172,10 @@ class SquarespaceScraper(BaseScraper):
                 source_url=source_url,
             )
         except Exception as e:
-            logger.warning(f"[Squarespace] Failed to parse event: {e}")
+            # Name the venue and the event: the previous message identified neither,
+            # which is why four silently dropped Boom Club events went unnoticed.
+            logger.warning(
+                f"[Squarespace] {self.venue_slug}: failed to parse "
+                f"{item.get('title', '?')!r}: {e}"
+            )
             return None

--- a/backend/app/scrapers/squarespace.py
+++ b/backend/app/scrapers/squarespace.py
@@ -15,6 +15,7 @@ from bs4 import BeautifulSoup
 import httpx
 
 from app.scrapers.base import BaseScraper, ScrapedEvent, BROWSER_HEADERS
+from app.scrapers.html_text import clean_html_text
 
 # --- Module-level setup ---
 
@@ -73,28 +74,32 @@ class SquarespaceScraper(BaseScraper):
         """
         return data.get("items") or data.get("upcoming") or data.get("events") or []
 
-    def _extract_description(self, item: dict) -> str:
-        """Pull a plain-text description out of a Squarespace event body.
+    def _extract_description(self, item: dict, title: str) -> Optional[str]:
+        """Pull a human-readable description out of a Squarespace event.
 
-        Squarespace nests the post body in a `div.sqs-html-content` block whose first
-        child repeats the event title, so the walk starts at the second child and takes
-        the text of each remaining one — the raw HTML must not reach the database (#17).
+        Two shapes of source content, told apart by which field they came from:
 
-        Returns '' when there is nothing to read. A venue that leaves an event body
-        empty gets layout scaffolding with no `sqs-html-content` block at all, and an
-        empty description is never a reason to discard the event (#35).
+        - `excerpt`, when present, is a genuinely separate summary field: bare `<p>`
+          tags with real content, never a repeat of the title (confirmed against
+          Boom Club, which fills in excerpts but leaves `body` looking like an empty
+          Post Body block). Its paragraphs are kept as-is.
+        - `body` is the Post Body WYSIWYG editor's output, wrapped in Squarespace's
+          layout markup, and its first paragraph always repeats the event's own
+          title (confirmed against Neptune's Parlour) — dropped via
+          `drop_first_paragraph_if` rather than a positional skip, so it only ever
+          removes an actual title repeat and never a paragraph of real content that
+          happens to come first (#13, #17).
+
+        An event whose body is empty layout scaffolding with no readable text
+        returns None — that is never a reason to discard the event itself (#35).
         """
-        raw = item.get("excerpt") or item.get("body") or ""
-        if not raw:
-            return ''
-
         try:
-            body = BeautifulSoup(raw, "lxml").select_one("div.sqs-html-content")
-            if body is None:
-                return ''
-            # select_one rather than select()[0]: an absent block returns None instead of
-            # raising IndexError, which is what used to take the whole event down.
-            return ''.join(child.text + "\r\n" for child in list(body.contents)[1:])
+            excerpt = item.get("excerpt")
+            if excerpt:
+                # A real excerpt is never dropped for matching the title — only
+                # body's known title-repeat paragraph is.
+                return clean_html_text(excerpt)
+            return clean_html_text(item.get("body") or "", drop_first_paragraph_if=title)
         except Exception as e:
             # Description is optional metadata. Losing it must never lose the event, so
             # this stays outside the caller's try block for the required fields.
@@ -102,7 +107,7 @@ class SquarespaceScraper(BaseScraper):
                 f"[Squarespace] {self.venue_slug}: could not read description for "
                 f"{item.get('title', '?')!r}: {e}"
             )
-            return ''
+            return None
 
     def _parse_event(self, item: dict) -> Optional[ScrapedEvent]:
         """Parse a single Squarespace event dict into a ScrapedEvent, returning None on failure."""
@@ -134,7 +139,7 @@ class SquarespaceScraper(BaseScraper):
             # End date (usually same day)
             end_ts = item.get("endDate")
 
-            description = self._extract_description(item)
+            description = self._extract_description(item, title)
             # Image
             image_url = None
             if item.get("assetUrl"):

--- a/backend/requirements-dev.txt
+++ b/backend/requirements-dev.txt
@@ -1,0 +1,3 @@
+# Development / test dependencies (not installed in the production image).
+-r requirements.txt
+pytest==8.3.4

--- a/backend/tests/test_html_text.py
+++ b/backend/tests/test_html_text.py
@@ -1,0 +1,158 @@
+"""
+Tests for clean_html_text, the shared HTML-to-readable-text helper (#13).
+
+Two real bugs motivated this: Shadowbox (MEC) stored a description that was HTML
+markup put through an extra HTML-entity pass, so the literal text '&lt;p&gt;...' was
+what ended up on the page. Boom Club (Squarespace) had its real excerpt content
+silently discarded because the extraction only knew how to read Squarespace's
+Post-Body wrapper, which excerpt content is never wrapped in.
+
+Fixtures below are trimmed from real feeds where noted.
+"""
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from app.scrapers.html_text import clean_html_text  # noqa: E402
+
+
+# --- The core regressions ---
+
+class TestDoubleEncodedHtml:
+    """Shadowbox / MEC: the JSON-LD description field itself has been HTML-escaped."""
+
+    RAW = (
+        "&lt;p&gt;&lt;strong&gt;Presenting the final volume of Summer Nights hip hop "
+        "showcase!&lt;/strong&gt;&lt;/p&gt; &lt;p&gt;Co-presented by "
+        "&lt;strong&gt;&lt;a href=&quot;https://www.superempty.com&quot; "
+        "target=&quot;_blank&quot;&gt;Super Empty&lt;/a&gt;&lt;/strong&gt;.&lt;/p&gt;"
+    )
+
+    def test_no_escape_sequences_survive(self):
+        out = clean_html_text(self.RAW)
+        assert "&lt;" not in out and "&gt;" not in out and "&quot;" not in out
+
+    def test_no_tags_survive(self):
+        out = clean_html_text(self.RAW)
+        assert "<p>" not in out and "<strong>" not in out and "<a " not in out
+
+    def test_the_readable_text_survives(self):
+        out = clean_html_text(self.RAW)
+        assert "Presenting the final volume of Summer Nights hip hop showcase!" in out
+        assert "Co-presented by Super Empty." in out
+
+    def test_paragraphs_are_separated(self):
+        out = clean_html_text(self.RAW)
+        assert "\n\n" in out
+
+
+class TestExcerptContentIsNotDiscarded:
+    """Boom Club: excerpt is real content with no Post-Body wrapper around it."""
+
+    # Trimmed from the live boom-club.org feed.
+    EXCERPT = (
+        '<p style="white-space:pre-wrap;" data-rte-preserve-empty="true">'
+        "Modular virtuoso (and great friend of BOOM) Matthew Cha presents "
+        "<em>Technojazz,</em> a live, semi-improvised suite.</p>"
+    )
+
+    def test_content_with_no_wrapping_div_is_still_read(self):
+        """The regression: this used to return None with no wrapper to find."""
+        out = clean_html_text(self.EXCERPT)
+        assert out is not None
+        assert "Modular virtuoso" in out
+        assert "Technojazz" in out
+
+
+# --- Title-repeat handling ---
+
+class TestDropFirstParagraph:
+    def test_matching_first_paragraph_is_dropped(self):
+        html = "<p>The Regulars</p><p>Doors at 8pm.</p>"
+        out = clean_html_text(html, drop_first_paragraph_if="The Regulars")
+        assert "The Regulars" not in out
+        assert out == "Doors at 8pm."
+
+    def test_match_is_case_insensitive(self):
+        html = "<p>THE REGULARS</p><p>Doors at 8pm.</p>"
+        out = clean_html_text(html, drop_first_paragraph_if="the regulars")
+        assert out == "Doors at 8pm."
+
+    def test_non_matching_first_paragraph_is_kept(self):
+        """Real content that isn't a title repeat must never be discarded."""
+        html = "<p>Doors at 8pm.</p><p>$12 advance</p>"
+        out = clean_html_text(html, drop_first_paragraph_if="The Regulars")
+        assert "Doors at 8pm." in out
+
+    def test_unset_never_drops_anything(self):
+        """Excerpt content is never checked against the title — see squarespace.py."""
+        html = "<p>The Regulars</p><p>Doors at 8pm.</p>"
+        out = clean_html_text(html)
+        assert "The Regulars" in out
+
+    def test_a_solo_matching_paragraph_leaves_nothing(self):
+        out = clean_html_text("<p>The Regulars</p>", drop_first_paragraph_if="The Regulars")
+        assert out is None
+
+
+# --- Structural handling ---
+
+class TestStructure:
+    def test_br_becomes_a_newline(self):
+        out = clean_html_text("<p>Line one<br>Line two</p>")
+        assert out == "Line one\nLine two"
+
+    def test_no_p_tags_falls_back_to_the_whole_fragment(self):
+        """Not every source wraps content in <p> — plain text must not vanish."""
+        assert clean_html_text("Plain text, no markup at all.") == "Plain text, no markup at all."
+
+    def test_inline_tags_do_not_fragment_a_paragraph(self):
+        """<strong>/<a> must not each become their own paragraph."""
+        out = clean_html_text("<p>Come see <strong>the band</strong> tonight.</p>")
+        assert out == "Come see the band tonight."
+
+    def test_nbsp_is_treated_as_whitespace(self):
+        out = clean_html_text("<p>Doors at 8pm.</p>")
+        assert out == "Doors at 8pm."
+
+    def test_empty_paragraphs_are_dropped(self):
+        out = clean_html_text("<p></p><p>Real content.</p><p>   </p>")
+        assert out == "Real content."
+
+
+# --- Truncation ---
+
+class TestLimit:
+    def test_truncates_the_cleaned_text_not_the_markup(self):
+        """Truncating raw HTML first could cut mid-tag; this must cut the clean text."""
+        html = "<p>" + ("x" * 600) + "</p>"
+        out = clean_html_text(html, limit=500)
+        assert len(out) == 500
+        assert "<" not in out
+
+    def test_short_text_is_not_padded_or_altered(self):
+        assert clean_html_text("<p>Short.</p>", limit=500) == "Short."
+
+
+# --- Empty / missing input ---
+
+class TestEmptyInput:
+    def test_none_returns_none(self):
+        assert clean_html_text(None) is None
+
+    def test_empty_string_returns_none(self):
+        assert clean_html_text("") is None
+
+    def test_whitespace_only_html_returns_none(self):
+        assert clean_html_text("<p>   </p>") is None
+
+    def test_layout_scaffolding_with_no_text_returns_none(self):
+        """Boom Club's genuinely empty events (#35) — layout markup, zero text."""
+        html = (
+            '<div class="sqs-layout sqs-grid-12 columns-12 empty" '
+            'data-layout-label="Post Body"><div class="row sqs-row">'
+            '<div class="col sqs-col-12 span-12"></div></div></div>'
+        )
+        assert clean_html_text(html) is None

--- a/backend/tests/test_mec.py
+++ b/backend/tests/test_mec.py
@@ -1,0 +1,84 @@
+"""
+Tests for the MEC scraper's description handling (#13).
+
+Regression: MEC's JSON-LD `description` field stores markup that has itself been
+through an HTML-entity pass — the literal text '&lt;p&gt;&lt;strong&gt;...' rather
+than an actual '<p>' tag. Reading it with a plain `data.get("description")` put that
+literal escape text on the page, e.g. "&lt;p&gt;&lt;strong&gt;Presenting the final
+volume...". Confirmed against real Shadowbox Studio data.
+
+The fixture below is trimmed from a real Shadowbox event.
+"""
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from app.scrapers.mec import MECScraper  # noqa: E402
+
+
+# Trimmed from a real Shadowbox Studio JSON-LD Event block.
+DOUBLE_ENCODED_DESCRIPTION = (
+    "&lt;p&gt;&lt;strong&gt;Presenting the final volume of Summer Nights hip hop "
+    "showcase!&lt;/strong&gt;&lt;/p&gt; &lt;p&gt;Co-presented by "
+    "&lt;strong&gt;&lt;a href=&quot;https://www.superempty.com&quot; "
+    "target=&quot;_blank&quot;&gt;Super Empty&lt;/a&gt;&lt;/strong&gt;.&lt;/p&gt;"
+)
+
+
+def _scraper() -> MECScraper:
+    return MECScraper("shadowbox-studio", {"url": "https://example.org/events/"})
+
+
+def _jsonld(**overrides) -> dict:
+    data = {
+        "@type": "Event",
+        "name": "Summer Nights, Vol. 3",
+        "startDate": "2026-09-10T20:00:00",
+        "description": DOUBLE_ENCODED_DESCRIPTION,
+    }
+    data.update(overrides)
+    return data
+
+
+class TestDescriptionIsReadable:
+    def test_no_escape_sequences_reach_the_event(self):
+        """The regression: this used to be the literal text '&lt;p&gt;...'."""
+        parsed = _scraper()._parse_jsonld_event(_jsonld())
+
+        assert parsed is not None
+        assert "&lt;" not in parsed.description
+        assert "&gt;" not in parsed.description
+
+    def test_no_tags_reach_the_event(self):
+        parsed = _scraper()._parse_jsonld_event(_jsonld())
+        assert "<p>" not in parsed.description
+        assert "<strong>" not in parsed.description
+
+    def test_the_readable_text_is_present(self):
+        parsed = _scraper()._parse_jsonld_event(_jsonld())
+        assert "Presenting the final volume of Summer Nights hip hop showcase!" in (
+            parsed.description
+        )
+        assert "Co-presented by Super Empty." in parsed.description
+
+    def test_missing_description_is_none_not_empty_string(self):
+        data = _jsonld()
+        del data["description"]
+        parsed = _scraper()._parse_jsonld_event(data)
+        assert parsed.description is None
+
+    def test_a_long_description_is_truncated_after_cleaning(self):
+        """Truncating the raw markup first could cut mid-tag; must cut clean text."""
+        html = "&lt;p&gt;" + ("x" * 600) + "&lt;/p&gt;"
+        parsed = _scraper()._parse_jsonld_event(_jsonld(description=html))
+        assert len(parsed.description) == 500
+        assert "&lt;" not in parsed.description
+
+    def test_required_fields_are_unaffected(self):
+        """Description cleaning must not disturb the rest of the parse."""
+        parsed = _scraper()._parse_jsonld_event(_jsonld())
+        assert parsed.name == "Summer Nights, Vol. 3"
+        assert parsed.venue_slug == "shadowbox-studio"
+        assert parsed.source == "mec"

--- a/backend/tests/test_squarespace.py
+++ b/backend/tests/test_squarespace.py
@@ -53,6 +53,35 @@ def _item(**overrides) -> dict:
     return item
 
 
+# --- _select_items ---
+
+class TestSelectItems:
+    def test_reads_the_items_key(self):
+        assert SquarespaceScraper._select_items({"items": [1, 2]}) == [1, 2]
+
+    def test_reads_the_upcoming_key(self):
+        """Boom Club's template has no 'items' key at all."""
+        assert SquarespaceScraper._select_items({"upcoming": [1]}) == [1]
+
+    def test_reads_the_events_key(self):
+        assert SquarespaceScraper._select_items({"events": [1]}) == [1]
+
+    def test_an_empty_items_key_does_not_mask_upcoming(self):
+        """The reason for `or` over a get() default — a default only fires when the
+        key is absent, so "items": [] used to win and hide the real events."""
+        data = {"items": [], "upcoming": [{"title": "MICROMACHINES"}]}
+        assert SquarespaceScraper._select_items(data) == [{"title": "MICROMACHINES"}]
+
+    def test_items_wins_when_both_are_populated(self):
+        assert SquarespaceScraper._select_items({"items": [1], "upcoming": [2]}) == [1]
+
+    def test_no_known_key_yields_an_empty_list(self):
+        assert SquarespaceScraper._select_items({"past": [1]}) == []
+
+    def test_all_keys_empty_yields_an_empty_list(self):
+        assert SquarespaceScraper._select_items({"items": [], "upcoming": []}) == []
+
+
 # --- _extract_description ---
 
 class TestExtractDescription:

--- a/backend/tests/test_squarespace.py
+++ b/backend/tests/test_squarespace.py
@@ -1,0 +1,128 @@
+"""
+Tests for the Squarespace scraper's description handling.
+
+Regression cover for #35: an event whose body has no `div.sqs-html-content` block
+raised IndexError, which the broad except in _parse_event swallowed — dropping the
+whole event. Every Boom Club listing has an empty body, so the venue sat at zero
+events in the database while its scrape logs reported success.
+
+The markup fixtures below are trimmed copies of what the two live feeds return.
+"""
+
+import sys
+from datetime import date
+from pathlib import Path
+
+# Make `app` importable when running pytest from backend/.
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from app.scrapers.squarespace import SquarespaceScraper  # noqa: E402
+
+
+# --- Fixtures drawn from the live feeds ---
+
+# Boom Club: the venue never filled in a body, so Squarespace emits layout
+# scaffolding marked `empty` with no sqs-html-content block anywhere.
+EMPTY_BODY = (
+    '<div class="sqs-layout sqs-grid-12 columns-12 empty" data-layout-label="Post Body"'
+    ' data-type="item" id="item-6a626f7c24c2d308343e7804">'
+    '<div class="row sqs-row"><div class="col sqs-col-12 span-12"></div></div></div>'
+)
+
+# Neptune's Parlour: a populated body. First child repeats the title, so it is skipped.
+POPULATED_BODY = (
+    '<div class="sqs-layout"><div class="row sqs-row"><div class="col">'
+    '<div class="sqs-block html-block"><div class="sqs-block-content">'
+    '<div class="sqs-html-content">'
+    "<h2>The Regulars</h2>"
+    "<p>Doors at 8pm.</p>"
+    "<p>$12 advance</p>"
+    "</div></div></div></div></div></div>"
+)
+
+START_MS = 1788000000000  # milliseconds, as Squarespace sends them
+
+
+def _scraper() -> SquarespaceScraper:
+    return SquarespaceScraper("boom-club", {"url": "https://example.org/events?format=json"})
+
+
+def _item(**overrides) -> dict:
+    item = {"title": "MICROMACHINES", "startDate": START_MS, "body": EMPTY_BODY}
+    item.update(overrides)
+    return item
+
+
+# --- _extract_description ---
+
+class TestExtractDescription:
+    def test_empty_body_yields_empty_string(self):
+        assert _scraper()._extract_description(_item()) == ''
+
+    def test_missing_body_and_excerpt_yields_empty_string(self):
+        assert _scraper()._extract_description({"title": "X"}) == ''
+
+    def test_populated_body_is_read_as_plain_text(self):
+        out = _scraper()._extract_description(_item(body=POPULATED_BODY))
+        assert "Doors at 8pm." in out
+        assert "$12 advance" in out
+
+    def test_leading_title_child_is_skipped(self):
+        """The first child of sqs-html-content repeats the title (#17)."""
+        out = _scraper()._extract_description(_item(body=POPULATED_BODY))
+        assert "The Regulars" not in out
+
+    def test_html_is_stripped(self):
+        """#17 — raw markup must not reach the database."""
+        out = _scraper()._extract_description(_item(body=POPULATED_BODY))
+        assert "<p>" not in out and "div" not in out
+
+    def test_excerpt_is_preferred_over_body(self):
+        item = _item(excerpt=POPULATED_BODY, body=EMPTY_BODY)
+        assert "Doors at 8pm." in _scraper()._extract_description(item)
+
+
+# --- _parse_event: the actual #35 regression ---
+
+class TestParseEventSurvivesEmptyDescription:
+    def test_event_with_empty_body_is_still_returned(self):
+        """The regression: this used to return None and the event vanished."""
+        parsed = _scraper()._parse_event(_item())
+
+        assert parsed is not None, "an empty description must not discard the event"
+        assert parsed.name == "MICROMACHINES"
+        assert parsed.description == ''
+
+    def test_event_with_empty_body_keeps_its_required_fields(self):
+        parsed = _scraper()._parse_event(_item())
+
+        assert isinstance(parsed.date, date)
+        assert parsed.venue_slug == "boom-club"
+        assert parsed.source == "squarespace"
+
+    def test_event_with_a_description_still_parses(self):
+        parsed = _scraper()._parse_event(_item(body=POPULATED_BODY))
+
+        assert parsed is not None
+        assert "Doors at 8pm." in parsed.description
+
+    def test_price_is_still_read_from_a_populated_description(self):
+        """Description feeds price parsing, so the two must stay wired together."""
+        parsed = _scraper()._parse_event(_item(body=POPULATED_BODY))
+        assert parsed.price_min == 12.0
+
+    def test_missing_title_is_still_rejected(self):
+        """Required fields must keep failing closed — only description got lenient."""
+        assert _scraper()._parse_event(_item(title="")) is None
+
+    def test_missing_start_date_is_still_rejected(self):
+        item = _item()
+        del item["startDate"]
+        assert _scraper()._parse_event(item) is None
+
+    def test_excluded_titles_are_still_skipped(self):
+        scraper = SquarespaceScraper("boom-club", {
+            "url": "https://example.org/events?format=json",
+            "exclude_titles": ["micromachines"],
+        })
+        assert scraper._parse_event(_item()) is None

--- a/backend/tests/test_squarespace.py
+++ b/backend/tests/test_squarespace.py
@@ -1,10 +1,16 @@
 """
 Tests for the Squarespace scraper's description handling.
 
-Regression cover for #35: an event whose body has no `div.sqs-html-content` block
-raised IndexError, which the broad except in _parse_event swallowed — dropping the
-whole event. Every Boom Club listing has an empty body, so the venue sat at zero
-events in the database while its scrape logs reported success.
+Two regressions covered here:
+
+- #35: an event whose body has no `div.sqs-html-content` block raised IndexError,
+  which the broad except in _parse_event swallowed — dropping the whole event.
+  Every Boom Club listing has an empty body, so the venue sat at zero events in the
+  database while its scrape logs reported success.
+- #13: `excerpt` content (Boom Club fills this in with real summaries) was read with
+  the same "look for a Post-Body wrapper, skip its first child" logic that only
+  applies to `body`. Excerpt has no such wrapper and never repeats the title, so real
+  description text was silently discarded — not shown as raw HTML, but lost outright.
 
 The markup fixtures below are trimmed copies of what the two live feeds return.
 """
@@ -29,15 +35,24 @@ EMPTY_BODY = (
     '<div class="row sqs-row"><div class="col sqs-col-12 span-12"></div></div></div>'
 )
 
-# Neptune's Parlour: a populated body. First child repeats the title, so it is skipped.
+# Neptune's Parlour: the Post Body editor's first <p> always repeats the event's own
+# title verbatim (confirmed against the live feed) — real content follows after it.
 POPULATED_BODY = (
     '<div class="sqs-layout"><div class="row sqs-row"><div class="col">'
     '<div class="sqs-block html-block"><div class="sqs-block-content">'
     '<div class="sqs-html-content">'
-    "<h2>The Regulars</h2>"
+    '<p class="" style="white-space:pre-wrap;">The Regulars</p>'
     "<p>Doors at 8pm.</p>"
     "<p>$12 advance</p>"
     "</div></div></div></div></div></div>"
+)
+
+# Boom Club: `excerpt` is a genuinely separate summary field — bare <p> tags, no
+# Post-Body wrapper, and never a repeat of the title (confirmed against the live feed,
+# where `body` for these same events looks like an unrelated, mostly-empty layout).
+EXCERPT_CONTENT = (
+    '<p style="white-space:pre-wrap;" data-rte-preserve-empty="true">'
+    "Modular virtuoso Matthew Cha presents a live, semi-improvised suite.</p>"
 )
 
 START_MS = 1788000000000  # milliseconds, as Squarespace sends them
@@ -85,30 +100,47 @@ class TestSelectItems:
 # --- _extract_description ---
 
 class TestExtractDescription:
-    def test_empty_body_yields_empty_string(self):
-        assert _scraper()._extract_description(_item()) == ''
+    def test_empty_body_yields_none(self):
+        assert _scraper()._extract_description(_item(), "MICROMACHINES") is None
 
-    def test_missing_body_and_excerpt_yields_empty_string(self):
-        assert _scraper()._extract_description({"title": "X"}) == ''
+    def test_missing_body_and_excerpt_yields_none(self):
+        assert _scraper()._extract_description({"title": "X"}, "X") is None
 
     def test_populated_body_is_read_as_plain_text(self):
-        out = _scraper()._extract_description(_item(body=POPULATED_BODY))
+        out = _scraper()._extract_description(_item(body=POPULATED_BODY), "The Regulars")
         assert "Doors at 8pm." in out
         assert "$12 advance" in out
 
-    def test_leading_title_child_is_skipped(self):
-        """The first child of sqs-html-content repeats the title (#17)."""
-        out = _scraper()._extract_description(_item(body=POPULATED_BODY))
+    def test_leading_title_paragraph_is_dropped_from_body(self):
+        """body's Post-Body editor repeats the title as its first paragraph (#17)."""
+        out = _scraper()._extract_description(_item(body=POPULATED_BODY), "The Regulars")
         assert "The Regulars" not in out
 
     def test_html_is_stripped(self):
         """#17 — raw markup must not reach the database."""
-        out = _scraper()._extract_description(_item(body=POPULATED_BODY))
+        out = _scraper()._extract_description(_item(body=POPULATED_BODY), "The Regulars")
         assert "<p>" not in out and "div" not in out
 
     def test_excerpt_is_preferred_over_body(self):
-        item = _item(excerpt=POPULATED_BODY, body=EMPTY_BODY)
-        assert "Doors at 8pm." in _scraper()._extract_description(item)
+        item = _item(excerpt=EXCERPT_CONTENT, body=POPULATED_BODY)
+        out = _scraper()._extract_description(item, "The Regulars")
+        assert "Matthew Cha" in out
+
+    def test_excerpt_with_no_wrapper_is_still_read(self):
+        """The #13 regression: excerpt has no Post-Body div to find, and previously
+        that meant it was read as having nothing in it."""
+        item = _item(excerpt=EXCERPT_CONTENT)
+        out = _scraper()._extract_description(item, "Matthew Cha \"Technojazz\" Release")
+        assert out is not None
+        assert "Modular virtuoso Matthew Cha" in out
+
+    def test_excerpt_is_never_checked_against_the_title(self):
+        """Only body's known title-repeat paragraph is dropped. Excerpt is a genuinely
+        separate field and must survive even a coincidental title match."""
+        item = _item(excerpt="<p>The Regulars</p><p>A special guest tonight.</p>")
+        out = _scraper()._extract_description(item, "The Regulars")
+        assert "The Regulars" in out
+        assert "A special guest tonight." in out
 
 
 # --- _parse_event: the actual #35 regression ---
@@ -120,7 +152,7 @@ class TestParseEventSurvivesEmptyDescription:
 
         assert parsed is not None, "an empty description must not discard the event"
         assert parsed.name == "MICROMACHINES"
-        assert parsed.description == ''
+        assert parsed.description is None
 
     def test_event_with_empty_body_keeps_its_required_fields(self):
         parsed = _scraper()._parse_event(_item())
@@ -155,3 +187,18 @@ class TestParseEventSurvivesEmptyDescription:
             "exclude_titles": ["micromachines"],
         })
         assert scraper._parse_event(_item()) is None
+
+    def test_excerpt_content_survives_end_to_end(self):
+        """The #13 regression, through the full parse path rather than just the
+        extraction helper: Boom Club's real excerpts must reach the stored event."""
+        item = _item(
+            title='Matthew Cha "Technojazz" Release',
+            excerpt=EXCERPT_CONTENT,
+            body=EMPTY_BODY,
+        )
+        parsed = _scraper()._parse_event(item)
+
+        assert parsed is not None
+        assert parsed.description is not None
+        assert "Modular virtuoso Matthew Cha" in parsed.description
+        assert "<p>" not in parsed.description

--- a/frontend/css/styles.css
+++ b/frontend/css/styles.css
@@ -901,6 +901,11 @@ a:hover { color: var(--accent-hover); text-decoration: underline; }
   font-size: 0.8rem;
   color: var(--muted);
   line-height: 1.5;
+  /* Descriptions are plain text with blank lines between paragraphs (see
+     clean_html_text in the backend) — pre-line renders those breaks instead of
+     collapsing every description into one run-on line, while still collapsing
+     ordinary runs of spaces the way normal HTML text does. */
+  white-space: pre-line;
 }
 
 /* Badges */


### PR DESCRIPTION
Fixes #35 and #13.

## #35 — Squarespace scraper quits after an event with an empty description

The description walk added for #17 indexes the select result without checking it matched anything:

```python
html_content = soup.select("div.sqs-html-content")
for index in range(1, len(html_content[0].contents)):   # IndexError when select() returned []
```

A venue that leaves an event body empty gets layout scaffolding with no `sqs-html-content` block at all, so `select(...)` returns `[]`, `[0]` raises `IndexError`, and the broad `except Exception` in `_parse_event` swallows it and returns `None` — discarding **the whole event**, not just its description.

Every Boom Club listing has an empty body, so all four of its events were dropped on every scrape, while scrape logs reported `success`.

| Venue | Feed items | Before | After |
|---|---|---|---|
| `boom-club` | 4 | **0** | **4** |
| `neptunes-parlour` | 67 | 67 | 67 |

Also fixed in the same pass: `_select_items()` picks the event list out of the JSON payload using nested `get()` defaults, which only fall through when a key is **absent** — a feed carrying `"items": []` would take that empty list and stop, never reaching the `upcoming` key that actually holds its events. Rewritten with `or` chaining and covered by its own tests.

## #13 — raw HTML in event descriptions

Two separate bugs, both surfacing as unreadable description text:

- **MEC (Shadowbox, Slim's):** the JSON-LD `description` field stores markup that has itself been through an extra HTML-entity pass — the literal string `&lt;p&gt;&lt;strong&gt;...` rather than an actual `<p>` tag. The frontend's `_h()` then escapes the leading `&` again, so what actually renders is visible text like `&lt;p&gt;&lt;strong&gt;Presenting the final volume...`.
- **Squarespace (Boom Club):** `_extract_description` only knew how to read the Post-Body wrapper structure (`div.sqs-html-content`, skip the first child because it repeats the title). Boom Club fills in `excerpt` instead — bare `<p>` tags with real content, no wrapper, no title repeat — so extraction found nothing to read and silently discarded genuine description text.

Added `backend/app/scrapers/html_text.py`: a small shared `clean_html_text()` used by both scrapers. It decodes entities (idempotently — a no-op on already-plain HTML), strips tags, and joins `<p>`-level paragraphs with a blank line. It takes an optional `drop_first_paragraph_if`, matched by text rather than position, so Squarespace's body-only title-repeat can be dropped without ever risking a paragraph of real content — `excerpt` never passes this, since it's a genuinely separate field that doesn't repeat the title.

Kept out of `scrapers/base.py`, which stays pure-stdlib by design; only the two scrapers with HTML to clean import it.

Also fixed `frontend/css/styles.css`: `.modal-description` had no `white-space` rule, so the paragraph breaks this now produces would have collapsed into one run-on line. Added `white-space: pre-line`.

### Verified against the live feeds

| Venue | Before | After |
|---|---|---|
| Boom Club | 0 events, 0 readable descriptions | 4 events, 3 with readable multi-paragraph descriptions (4th has a genuinely empty body) |
| Neptune's Parlour | 67 events, clean descriptions | Unchanged — confirmed still clean |
| Shadowbox Studio | descriptions containing literal `&lt;p&gt;` / `&lt;strong&gt;` | Zero remaining escape sequences or tags |

## Tests

37 tests across `test_squarespace.py`, `test_html_text.py` (new), and `test_mec.py` (new) — markup fixtures trimmed from the three live feeds. Covers the empty-body regression, the excerpt-vs-body distinction, double-encoded entity decoding, title-repeat dropping (matched by text, never by position), truncation happening after cleaning rather than on raw markup, and that required-field rejections are unchanged. 50 passing total including the CI/tooling additions below.

This branch also adds `backend/requirements-dev.txt` and a CI pytest step, since `main` has no way to run tests today. Both also appear on `fix/duplicate-event-listings` with identical content, so whichever lands first satisfies the other.

## Note for the reviewer

`main`'s `.gitignore` still lists the dot-prefixed session files (`.SESSION-CONTEXT.md`, `.todo`, `.context-history/`) from an earlier convention; those are now stale relative to the current `_`-prefixed convention. Left out of this PR to keep it focused.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
