### PR TITLE
Match events by venue ID and drop listings sources no longer carry

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,9 @@ jobs:
         with:
           python-version: "3.12"
           cache: pip
-          cache-dependency-path: backend/requirements.txt
+          cache-dependency-path: |
+            backend/requirements.txt
+            backend/requirements-dev.txt
 
       - name: Install dependencies
         run: pip install -r backend/requirements-dev.txt

--- a/backend/app/api/events.py
+++ b/backend/app/api/events.py
@@ -27,6 +27,19 @@ router = APIRouter(prefix="/api/events", tags=["events"])
 
 # --- Helpers ---
 
+def _completeness(event: Event) -> tuple:
+    """Rank two listings of the same show: richer record wins, then most recently scraped.
+
+    Every component is total and the id breaks the last tie, so the winner does not depend
+    on the order the database returned rows in.
+    """
+    return (
+        bool(event.image_url) + bool(event.ticket_url) + (event.price_min is not None),
+        event.updated_at or datetime.min,
+        event.id,
+    )
+
+
 def _event_to_response(event: Event) -> EventResponse:
     """Map an ORM Event (with venue eagerly loaded) to the EventResponse schema."""
     return EventResponse(
@@ -110,26 +123,24 @@ async def get_fullcalendar_events(
     # unique() is required when using joinedload to collapse duplicate rows from the JOIN.
     events = result.unique().scalars().all()
 
-    # --- Cross-venue deduplication ---
-    # Cross-venue dedup: if the same artist performs on the same date at two
-    # different venues (e.g. listed on both a venue's own site and Ticketmaster),
-    # keep only the entry with the most complete metadata.
+    # --- Same-venue duplicate guard ---
+    # scrapers/manager.py is where duplicates are actually prevented; this is a display-time
+    # backstop covering the window between a venue editing an event and the next scrape.
+    #
+    # The key is scoped to the venue deliberately. An earlier version keyed only on
+    # (date, artist), which also collapsed listings at *different* venues — and two venues
+    # showing the same artist on one night is a moved or miscopied show, not a duplicate.
+    # Discarding one of them hid a real listing, and picked which venue survived from
+    # whichever row the database happened to return first.
     _dedup_best: dict[tuple, Event] = {}
-    _dedup_score: dict[tuple, int] = {}
     for event in events:
         label = event.artist or event.name
         # Normalize to lowercase alphanumeric so minor name differences don't prevent matching.
         norm = re.sub(r"[^a-z0-9]", "", label.lower())
-        key = (event.date, norm)
-        # Score based on how many key fields are populated; prefer richer records.
-        score = bool(event.image_url) + bool(event.ticket_url) + (event.price_min is not None)
-        if key not in _dedup_best:
+        key = (event.venue_id, event.date, norm)
+        incumbent = _dedup_best.get(key)
+        if incumbent is None or _completeness(event) > _completeness(incumbent):
             _dedup_best[key] = event
-            _dedup_score[key] = score
-        elif event.venue_id != _dedup_best[key].venue_id and score > _dedup_score[key]:
-            # Different venue but same artist/date — keep the more complete record.
-            _dedup_best[key] = event
-            _dedup_score[key] = score
     kept = {ev.id for ev in _dedup_best.values()}
     events = [e for e in events if e.id in kept]
 

--- a/backend/app/scrapers/base.py
+++ b/backend/app/scrapers/base.py
@@ -8,11 +8,49 @@ method, and uses ScrapedEvent.hash for deduplication before upserting to Postgre
 Requires: No env vars or external services — pure Python stdlib only.
 """
 import hashlib
+import html
 import re
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
 from datetime import date, time, datetime
 from typing import Optional
+from urllib.parse import unquote
+
+
+# --- Title normalization ---
+
+# A percent-escape: '%' followed by exactly two hex digits, e.g. '%26' for '&'.
+_PCT_ESCAPE = re.compile(r"%[0-9A-Fa-f]{2}")
+
+
+def clean_title(text: Optional[str]) -> Optional[str]:
+    """Decode escape sequences a source left in a human-readable title.
+
+    Venue sites hand us the same title in different encodings depending on which page
+    it came from — Shadowbox's listing page yields 'A &#038; B' while its detail page
+    yields 'A %26 B' for the same show. Because the dedup hash is built from the title,
+    two encodings of one title produce two database rows. Normalizing here means every
+    scraper hashes the same string, and users stop seeing raw escape codes.
+
+    Percent-decoding the whole string (rather than each escape separately) is what makes
+    multi-byte UTF-8 sequences like '%E2%80%99' come back as one character. The tradeoff
+    is that a literal '%' followed by two hex digits would be mangled; that does not
+    happen in practice in event titles, and leaving '%26' on screen is the worse failure.
+    """
+    if not text:
+        return text
+
+    # WordPress feeds sometimes double-escape ('&amp;#038;'), so unescape until stable.
+    for _ in range(3):
+        decoded = html.unescape(text)
+        if decoded == text:
+            break
+        text = decoded
+
+    if _PCT_ESCAPE.search(text):
+        text = unquote(text)
+
+    return re.sub(r"\s+", " ", text).strip()
 
 
 # --- ScrapedEvent Dataclass ---
@@ -40,6 +78,12 @@ class ScrapedEvent:
     age_restriction: Optional[str] = None
     description: Optional[str] = None
     source_url: Optional[str] = None
+
+    def __post_init__(self):
+        """Normalize the human-readable fields before anything hashes or stores them."""
+        self.name = clean_title(self.name)
+        self.artist = clean_title(self.artist)
+        self.support_artists = clean_title(self.support_artists)
 
     @property
     def hash(self) -> str:

--- a/backend/app/scrapers/manager.py
+++ b/backend/app/scrapers/manager.py
@@ -1,6 +1,11 @@
 """
-Scrape orchestrator: runs all venue scrapers, deduplicates results by hash, and
-upserts events + scrape logs into the database.
+Scrape orchestrator: runs all venue scrapers, matches each run against the events already
+stored for that venue, and upserts events + scrape logs into the database.
+
+Matching is the interesting part. Rows are identified by the venue's own event ID first
+and only then by a hash of the title, because titles get edited (support acts announced,
+events renamed) and a title-only identity turns every edit into a second listing. Rows the
+source has stopped listing are removed, subject to the safety valves below.
 
 Role: Triggered by POST /api/scrape (called by the scheduler every 6 hours or
 by Cloud Scheduler). Sits between the individual scrapers and the database —
@@ -11,8 +16,10 @@ session, and all scraper modules in app.scrapers/.
 
 # --- Imports ---
 import logging
-from datetime import datetime
-from typing import Optional
+from collections import defaultdict
+from dataclasses import dataclass, field
+from datetime import date, datetime
+from typing import Any, Optional
 
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -24,6 +31,151 @@ from app.scrapers.base import BaseScraper, ScrapedEvent
 from app.scrapers.ticketmaster import TicketmasterScraper
 
 logger = logging.getLogger(__name__)
+
+
+# --- Reconcile safety valves ---
+#
+# Reconciling deletes rows, so it has to stay skeptical of its own input. A scraper that
+# half-succeeds — a selector that stops matching, a paginated feed that returns page one —
+# looks exactly like a venue that cancelled most of its calendar. These two constants
+# decide when a run is too lossy to trust.
+
+# Below this many orphans, reconcile always proceeds: small absolute numbers are normal
+# churn (a cancelled show, a series wrapping up) and never worth second-guessing.
+RECONCILE_ALWAYS_ALLOW = 4
+
+# Above that floor, refuse to delete if orphans exceed this share of the venue's rows in
+# the scraped date window. Losing half a venue's calendar in one run means the scraper
+# broke, not that the venue emptied out.
+RECONCILE_MAX_ORPHAN_FRACTION = 0.5
+
+
+# --- Upsert planning ---
+
+
+@dataclass
+class UpsertPlan:
+    """What a scrape run should do to the rows already stored for a venue.
+
+    Pure data — computed by plan_upsert() without touching the session, so the matching
+    rules can be tested without a database.
+    """
+
+    updates: list[tuple[ScrapedEvent, Any]] = field(default_factory=list)   # (scraped, row to update)
+    inserts: list[ScrapedEvent] = field(default_factory=list)               # no row matched
+    superseded: list[Any] = field(default_factory=list)                     # older rows folded into a match
+    expired: list[Any] = field(default_factory=list)                        # rows the source no longer lists
+    reconcile_skipped: bool = False                                         # True when the safety valve tripped
+
+
+def dedupe_scraped(scraped_events: list[ScrapedEvent]) -> list[ScrapedEvent]:
+    """Collapse repeats within a single scrape run, keeping the first of each.
+
+    Sites list the same event twice (a featured section plus the main listing), and
+    without this the repeats collide on Event.hash inside one INSERT batch.
+    """
+    out: list[ScrapedEvent] = []
+    seen_ext: set[tuple[str, date]] = set()
+    seen_hash: set[str] = set()
+
+    for se in scraped_events:
+        ext_key = (se.external_id, se.date) if se.external_id else None
+        if ext_key is not None and ext_key in seen_ext:
+            continue
+        if se.hash in seen_hash:
+            continue
+        if ext_key is not None:
+            seen_ext.add(ext_key)
+        seen_hash.add(se.hash)
+        out.append(se)
+
+    return out
+
+
+def plan_upsert(existing: list[Any], scraped_events: list[ScrapedEvent], today: date) -> UpsertPlan:
+    """Match a scrape run against the rows already stored for one venue.
+
+    Rows are matched on (external_id, date) first and only then on the title hash. That
+    order is the whole point: the hash is built from the title, so when a venue edits an
+    event — adding a support act, renaming it, prefixing a series — the hash changes and
+    a hash-only match sees a brand-new event. The venue's own ID does not change, so it
+    identifies the show across a rename where the title cannot.
+
+    Rows for the same show that were created by earlier renames are `superseded` and get
+    folded into the survivor. Rows inside the scraped date window that the source stopped
+    listing are `expired`.
+
+    Only attribute access is used on `existing` rows (.id, .date, .hash, .external_id,
+    .updated_at), so tests can pass stand-ins instead of ORM objects.
+    """
+    plan = UpsertPlan()
+    if not scraped_events:
+        return plan
+
+    by_ext: dict[tuple[str, date], list[Any]] = defaultdict(list)
+    by_hash: dict[str, Any] = {}
+    for row in existing:
+        if row.external_id:
+            by_ext[(row.external_id, row.date)].append(row)
+        by_hash[row.hash] = row
+
+    claimed: set[int] = set()
+
+    for se in scraped_events:
+        candidates: list[Any] = []
+        if se.external_id:
+            candidates.extend(by_ext.get((se.external_id, se.date), []))
+        hash_row = by_hash.get(se.hash)
+        if hash_row is not None:
+            candidates.append(hash_row)
+
+        # An external_id match and a hash match are often the same row; and a row already
+        # claimed by an earlier scraped event must not be claimed twice.
+        unique: list[Any] = []
+        picked: set[int] = set()
+        for row in candidates:
+            if row.id in claimed or row.id in picked:
+                continue
+            picked.add(row.id)
+            unique.append(row)
+
+        if not unique:
+            plan.inserts.append(se)
+            continue
+
+        # Prefer the row whose title already matches what the source says now; fall back
+        # to the most recently seen row. Both keys are total, so the choice is stable.
+        unique.sort(
+            key=lambda r: (r.hash == se.hash, r.updated_at or datetime.min),
+            reverse=True,
+        )
+        keep, rest = unique[0], unique[1:]
+        claimed.add(keep.id)
+        plan.updates.append((se, keep))
+        for row in rest:
+            claimed.add(row.id)
+            plan.superseded.append(row)
+
+    # --- Reconcile ---
+    # Only rows inside the window the scraper actually covered are candidates. A scraper
+    # that returns three months of listings says nothing about a show ten months out, and
+    # deleting past events would wipe the archive every run — venues drop them from their
+    # own listings as soon as they happen.
+    horizon = max(se.date for se in scraped_events)
+    in_window = [r for r in existing if today <= r.date <= horizon]
+    orphans = [r for r in in_window if r.id not in claimed]
+
+    if orphans:
+        too_lossy = (
+            len(orphans) > RECONCILE_ALWAYS_ALLOW
+            and len(orphans) > len(in_window) * RECONCILE_MAX_ORPHAN_FRACTION
+        )
+        if too_lossy:
+            plan.reconcile_skipped = True
+        else:
+            plan.expired = orphans
+
+    return plan
 
 
 # --- ScrapeManager ---
@@ -112,26 +264,28 @@ class ScrapeManager:
                 raise ValueError(f"No scraper available for {venue_slug}")
 
             scraped_events = await scraper.scrape()
-            created, updated = await self._upsert_events(venue_id, scraped_events)
+            counts = await self._upsert_events(venue_id, venue_slug, scraped_events)
 
             log.status = "success"
             log.events_found = len(scraped_events)
-            log.events_created = created
-            log.events_updated = updated
+            log.events_created = counts["created"]
+            log.events_updated = counts["updated"]
             log.finished_at = datetime.utcnow()
             log.duration_seconds = (log.finished_at - log.started_at).total_seconds()
             await self.session.commit()
 
+            # merged/expired counts have no ScrapeLog column yet, so they live in the log
+            # line and the API response. Individual removals are logged in _upsert_events.
             logger.info(
                 f"[{venue_slug}] Scrape complete: {len(scraped_events)} found, "
-                f"{created} created, {updated} updated"
+                f"{counts['created']} created, {counts['updated']} updated, "
+                f"{counts['merged']} merged, {counts['expired']} expired"
             )
             return {
                 "venue": venue_slug,
                 "status": "success",
                 "found": len(scraped_events),
-                "created": created,
-                "updated": updated,
+                **counts,
             }
 
         except Exception as e:
@@ -152,79 +306,104 @@ class ScrapeManager:
 
     # --- Upsert helpers ---
 
-    async def _upsert_events(self, venue_id: int, scraped_events: list[ScrapedEvent]) -> tuple[int, int]:
-        """Upsert events using hash-based dedup. Returns (created, updated) counts."""
+    @staticmethod
+    def _apply_scraped(row: Event, se: ScrapedEvent) -> None:
+        """Copy a freshly scraped event onto the row that represents it.
+
+        The title and its hash are written back, because a row matched on external_id may
+        be carrying a title the venue has since edited. Optional fields fall back to the
+        stored value so a source that briefly omits a field does not blank out good data.
+        """
+        row.name = se.name
+        row.artist = se.artist or row.artist
+        row.hash = se.hash
+        row.external_id = se.external_id or row.external_id
+        row.source = se.source
+        row.source_url = se.source_url or row.source_url
+        row.price_min = se.price_min
+        row.price_max = se.price_max
+        row.status = se.status
+        row.image_url = se.image_url or row.image_url
+        row.ticket_url = se.ticket_url or row.ticket_url
+        row.doors_time = se.doors_time or row.doors_time
+        row.show_time = se.show_time or row.show_time
+        row.support_artists = se.support_artists or row.support_artists
+        row.genre = se.genre or row.genre
+        row.subgenre = se.subgenre or row.subgenre
+        row.age_restriction = se.age_restriction or row.age_restriction
+        row.description = se.description or row.description
+        row.updated_at = datetime.utcnow()
+
+    async def _upsert_events(self, venue_id: int, venue_slug: str, scraped_events: list[ScrapedEvent]) -> dict:
+        """Reconcile a scrape run against stored events. Returns per-outcome counts."""
         if not scraped_events:
-            return 0, 0
+            return {"created": 0, "updated": 0, "merged": 0, "expired": 0}
 
-        # Deduplicate scraped events by hash (sites sometimes list the same event
-        # twice — e.g. a featured section + main listing — which would cause a
-        # UniqueViolationError when both end up in the same INSERT flush batch.
-        seen: dict[str, ScrapedEvent] = {}
-        for se in scraped_events:
-            seen.setdefault(se.hash, se)
-        scraped_events = list(seen.values())
+        scraped_events = dedupe_scraped(scraped_events)
 
-        # Fetch all matching existing events in one query instead of one per event.
-        hashes = [se.hash for se in scraped_events]
+        # Load the venue's whole calendar in one query. Matching on external_id and
+        # spotting rows the source dropped both need the full picture, and no venue
+        # holds more than a couple hundred rows.
         result = await self.session.execute(
-            select(Event).where(Event.hash.in_(hashes))
+            select(Event).where(Event.venue_id == venue_id)
         )
-        existing_by_hash = {e.hash: e for e in result.scalars().all()}
+        existing = list(result.scalars().all())
 
-        created = 0
-        updated = 0
+        plan = plan_upsert(existing, scraped_events, datetime.utcnow().date())
 
-        for se in scraped_events:
-            existing = existing_by_hash.get(se.hash)
+        if plan.reconcile_skipped:
+            logger.warning(
+                f"[{venue_slug}] Reconcile skipped: {len(scraped_events)} events scraped would "
+                f"orphan too large a share of the stored calendar. Leaving rows in place — "
+                f"this usually means the scraper is partially broken, not that the venue emptied."
+            )
 
-            if existing:
-                # Update mutable fields — identity fields (name, date, venue) are
-                # baked into the hash so they never change for a given event row.
-                existing.price_min = se.price_min
-                existing.price_max = se.price_max
-                existing.status = se.status
-                # Prefer the freshly scraped value but fall back to whatever we already
-                # have stored so we don't accidentally blank out previously-good data.
-                existing.image_url = se.image_url or existing.image_url
-                existing.ticket_url = se.ticket_url or existing.ticket_url
-                existing.doors_time = se.doors_time or existing.doors_time
-                existing.show_time = se.show_time or existing.show_time
-                existing.support_artists = se.support_artists or existing.support_artists
-                existing.genre = se.genre or existing.genre
-                existing.subgenre = se.subgenre or existing.subgenre
-                existing.age_restriction = se.age_restriction or existing.age_restriction
-                existing.description = se.description or existing.description
-                existing.updated_at = datetime.utcnow()
-                updated += 1
-            else:
-                event = Event(
-                    external_id=se.external_id,
-                    venue_id=venue_id,
-                    name=se.name,
-                    artist=se.artist,
-                    support_artists=se.support_artists,
-                    date=se.date,
-                    doors_time=se.doors_time,
-                    show_time=se.show_time,
-                    ticket_url=se.ticket_url,
-                    price_min=se.price_min,
-                    price_max=se.price_max,
-                    image_url=se.image_url,
-                    genre=se.genre,
-                    subgenre=se.subgenre,
-                    status=se.status,
-                    age_restriction=se.age_restriction,
-                    description=se.description,
-                    source=se.source,
-                    source_url=se.source_url,
-                    hash=se.hash,
-                )
-                self.session.add(event)
-                created += 1
+        # Deletes go first, and get their own flush. Event.hash is globally unique, and a
+        # surviving row is often about to take the hash a superseded row still holds.
+        removals = (
+            [(r, "superseded by another listing for the same show") for r in plan.superseded]
+            + [(r, "no longer listed by the source") for r in plan.expired]
+        )
+        for row, why in removals:
+            logger.info(f"[{venue_slug}] Removing event {row.id} ({row.date} {row.name!r}) — {why}")
+            await self.session.delete(row)
+        if removals:
+            await self.session.flush()
+
+        for se, row in plan.updates:
+            self._apply_scraped(row, se)
+
+        for se in plan.inserts:
+            self.session.add(Event(
+                external_id=se.external_id,
+                venue_id=venue_id,
+                name=se.name,
+                artist=se.artist,
+                support_artists=se.support_artists,
+                date=se.date,
+                doors_time=se.doors_time,
+                show_time=se.show_time,
+                ticket_url=se.ticket_url,
+                price_min=se.price_min,
+                price_max=se.price_max,
+                image_url=se.image_url,
+                genre=se.genre,
+                subgenre=se.subgenre,
+                status=se.status,
+                age_restriction=se.age_restriction,
+                description=se.description,
+                source=se.source,
+                source_url=se.source_url,
+                hash=se.hash,
+            ))
 
         await self.session.flush()
-        return created, updated
+        return {
+            "created": len(plan.inserts),
+            "updated": len(plan.updates),
+            "merged": len(plan.superseded),
+            "expired": len(plan.expired),
+        }
 
     # --- Bulk scrape entry points ---
 

--- a/backend/requirements-dev.txt
+++ b/backend/requirements-dev.txt
@@ -1,3 +1,5 @@
-# Development / test dependencies (not installed in the production image).
+# Test-only dependencies. Kept out of requirements.txt so the Cloud Run image
+# does not ship a test runner. Install with:
+#   pip install -r backend/requirements-dev.txt
 -r requirements.txt
 pytest==8.3.4

--- a/backend/tests/test_dedup.py
+++ b/backend/tests/test_dedup.py
@@ -1,0 +1,323 @@
+"""
+Tests for duplicate prevention: title normalization, run-level dedup, and upsert planning.
+
+These cover the two ways the same show used to end up in the database twice — a venue
+editing an event's title, and one scraper reporting a title in two encodings — plus the
+reconcile pass that removes listings a source has dropped.
+
+Every case here is drawn from a real pair found in the production data.
+"""
+
+from dataclasses import dataclass
+from datetime import date, datetime, timedelta
+from typing import Optional
+
+import pytest
+
+from app.scrapers.base import ScrapedEvent, clean_title
+from app.scrapers.manager import (
+    RECONCILE_ALWAYS_ALLOW,
+    dedupe_scraped,
+    plan_upsert,
+)
+
+
+TODAY = date(2026, 9, 1)
+
+
+# --- Test helpers ---
+
+
+@dataclass
+class Row:
+    """Stand-in for an Event row. plan_upsert only reads these attributes."""
+
+    id: int
+    date: date
+    hash: str
+    external_id: Optional[str] = None
+    updated_at: Optional[datetime] = None
+
+
+def scraped(name: str, on: date = TODAY, external_id: Optional[str] = None) -> ScrapedEvent:
+    return ScrapedEvent(
+        name=name,
+        date=on,
+        venue_slug="the-pinhook",
+        source="venuepilot",
+        external_id=external_id,
+    )
+
+
+def row_for(se: ScrapedEvent, id: int, seen: Optional[datetime] = None) -> Row:
+    """A stored row matching a scraped event exactly — the already-up-to-date case."""
+    return Row(
+        id=id,
+        date=se.date,
+        hash=se.hash,
+        external_id=se.external_id,
+        updated_at=seen or datetime(2026, 8, 27),
+    )
+
+
+# --- clean_title ---
+
+
+class TestCleanTitle:
+    def test_decodes_html_entities(self):
+        assert clean_title("JoVia Armstrong &#038; alana amore colvin") == (
+            "JoVia Armstrong & alana amore colvin"
+        )
+
+    def test_decodes_percent_escapes(self):
+        assert clean_title("JoVia Armstrong %26 alana amore colvin") == (
+            "JoVia Armstrong & alana amore colvin"
+        )
+
+    def test_both_encodings_converge(self):
+        """The Shadowbox bug: one event, two pages, two encodings, two database rows."""
+        entity = clean_title("Ben Copperhead &#038; David Menestres")
+        percent = clean_title("Ben Copperhead %26 David Menestres")
+        assert entity == percent
+
+    def test_decodes_double_escaped_entities(self):
+        assert clean_title("Cool Boy&amp;#039;s Tapes") == "Cool Boy's Tapes"
+
+    def test_decodes_multibyte_percent_escapes(self):
+        """Decoding the whole string, not each escape, is what makes this come out right."""
+        assert clean_title("Cool Boy%E2%80%99s Tapes") == "Cool Boy’s Tapes"
+
+    def test_collapses_whitespace(self):
+        assert clean_title("Alex Cameron /  Josh De Costa") == "Alex Cameron / Josh De Costa"
+
+    def test_leaves_a_bare_percent_alone(self):
+        assert clean_title("Get 50% Off Before Doors") == "Get 50% Off Before Doors"
+
+    def test_passes_through_empty_values(self):
+        assert clean_title(None) is None
+        assert clean_title("") == ""
+
+    def test_applied_on_construction(self):
+        assert scraped("A &#038; B").name == "A & B"
+
+    def test_encodings_hash_identically(self):
+        assert scraped("A &#038; B").hash == scraped("A %26 B").hash
+
+
+# --- dedupe_scraped ---
+
+
+class TestDedupeScraped:
+    def test_collapses_repeated_hash(self):
+        events = [scraped("Acopia"), scraped("Acopia")]
+        assert len(dedupe_scraped(events)) == 1
+
+    def test_collapses_repeated_external_id_on_one_date(self):
+        """Two sections of one page describing the same show with different titles."""
+        events = [scraped("Acopia", external_id="188044"),
+                  scraped("Acopia / Lilly Flower", external_id="188044")]
+        assert [e.name for e in dedupe_scraped(events)] == ["Acopia"]
+
+    def test_keeps_same_external_id_on_different_dates(self):
+        """A recurring series reuses its ID; each night is still its own event."""
+        events = [scraped("Open Mic", TODAY, external_id="900"),
+                  scraped("Open Mic", TODAY + timedelta(days=7), external_id="900")]
+        assert len(dedupe_scraped(events)) == 2
+
+    def test_keeps_distinct_events(self):
+        events = [scraped("Acopia"), scraped("Anna Graves")]
+        assert len(dedupe_scraped(events)) == 2
+
+
+# --- plan_upsert: matching ---
+
+
+class TestMatching:
+    def test_unchanged_event_is_updated_not_reinserted(self):
+        se = scraped("Acopia", external_id="188044")
+        plan = plan_upsert([row_for(se, id=1)], [se], TODAY)
+        assert plan.inserts == []
+        assert [(s.name, r.id) for s, r in plan.updates] == [("Acopia", 1)]
+
+    def test_new_event_is_inserted(self):
+        plan = plan_upsert([], [scraped("Acopia", external_id="188044")], TODAY)
+        assert [se.name for se in plan.inserts] == ["Acopia"]
+        assert plan.updates == []
+
+    def test_support_act_added_to_title_updates_in_place(self):
+        """The Pinhook's most common case, and the one hash-only matching got wrong."""
+        stored = row_for(scraped("Acopia", external_id="188044"), id=1)
+        se = scraped("Acopia / Lilly Flower", external_id="188044")
+
+        plan = plan_upsert([stored], [se], TODAY)
+
+        assert plan.inserts == [], "a retitled event is the same event"
+        assert [r.id for _, r in plan.updates] == [1]
+        assert plan.expired == []
+
+    def test_full_rename_updates_in_place(self):
+        """Stanczyks: 'Duke Music Collective' became 'Private Event' under one ID."""
+        stored = row_for(scraped("Duke Music Collective", external_id="192587"), id=1)
+        se = scraped("Private Event", external_id="192587")
+
+        plan = plan_upsert([stored], [se], TODAY)
+
+        assert [r.id for _, r in plan.updates] == [1]
+        assert plan.inserts == []
+
+    def test_matches_on_hash_when_no_external_id(self):
+        """Scrapers like webflow_cms and mec expose no venue-side ID."""
+        se = scraped("Electro Lust w/ Domocile")
+        stored = Row(id=1, date=se.date, hash=se.hash, updated_at=datetime(2026, 8, 27))
+
+        plan = plan_upsert([stored], [se], TODAY)
+
+        assert [r.id for _, r in plan.updates] == [1]
+
+    def test_same_external_id_different_date_does_not_match(self):
+        """Merging a recurring series onto one row would delete every other night."""
+        stored = row_for(scraped("Open Mic", TODAY, external_id="900"), id=1)
+        se = scraped("Open Mic", TODAY + timedelta(days=7), external_id="900")
+
+        plan = plan_upsert([stored], [se], TODAY)
+
+        assert [s.date for s in plan.inserts] == [TODAY + timedelta(days=7)]
+        assert plan.updates == []
+
+    def test_different_external_ids_stay_separate(self):
+        """Rubies lists two shows one night under two IDs; they are not duplicates."""
+        first = row_for(scraped("Adulting - Shallow Cuts", external_id="161232"), id=1)
+        second = row_for(scraped("Shallow Cuts", external_id="160887"), id=2)
+        events = [scraped("Adulting - Shallow Cuts", external_id="161232"),
+                  scraped("Shallow Cuts", external_id="160887")]
+
+        plan = plan_upsert([first, second], events, TODAY)
+
+        assert len(plan.updates) == 2
+        assert plan.superseded == []
+        assert plan.expired == []
+
+    def test_one_row_is_not_claimed_by_two_scraped_events(self):
+        stored = row_for(scraped("Acopia", external_id="188044"), id=1)
+        events = [scraped("Acopia", external_id="188044"),
+                  scraped("Acopia", external_id="999")]
+
+        plan = plan_upsert([stored], events, TODAY)
+
+        assert len(plan.updates) == 1
+        assert len(plan.inserts) == 1
+
+
+# --- plan_upsert: merging existing duplicates ---
+
+
+class TestMerging:
+    def test_existing_duplicate_pair_is_merged(self):
+        """Self-healing: the pairs already in the database collapse on the next scrape."""
+        old = row_for(scraped("Acopia", external_id="188044"), id=1,
+                      seen=datetime(2026, 8, 18))
+        new = row_for(scraped("Acopia / Lilly Flower", external_id="188044"), id=2,
+                      seen=datetime(2026, 8, 27))
+        se = scraped("Acopia / Lilly Flower", external_id="188044")
+
+        plan = plan_upsert([old, new], [se], TODAY)
+
+        assert [r.id for _, r in plan.updates] == [2], "keep the row the source still matches"
+        assert [r.id for r in plan.superseded] == [1]
+        assert plan.expired == [], "a merged row is not also an orphan"
+
+    def test_survivor_is_chosen_by_title_not_recency(self):
+        """A stale row touched more recently must not win over the one that matches."""
+        matching = row_for(scraped("Acopia / Lilly Flower", external_id="188044"), id=1,
+                           seen=datetime(2026, 8, 18))
+        other = row_for(scraped("Acopia", external_id="188044"), id=2,
+                        seen=datetime(2026, 8, 27))
+        se = scraped("Acopia / Lilly Flower", external_id="188044")
+
+        plan = plan_upsert([matching, other], [se], TODAY)
+
+        assert [r.id for _, r in plan.updates] == [1]
+        assert [r.id for r in plan.superseded] == [2]
+
+    def test_survivor_is_stable_regardless_of_row_order(self):
+        old = row_for(scraped("Acopia", external_id="188044"), id=1,
+                      seen=datetime(2026, 8, 18))
+        new = row_for(scraped("Acopia / Lilly Flower", external_id="188044"), id=2,
+                      seen=datetime(2026, 8, 27))
+        se = scraped("Acopia / Lilly Flower", external_id="188044")
+
+        forward = plan_upsert([old, new], [se], TODAY)
+        reverse = plan_upsert([new, old], [se], TODAY)
+
+        assert [r.id for _, r in forward.updates] == [r.id for _, r in reverse.updates]
+        assert [r.id for r in forward.superseded] == [r.id for r in reverse.superseded]
+
+
+# --- plan_upsert: reconcile ---
+
+
+class TestReconcile:
+    def test_dropped_listing_expires(self):
+        """Lincoln Theatre's cancelled shows sat on the calendar because nothing removed them."""
+        gone = row_for(scraped("Crucial Fiya", external_id="500"), id=1)
+        kept = scraped("Anna Graves", TODAY, external_id="187015")
+
+        plan = plan_upsert([gone, row_for(kept, id=2)], [kept], TODAY)
+
+        assert [r.id for r in plan.expired] == [1]
+        assert plan.reconcile_skipped is False
+
+    def test_past_events_are_never_expired(self):
+        """Venues drop past shows from their listings; the archive must survive that."""
+        archived = Row(id=1, date=TODAY - timedelta(days=30), hash="old", updated_at=None)
+        se = scraped("Anna Graves", TODAY, external_id="187015")
+
+        plan = plan_upsert([archived, row_for(se, id=2)], [se], TODAY)
+
+        assert plan.expired == []
+
+    def test_events_beyond_the_scraped_horizon_are_never_expired(self):
+        """A scraper covering three months says nothing about a show ten months out."""
+        far_future = Row(id=1, date=TODAY + timedelta(days=300), hash="far", updated_at=None)
+        se = scraped("Anna Graves", TODAY + timedelta(days=7), external_id="187015")
+
+        plan = plan_upsert([far_future, row_for(se, id=2)], [se], TODAY)
+
+        assert plan.expired == []
+
+    def test_small_orphan_counts_always_expire(self):
+        """A couple of cancellations is normal churn, even against a short calendar."""
+        se = scraped("Anna Graves", TODAY + timedelta(days=10), external_id="187015")
+        orphans = [
+            Row(id=i, date=TODAY + timedelta(days=i), hash=f"h{i}", updated_at=None)
+            for i in range(1, RECONCILE_ALWAYS_ALLOW + 1)
+        ]
+
+        plan = plan_upsert(orphans + [row_for(se, id=99)], [se], TODAY)
+
+        assert len(plan.expired) == RECONCILE_ALWAYS_ALLOW
+        assert plan.reconcile_skipped is False
+
+    def test_a_half_broken_scraper_deletes_nothing(self):
+        """One event returned against a full calendar means the scraper broke."""
+        se = scraped("Anna Graves", TODAY + timedelta(days=30), external_id="187015")
+        orphans = [
+            Row(id=i, date=TODAY + timedelta(days=i), hash=f"h{i}", updated_at=None)
+            for i in range(1, 21)
+        ]
+
+        plan = plan_upsert(orphans + [row_for(se, id=99)], [se], TODAY)
+
+        assert plan.expired == []
+        assert plan.reconcile_skipped is True
+
+    def test_an_empty_run_changes_nothing(self):
+        """A scraper returning nothing must never be read as 'the venue has no shows'."""
+        stored = [Row(id=i, date=TODAY + timedelta(days=i), hash=f"h{i}") for i in range(1, 6)]
+
+        plan = plan_upsert(stored, [], TODAY)
+
+        assert plan.expired == []
+        assert plan.superseded == []
+        assert plan.inserts == []
+        assert plan.updates == []


### PR DESCRIPTION
The dedup hash is built from the event title, so any title edit — a support act announced, an event renamed, a series prefix added — looked like a brand-new event and inserted a second row. Nothing ever deleted the first. The database held 16 duplicate groups, 12 of them visible on the calendar, plus 4 phantom listings for shows that had been cancelled or moved.

- Match on (external_id, date) before falling back to the title hash. A venue's own event ID survives a rename where the title cannot, so a retitled event now updates in place. Pairs already in the database merge on the next scrape.
- Reconcile after each successful scrape: remove rows inside the scraped date window that the source has stopped listing. Bounded to future dates and to the window the scraper actually covered, and skipped entirely when the orphan count suggests the scraper half-failed rather than the venue emptying out.
- Decode HTML entities and percent-escapes in titles before hashing. Shadowbox's listing and detail pages report the same title as 'A &#038; B' and 'A %26 B', which was enough to make one show into two rows — and left the escape codes on screen.
- Scope the display-time dedup to the venue. Keyed only on (date, artist) it also collapsed listings at different venues, which hid real shows and picked the surviving venue from whatever order the database returned rows in.

Verified against a database built from scratch on this branch: two consecutive full scrapes create 806 events and then change nothing. Duplicate groups fall from 16 to 2, and both survivors are shows the venue itself lists under two separate IDs — ambiguous by the source's own account, so deliberately left alone.