### PR TITLE
Import `app` from one conftest.py instead of every test module

### DIFF
--- a/backend/conftest.py
+++ b/backend/conftest.py
@@ -1,0 +1,27 @@
+"""Pytest configuration for the backend suite: make `app` importable.
+
+The tests import the code under test as `app.scrapers.…`, but `app` is a plain
+directory inside `backend/` rather than an installed package, so it is only
+importable when `backend/` is on `sys.path`. Every test module used to arrange that
+for itself with a three-line preamble before its real imports.
+
+That worked, but it made the suite quietly invocation-dependent. `python -m pytest`
+puts the current directory on `sys.path` as a side effect of `-m`, so from `backend/`
+the preamble was redundant and its absence went unnoticed; a bare `pytest tests`
+adds no such entry, so a module that omitted the preamble failed at collection with
+`ModuleNotFoundError: No module named 'app'`. CI uses the `python -m` form, which is
+why it never surfaced there.
+
+pytest imports the conftest.py files covering a test's directory before importing the
+test modules themselves, so putting the insert here runs early enough for the whole
+suite and stays correct however pytest is invoked -- and applies to new test modules
+without them needing to remember anything.
+"""
+
+import sys
+from pathlib import Path
+
+BACKEND_DIR = Path(__file__).resolve().parent
+
+if str(BACKEND_DIR) not in sys.path:
+    sys.path.insert(0, str(BACKEND_DIR))

--- a/backend/tests/test_html_text.py
+++ b/backend/tests/test_html_text.py
@@ -10,12 +10,7 @@ Post-Body wrapper, which excerpt content is never wrapped in.
 Fixtures below are trimmed from real feeds where noted.
 """
 
-import sys
-from pathlib import Path
-
-sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
-
-from app.scrapers.html_text import clean_html_text  # noqa: E402
+from app.scrapers.html_text import clean_html_text
 
 
 # --- The core regressions ---

--- a/backend/tests/test_mec.py
+++ b/backend/tests/test_mec.py
@@ -10,12 +10,7 @@ volume...". Confirmed against real Shadowbox Studio data.
 The fixture below is trimmed from a real Shadowbox event.
 """
 
-import sys
-from pathlib import Path
-
-sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
-
-from app.scrapers.mec import MECScraper  # noqa: E402
+from app.scrapers.mec import MECScraper
 
 
 # Trimmed from a real Shadowbox Studio JSON-LD Event block.

--- a/backend/tests/test_motorco.py
+++ b/backend/tests/test_motorco.py
@@ -7,19 +7,14 @@ stop-at-the-first-quote pattern terminated there, storing a truncated title with
 a trailing backslash. A fetch of the live calendar showed 61 of 625 titles
 carrying such an escape.
 
-Run from the backend/ directory:  python -m pytest tests/test_motorco.py
+Run from the backend/ directory:  pytest tests/test_motorco.py
 The extraction is pure stdlib regex, so no DB, no network and no fixtures are
 needed — the scraper's own HTTP call is not exercised here.
 """
 
-import sys
 from datetime import date, timedelta
-from pathlib import Path
 
-# Make `app` importable when running pytest from backend/.
-sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
-
-from app.scrapers.motorco import _EVENT_PATTERN, MotorcoScraper  # noqa: E402
+from app.scrapers.motorco import _EVENT_PATTERN, MotorcoScraper
 
 
 def _scraper() -> MotorcoScraper:

--- a/backend/tests/test_squarespace.py
+++ b/backend/tests/test_squarespace.py
@@ -15,14 +15,9 @@ Two regressions covered here:
 The markup fixtures below are trimmed copies of what the two live feeds return.
 """
 
-import sys
 from datetime import date
-from pathlib import Path
 
-# Make `app` importable when running pytest from backend/.
-sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
-
-from app.scrapers.squarespace import SquarespaceScraper  # noqa: E402
+from app.scrapers.squarespace import SquarespaceScraper
 
 
 # --- Fixtures drawn from the live feeds ---


### PR DESCRIPTION
Follow-up to #51, which surfaced this. Test-only change — no application code touched.

## The problem

The tests import the code under test as `app.scrapers.…`. But `app` is a plain directory inside `backend/`, not an installed package, so Python can only find it when `backend/` is listed in `sys.path` — the list of directories Python searches on an `import`. Nothing puts it there automatically.

Every test module solved that for itself, with a preamble before its real imports:

```python
import sys
from pathlib import Path

# Make `app` importable when running pytest from backend/.
sys.path.insert(0, str(Path(__file__).resolve().parent.parent))

from app.scrapers.squarespace import SquarespaceScraper  # noqa: E402
```

Four lines of boilerplate per file, plus a `# noqa: E402` to silence the linter — E402 is "module level import not at top of file", which fires because a statement now sits between the docstring and the imports.

The real cost isn't the boilerplate, it's that **a module that forgets the preamble breaks, and CI can't tell you.** The two ways to invoke pytest differ:

| Invocation | `backend/` on `sys.path`? |
|---|---|
| `python -m pytest tests` | **Yes** — `-m` adds the current directory as a side effect |
| `pytest tests` | **No** — the console script adds nothing |

CI uses the `python -m` form, so `backend/` is on the path regardless and the preamble is redundant there. Its absence is therefore completely invisible to CI. A contributor running the bare `pytest tests` gets:

```
tests/test_dedup.py:17: in <module>
    from app.scrapers.base import ScrapedEvent, clean_title
E   ModuleNotFoundError: No module named 'app'
!!!!!!!!! Interrupted: 1 error during collection !!!!!!!!!
```

Note "during collection" — this is not one test failing. Pytest imports every test module up front to discover the tests inside; a module that raises on import aborts the run, so **the other four files never execute either**.

`tests/test_dedup.py` on #51 is exactly this case: it's the one module without the preamble. It passes CI and fails locally.

## The fix

One `backend/conftest.py`. `conftest.py` is pytest's per-directory configuration file — pytest imports the ones covering a test's directory *before* it imports the test modules themselves, which is early enough to set the path up for the whole suite:

```python
BACKEND_DIR = Path(__file__).resolve().parent

if str(BACKEND_DIR) not in sys.path:
    sys.path.insert(0, str(BACKEND_DIR))
```

Two details worth noting:

- It derives the directory from `__file__` rather than the working directory, so it resolves to the same absolute path no matter where pytest was started from.
- The `not in sys.path` guard keeps repeat insertions out when pytest loads the file more than once in a session.

The four preambles then come out, along with their `# noqa: E402` markers, and `test_motorco.py`'s docstring drops the `python -m` it no longer needs. Net: **+32 / −25 lines**, and one place to look instead of five.

The payoff is for what comes next — new test modules get a working `app` import without their authors needing to know any of the above. Including `test_dedup.py`, which needs no change once this lands; whichever of the two PRs merges second, the suite works.

## Verification

`pytest` 8.3.4 against `backend/requirements-dev.txt`. All four invocations, 56 tests, no failures:

```
backend  $ pytest tests -q                      → 56 passed
backend  $ python -m pytest tests -q            → 56 passed   (the CI invocation)
repo     $ pytest backend/tests -q              → 56 passed
repo     $ pytest backend/tests/test_motorco.py → 6 passed
```

For an honest baseline: all four of these **also** pass on `main` today, because all four modules there carry the preamble. Nothing on `main` is currently broken. This is a preventive change — it removes the per-module requirement that `test_dedup.py` already forgot, rather than repairing a live failure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
