### PR TITLE
Promote main to prod

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -44,7 +44,17 @@ That asymmetry is deliberate. `main` stays quick to work on — you can commit a
 
 Neither ruleset has bypass actors, so the `prod` PR requirement applies to everyone, repository admins included. There is no direct path to `prod`.
 
-Automatic head-branch deletion is on, so a feature branch is removed from GitHub once its PR merges. `main` is exempt because its ruleset restricts deletions — it survives being merged into `prod`. Your local copies survive regardless; clean up with `git fetch --prune` and `git branch -d <branch>`.
+Branches are **not** removed automatically when a PR merges — auto-delete is off, so cleanup is a deliberate step:
+
+```bash
+git push origin --delete <branch>   # remove it from GitHub (takes several branch names at once)
+git fetch --prune                   # drop the stale origin/… references
+git branch -d <branch>              # remove your local copy
+```
+
+Use lowercase `-d`, which refuses to delete a branch with unmerged commits; `-D` forces past that check. To see what's safe to remove, `git branch -r --merged origin/main` lists remote branches already folded into `main` — but check for open PRs first, since a branch can be merged and still have follow-up work attached.
+
+`main` and `prod` cannot be deleted at all: both rulesets restrict deletions.
 
 ## Pull requests
 

--- a/.gitignore
+++ b/.gitignore
@@ -9,8 +9,15 @@ venv/
 .vscode/
 *.log
 
-# Internal process docs (session context, deployment guides, roadmap)
+# Internal process docs (session context, deployment guides, roadmap).
+# This repo is PUBLIC and these carry operational detail — cost figures, the private
+# internal repo, infrastructure notes — so they stay local. This deliberately differs
+# from the global convention of tracking AI-managed session files, which assumes a
+# private repo.
 _*.md
+.SESSION-CONTEXT.md
+.todo
+.context-history/
 .claude/
 .claude*
 CLAUDE.md

--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,11 @@ venv/
 # from the global convention of tracking AI-managed session files, which assumes a
 # private repo.
 _*.md
+_context-history/
+
+# Legacy dot-prefixed names. /save-context used these briefly before the convention
+# went back to the `_` prefix. Kept as a guard so a machine still running the older
+# skill cannot re-create them untracked in a public repo.
 .SESSION-CONTEXT.md
 .todo
 .context-history/

--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ See [ARCHITECTURE.md](docs/ARCHITECTURE.md) for how a request reaches the app an
 
 ## Roadmap
 
-Upcoming features and ideas are tracked in [GitHub Issues](https://github.com/ty-fi/triangle-shows/issues). Some things I'm currently thinking about:
+Upcoming features and ideas are tracked in [GitHub Issues](https://github.com/triangle-shows/triangle-shows/issues). Some things I'm currently thinking about:
 
 - Adding more venues (Sharp 9 Gallery, the Fruit, others)
 - Handling custom/one-off events and form submission

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -175,8 +175,13 @@ purpose, so an empty `ScrapeLog` is expected there and must not fail the smoke t
 
 ### Uptime checking
 
-External monitoring runs on **[UptimeRobot](https://uptimerobot.com)** (free plan), checking
-`https://triangle-shows.net/api/health`.
+External monitoring runs on **[UptimeRobot](https://uptimerobot.com)** (free plan):
+
+| | |
+|---|---|
+| Target | `https://triangle-shows.net/api/health` |
+| Interval | every 15 minutes |
+| Alerts | email |
 
 **The monitor must target the public hostname, not the `.run.app` URL.** The Cloudflare Worker
 is the component whose failure takes the public site down while Cloud Run stays perfectly
@@ -184,9 +189,14 @@ healthy — a check against the origin would report all-clear through exactly th
 through the public hostname exercises DNS, Cloudflare, the Worker, Cloud Run, and Neon in one
 request.
 
-Two settings worth keeping as they are: a generous request timeout (~30s), because
-`min-instances=0` means the first request after an idle period pays a 2–3 second cold start;
-and alerting only after two consecutive failures, so a single blip doesn't page anyone.
+Keep the request timeout generous (~30s). With `min-instances=0` the first request after an
+idle period pays a 2–3 second cold start, and at a 15-minute interval most checks arrive after
+Cloud Run has already scaled down — so cold starts are the normal case here, not the exception.
+
+**Detection latency is roughly 15–30 minutes.** One missed check takes up to 15 minutes to
+occur, and if the monitor is set to alert only after two consecutive failures, that doubles.
+That's a deliberate tradeoff against false alarms rather than an oversight; shortening the
+interval is the lever if an outage needs noticing sooner.
 
 ## If something breaks
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -173,10 +173,20 @@ only want the deployed SHA can still read it from a 503.
 Freshness is enforced only when `APP_ENV=production`. CI and local runs disable scraping on
 purpose, so an empty `ScrapeLog` is expected there and must not fail the smoke test.
 
-**Point any monitor at `https://triangle-shows.net/api/health`, not the `.run.app` URL.** The
-Cloudflare Worker is the component whose failure takes the public site down while Cloud Run
-stays healthy — a check against the origin would report all-clear through exactly that outage.
-Allow a generous timeout (~30s) for cold starts, and alert only after two consecutive failures.
+### Uptime checking
+
+External monitoring runs on **[UptimeRobot](https://uptimerobot.com)** (free plan), checking
+`https://triangle-shows.net/api/health`.
+
+**The monitor must target the public hostname, not the `.run.app` URL.** The Cloudflare Worker
+is the component whose failure takes the public site down while Cloud Run stays perfectly
+healthy — a check against the origin would report all-clear through exactly that outage. Going
+through the public hostname exercises DNS, Cloudflare, the Worker, Cloud Run, and Neon in one
+request.
+
+Two settings worth keeping as they are: a generous request timeout (~30s), because
+`min-instances=0` means the first request after an idle period pays a 2–3 second cold start;
+and alerting only after two consecutive failures, so a single blip doesn't page anyone.
 
 ## If something breaks
 

--- a/docs/SELF-HOSTING.md
+++ b/docs/SELF-HOSTING.md
@@ -8,7 +8,7 @@
 ## Setup
 
 ```bash
-git clone https://github.com/ty-fi/triangle-shows
+git clone https://github.com/triangle-shows/triangle-shows
 cd triangle-shows
 
 # Copy the example env file and fill in your Ticketmaster API key

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -121,7 +121,7 @@
     <!-- Calendar -->
     <main class="calendar-container">
       <div id="calendar"></div>
-      <footer class="site-credit">made by <a href="http://bsky.app/profile/tyfi.bsky.social" target="_blank" rel="noopener">@tyfi</a>. it's on <a href="https://github.com/ty-fi/triangle-shows" target="_blank" rel="noopener">github</a>.</footer>
+      <footer class="site-credit">made by <a href="http://bsky.app/profile/tyfi.bsky.social" target="_blank" rel="noopener">@tyfi</a>. it's on <a href="https://github.com/triangle-shows/triangle-shows" target="_blank" rel="noopener">github</a>.</footer>
     </main>
   </div>
 

--- a/tools/wait_for_deploy.py
+++ b/tools/wait_for_deploy.py
@@ -35,7 +35,7 @@ DEFAULT_TIMEOUT = 900  # give up after 15 minutes rather than polling forever
 
 # Cloudflare fronts triangle-shows.net and rejects urllib's default
 # "Python-urllib/x.y" agent with a 403. Any identifiable agent gets through.
-USER_AGENT = "triangle-shows-deploy-watcher/1.0 (+https://github.com/ty-fi/triangle-shows)"
+USER_AGENT = "triangle-shows-deploy-watcher/1.0 (+https://github.com/triangle-shows/triangle-shows)"
 
 
 # --- Helpers ---


### PR DESCRIPTION
Routine promotion — 6 commits, all docs/gitignore/monitoring notes, nothing functional:

- Correct branch-cleanup docs (auto-delete is off)
- Record UptimeRobot as the uptime checker + its interval/alert channel
- Keep session-context files out of this public repo
- Ignore the `_context-history/` archive directory
- Point hardcoded GitHub links at the new `triangle-shows` org

Doubling as the first real test of the Cloud Build trigger since the repo moved from `ty-fi` to the `triangle-shows` org. The trigger was recreated pointing at the new location; this push is what confirms it actually fires.

🤖 Generated with [Claude Code](https://claude.com/claude-code)