### PR TITLE
Stop publishing the Cloud Run origin hostnames in a public repo

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -54,7 +54,9 @@ does it instead:
 export default {
   async fetch(request) {
     const url = new URL(request.url);
-    url.hostname = 'triangle-shows-bs2va6mvba-ue.a.run.app';
+    // The hashed .run.app hostname — see "Origin hostnames" below for why it is not
+    // written out here, and how to look up the live value.
+    url.hostname = 'triangle-shows-<hash>-ue.a.run.app';
     return fetch(new Request(url.toString(), request));
   }
 }
@@ -73,25 +75,44 @@ contacted.
 
 | Domain | Type | Name | Target | Proxied |
 |---|---|---|---|---|
-| triangle-shows.net | CNAME | `@` | `triangle-shows-bs2va6mvba-ue.a.run.app` | Yes |
-| triangle-shows.net | CNAME | `www` | `triangle-shows-bs2va6mvba-ue.a.run.app` | Yes |
+| triangle-shows.net | CNAME | `@` | the hashed `.run.app` hostname | Yes |
+| triangle-shows.net | CNAME | `www` | the hashed `.run.app` hostname | Yes |
 | triangle-shows.org | A | `@` | `192.0.2.1` (dummy) | Yes |
 
 SSL mode is **Full**, with Always Use HTTPS on. Full works because the `.run.app` origin carries
 a valid Google-managed certificate.
 
-### Two Cloud Run URLs
+### Origin hostnames
 
-The service answers on both of these, and both are in active use:
+The service answers on two `.run.app` hostnames, both in active use:
 
+| Form | Used by |
+|---|---|
+| hashed — `triangle-shows-<hash>-ue.a.run.app` | Cloudflare Worker and the `.net` CNAMEs |
+| project-number — `triangle-shows-<project-number>.us-east1.run.app` | Cloud Scheduler |
+
+Cloud Run issues the project-number form for newer services and keeps the older hashed form
+working. They are the same service. This matters only when changing the hostname: the Worker
+hardcodes the hashed form, so updating one without the other breaks the site.
+
+**Both are deliberately left out of this repo, which is public.** No `--ingress` flag is set on
+the Cloud Run service, so it defaults to `ingress=all` and these hostnames reach the app directly,
+skipping Cloudflare and anything enforced there — including a Cloudflare Access policy on
+`/admin`. The `.net` CNAMEs are proxied, so the origin is not discoverable through public DNS
+either; this document was the only place it was written down.
+
+Treat that as reduced disclosure, not as protection: the origin stays directly reachable until
+ingress is restricted or the app requires a header only the Worker sets. Anything that must not be
+public needs its own authentication regardless of who knows the hostname.
+
+Look up the live values with:
+
+```bash
+gcloud run services describe triangle-shows \
+  --project=triangle-shows --region=us-east1 --format='value(status.url)'
 ```
-https://triangle-shows-bs2va6mvba-ue.a.run.app        ← Cloudflare Worker and CNAMEs
-https://triangle-shows-178508749672.us-east1.run.app  ← Cloud Scheduler
-```
 
-Cloud Run issues the second, project-number form for newer services and keeps the older hashed
-form working. They are the same service. This matters only when changing the hostname: the Worker
-hardcodes the first, so updating one without the other breaks the site.
+Both hostnames are also recorded in `_SESSION-CONTEXT.md`, which is gitignored.
 
 ## Deploy path
 


### PR DESCRIPTION
`docs/ARCHITECTURE.md` wrote out both `.run.app` hostnames. The service sets no `--ingress` flag, so it defaults to `ingress=all` and those hostnames reach the app **directly, skipping Cloudflare** — and therefore skipping the Cloudflare Access policy on `/admin`. Verified: the origin returns `200` on `/api/health` with Cloudflare out of the path.

Nothing else disclosed them:

- the `.net` CNAMEs are proxied, so a DNS lookup returns Cloudflare addresses only
- Cloud Run's default domain is served under a wildcard certificate, so individual service hostnames aren't enumerable from certificate transparency logs

This document was the only public copy.

## What changed

The literal hostnames are replaced with the *shape* of each (`triangle-shows-<hash>-ue.a.run.app`, `triangle-shows-<project-number>.us-east1.run.app`) plus a `gcloud run services describe` command to read the live values — which is what the operational notes here actually need. The renamed **Origin hostnames** section keeps the part that matters for debugging: the Worker hardcodes the hashed form, so changing one without the other breaks the site.

It also gains an explicit warning that this is reduced disclosure, **not** protection. The origin stays directly reachable until ingress is restricted or the app requires a header only the Worker sets. Without that caveat the redaction invites exactly the wrong conclusion.

Generic `.run.app` mentions are left alone — they describe the mechanism and disclose nothing.

## Two things this does not do

**It doesn't remove the hostname from history.** It was added in `0c7048a`, and forks and caches outlive a rewrite. Retiring the leaked value means renaming the Cloud Run service, which is a separate piece of work.

**It doesn't close the bypass.** Redacting a hostname is hygiene. `/admin` is still reachable on the origin without passing Cloudflare Access, which is why `ADMIN_PASSWORD` remains a real gate rather than a second layer — see PR #36 items #10 and #12.

Docs only; no code paths touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)