### PR TITLE
Verify signed tokens on /admin and POST /api/scrape at the origin

### DIFF
--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -25,6 +25,23 @@ class Settings(BaseSettings):
     APP_ENV: str = "development"
     LOG_LEVEL: str = "INFO"
 
+    # --- Origin enforcement (see app.tokens) ---
+    # The Cloud Run service accepts unauthenticated requests, so its .run.app hostnames
+    # reach the app without passing Cloudflare. These settings let the app itself verify
+    # who a request came from on the two routes that must not be open there.
+    #
+    # Each gate is inert until configured, deliberately: local dev and CI have no
+    # Cloudflare and no Cloud Scheduler in front of them. app.tokens.log_enforcement_state()
+    # logs which gates are live on every boot, so "inert" is never silent.
+
+    # Cloudflare Access gate on /admin/*. Both are required to enforce.
+    CF_ACCESS_TEAM_DOMAIN: str = ""  # e.g. "triangleshows.cloudflareaccess.com"
+    CF_ACCESS_AUD: str = ""  # the Access application's AUD tag
+
+    # Google OIDC gate on POST /api/scrape. Cloud Scheduler already sends the token.
+    SCRAPE_ALLOWED_SERVICE_ACCOUNTS: str = ""  # comma-separated service-account emails
+    SCRAPE_OIDC_AUDIENCE: str = ""  # optional; the audience configured on the scheduler job
+
     model_config = {"env_file": ".env", "env_file_encoding": "utf-8"}
 
 

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -14,9 +14,11 @@ import asyncio
 import logging
 from contextlib import asynccontextmanager
 from pathlib import Path
+from typing import Optional
 
-from fastapi import FastAPI
+from fastapi import Depends, FastAPI, Request
 from fastapi.middleware.cors import CORSMiddleware
+from fastapi.responses import JSONResponse
 from fastapi.staticfiles import StaticFiles
 
 from app.config import settings
@@ -24,6 +26,7 @@ from app.database import async_session
 from app.seed import seed_venues
 from app.scheduler import scheduler, configure_scheduler
 from app.api import events, venues, health, feeds
+from app import tokens
 
 # --- Logging setup ---
 logging.basicConfig(
@@ -68,6 +71,11 @@ async def _startup_scrape():
 async def lifespan(app: FastAPI):
     """Startup and shutdown logic."""
     logger.info("Starting Triangle Shows API...")
+
+    # Report which origin gates are live before serving anything, so a gate that is
+    # configured wrong (and therefore doing nothing) is visible in the boot logs rather
+    # than mistaken for protection.
+    tokens.log_enforcement_state()
 
     # Apply any pending Alembic migrations — creates tables on fresh DBs, updates schema on existing ones
     await asyncio.to_thread(_run_migrations)
@@ -114,6 +122,46 @@ app.add_middleware(
     allow_headers=["*"],
 )
 
+
+# --- Origin enforcement on /admin ---
+
+@app.middleware("http")
+async def enforce_admin_access(request: Request, call_next):
+    """Require a valid Cloudflare Access token on /admin/*, when configured.
+
+    Guarding by path rather than inside the admin router is deliberate. The admin
+    subsite arrives with a separate branch (PR #36); a path check protects those routes
+    from the moment they land, so the admin surface cannot reach production without the
+    origin gate in front of it. Until then this is inert — /admin merely 404s.
+
+    The login page is guarded too, not just the API beneath it. Reaching a password
+    prompt on the origin is the exposure being closed; an unauthenticated caller should
+    not see that the admin subsite exists at all.
+    """
+    if not request.url.path.startswith("/admin"):
+        return await call_next(request)
+
+    if not tokens.cloudflare_access_configured():
+        return await call_next(request)
+
+    try:
+        claims = tokens.verify_cloudflare_access(
+            request.headers.get("cf-access-jwt-assertion")
+        )
+    except tokens.TokenError as exc:
+        # Logged at info, not warning: on a public origin, unauthenticated probes of
+        # /admin are background noise rather than incidents.
+        logger.info(f"[admin] rejected {request.method} {request.url.path}: {exc}")
+        return JSONResponse(
+            {"detail": "This surface is reachable only through Cloudflare Access."},
+            status_code=403,
+        )
+
+    # Downstream handlers can attribute an action to a person rather than to whoever
+    # holds a shared password.
+    request.state.access_email = tokens.access_identity(claims)
+    return await call_next(request)
+
 # --- Route registration ---
 
 # API routes
@@ -122,13 +170,47 @@ app.include_router(venues.router)
 app.include_router(health.router)
 app.include_router(feeds.router)
 
-# Manual scrape trigger (dev only)
+# --- Origin enforcement on POST /api/scrape ---
+
+async def require_scrape_token(request: Request) -> Optional[str]:
+    """Require a Google-issued OIDC token from an allowlisted service account.
+
+    Cloud Scheduler already attaches this token; Cloud Run cannot enforce it, because the
+    service has to accept unauthenticated requests for the public site to work. So the
+    check belongs here.
+
+    Inert until SCRAPE_ALLOWED_SERVICE_ACCOUNTS names at least one account, which keeps
+    local dev and CI working. Returns the calling service account for the audit log.
+    """
+    from fastapi import HTTPException
+
+    if not tokens.scrape_token_configured():
+        return None
+
+    token = tokens.bearer_token(request.headers.get("authorization"))
+    try:
+        claims = tokens.verify_scrape_token(token)
+    except tokens.TokenError as exc:
+        logger.warning(f"[scrape] rejected trigger: {exc}")
+        raise HTTPException(status_code=403, detail="Not authorized to trigger a scrape.")
+
+    return claims.get("email")
+
+
+# Scrape trigger. Called by Cloud Scheduler every 6 hours in production; also usable by
+# hand in local dev, where the gate above is inert.
 @app.post("/api/scrape")
-async def trigger_scrape(scraper_type: str = None):
-    """Manually trigger a scrape (development use)."""
+async def trigger_scrape(
+    scraper_type: str = None,
+    caller: Optional[str] = Depends(require_scrape_token),
+):
+    """Trigger a scrape of every venue, or of one scraper_type."""
     from app.database import async_session
     from app.scrapers.manager import ScrapeManager
     from fastapi import HTTPException
+
+    if caller:
+        logger.info(f"[scrape] triggered by {caller}")
 
     try:
         async with async_session() as session:

--- a/backend/app/tokens.py
+++ b/backend/app/tokens.py
@@ -1,0 +1,268 @@
+"""
+Verification of signed tokens, so the Cloud Run origin can tell who a request came from.
+
+Role: Imported by main.py to guard two routes that must not be open on the origin —
+`/admin/*` (Cloudflare Access) and `POST /api/scrape` (Google OIDC, as sent by Cloud
+Scheduler). Pure verification: no database, no application state.
+
+Why this exists. The Cloud Run service sets no `--ingress` restriction, so its `.run.app`
+hostnames answer the public internet directly, skipping Cloudflare and anything enforced
+there. A Cloudflare Access policy on `triangle-shows.net/admin` therefore protects only
+the Cloudflare path; the origin remains reachable. Redacting the hostname (see
+docs/ARCHITECTURE.md) reduces disclosure but is not a control — the hostname is derived
+from the service name and project number rather than from anything secret.
+
+The fix is for the origin to require proof that a request passed through a trusted issuer.
+Both issuers here sign a short-lived token with a private key and publish the matching
+public keys at a fixed URL, so verification is local arithmetic against keys already
+fetched: no callback to the issuer on the request path, and a forged token is not
+possible without the issuer's private key.
+
+Four checks, and the audience check is the one worth being explicit about: without it a
+token the issuer legitimately minted for a *different* application would verify here.
+Signature, expiry, audience, issuer — all four or the token is rejected.
+
+Requires: `pyjwt[crypto]`. Configuration lives in app.config (CF_ACCESS_*, SCRAPE_*);
+each gate is inert until configured, which is what keeps local dev and CI working.
+"""
+
+# --- Imports ---
+import logging
+from typing import Any, Optional, Sequence
+
+import jwt
+from jwt import PyJWKClient
+
+logger = logging.getLogger(__name__)
+
+
+# --- Issuer endpoints ---
+
+GOOGLE_JWKS_URL = "https://www.googleapis.com/oauth2/v3/certs"
+
+# Google has emitted both spellings over the years and both remain valid on ID tokens.
+GOOGLE_ISSUERS = ("https://accounts.google.com", "accounts.google.com")
+
+# Only asymmetric signing is accepted. Allowing an HMAC algorithm here would let a caller
+# who knows the (public) verification key sign their own tokens with it.
+ALLOWED_ALGORITHMS = ("RS256",)
+
+# Tolerance for clock drift between the issuer and this container, in seconds.
+CLOCK_LEEWAY = 60
+
+
+class TokenError(Exception):
+    """A token was absent, malformed, or failed one of the four checks."""
+
+
+# --- Key fetching ---
+
+# One client per JWKS URL, module-scoped. Each client holds the keys it has fetched and
+# refetches only on seeing an unknown key id, so constructing one per request would turn
+# every request into an outbound HTTPS call and defeat the point of caching.
+_jwks_clients: dict[str, PyJWKClient] = {}
+
+
+def _jwks_client(url: str) -> PyJWKClient:
+    client = _jwks_clients.get(url)
+    if client is None:
+        client = PyJWKClient(url, cache_jwk_set=True, lifespan=3600)
+        _jwks_clients[url] = client
+    return client
+
+
+# --- Core verification ---
+
+def verify_token(
+    token: Optional[str],
+    *,
+    jwks_url: str,
+    issuers: Sequence[str],
+    audience: Optional[str],
+) -> dict[str, Any]:
+    """Verify a signed token and return its claims, or raise TokenError.
+
+    `audience` may be None to skip only the audience check — see the callers for when
+    that is a defensible trade and when it is not. Every other check always runs.
+
+    Raises TokenError for every failure mode, so a caller can turn any of them into one
+    response without distinguishing between them. Deliberate: telling an unauthenticated
+    caller *why* their token was rejected is free reconnaissance.
+    """
+    if not token:
+        raise TokenError("no token presented")
+
+    try:
+        signing_key = _jwks_client(jwks_url).get_signing_key_from_jwt(token)
+        claims = jwt.decode(
+            token,
+            signing_key.key,
+            algorithms=list(ALLOWED_ALGORITHMS),
+            audience=audience,
+            leeway=CLOCK_LEEWAY,
+            options={
+                "require": ["exp"],
+                "verify_exp": True,
+                "verify_aud": audience is not None,
+            },
+        )
+    except jwt.PyJWTError as exc:
+        raise TokenError(f"{type(exc).__name__}: {exc}") from exc
+    except Exception as exc:
+        # Key fetching failures (network, malformed JWKS) land here. Treated the same as a
+        # bad token: fail closed. An issuer we cannot reach is not an issuer we can trust.
+        raise TokenError(f"key retrieval failed: {type(exc).__name__}: {exc}") from exc
+
+    # Issuer is checked here rather than passed to jwt.decode() because Google accepts two
+    # spellings and decode() takes a single value.
+    issuer = claims.get("iss")
+    if issuer not in issuers:
+        raise TokenError(f"unexpected issuer: {issuer!r}")
+
+    return claims
+
+
+# --- Cloudflare Access (guards /admin/*) ---
+
+def cloudflare_access_configured() -> bool:
+    """True when both settings needed to enforce the Access gate are present."""
+    from app.config import settings
+
+    return bool(settings.CF_ACCESS_TEAM_DOMAIN and settings.CF_ACCESS_AUD)
+
+
+def verify_cloudflare_access(token: Optional[str]) -> dict[str, Any]:
+    """Verify a Cloudflare Access token and return its claims.
+
+    Cloudflare mints this after the visitor signs in against the configured identity
+    provider, and attaches it to every request it forwards as `Cf-Access-Jwt-Assertion`.
+    A request arriving at the origin directly carries no such header.
+
+    The audience is the Access application's AUD tag and is required: a Cloudflare team
+    can host several applications, and without this check a token issued for any of them
+    would open the admin surface.
+    """
+    from app.config import settings
+
+    team_domain = settings.CF_ACCESS_TEAM_DOMAIN.strip().rstrip("/")
+    # Accept the team domain with or without a scheme, since the dashboard shows it bare.
+    if "://" in team_domain:
+        team_domain = team_domain.split("://", 1)[1]
+
+    return verify_token(
+        token,
+        jwks_url=f"https://{team_domain}/cdn-cgi/access/certs",
+        issuers=(f"https://{team_domain}",),
+        audience=settings.CF_ACCESS_AUD.strip(),
+    )
+
+
+def access_identity(claims: dict[str, Any]) -> str:
+    """The signed-in person's email, for logging and attribution.
+
+    Access always sets `email` for an interactive login; `sub` is the fallback for a
+    service token, which has no human behind it.
+    """
+    return claims.get("email") or claims.get("sub") or "unknown"
+
+
+# --- Google OIDC (guards POST /api/scrape) ---
+
+def scrape_allowed_service_accounts() -> tuple[str, ...]:
+    """Service-account emails permitted to trigger a scrape.
+
+    Comma-separated in the environment so a second caller is a configuration change
+    rather than a code change.
+    """
+    from app.config import settings
+
+    raw = settings.SCRAPE_ALLOWED_SERVICE_ACCOUNTS or ""
+    return tuple(part.strip() for part in raw.split(",") if part.strip())
+
+
+def scrape_token_configured() -> bool:
+    """True when at least one service account is allowlisted, which enables the gate."""
+    return bool(scrape_allowed_service_accounts())
+
+
+def verify_scrape_token(token: Optional[str]) -> dict[str, Any]:
+    """Verify a Google-issued OIDC token from Cloud Scheduler and return its claims.
+
+    Cloud Scheduler is already configured to attach this token, so nothing changes on the
+    scheduler side — the endpoint simply starts reading what has been arriving all along.
+    Cloud Run cannot enforce it for us: the service must accept unauthenticated requests
+    for the public site to work, so the check has to happen in the application.
+
+    The allowlisted service-account email is the substantive control here. Only a caller
+    holding that identity can obtain a Google-signed token bearing it, and an attacker
+    cannot mint one.
+
+    SCRAPE_OIDC_AUDIENCE is honored when set and skipped when not. Skipping it is a real
+    if narrow weakening: it would permit a token this same service account obtained for a
+    *different* audience to be replayed here. With one scheduler job and one service
+    account there is no such second audience, but set it when the value is known.
+    """
+    from app.config import settings
+
+    audience = (settings.SCRAPE_OIDC_AUDIENCE or "").strip() or None
+    claims = verify_token(
+        token,
+        jwks_url=GOOGLE_JWKS_URL,
+        issuers=GOOGLE_ISSUERS,
+        audience=audience,
+    )
+
+    email = claims.get("email")
+    allowed = scrape_allowed_service_accounts()
+    if email not in allowed:
+        raise TokenError(f"service account not allowlisted: {email!r}")
+
+    return claims
+
+
+def bearer_token(header_value: Optional[str]) -> Optional[str]:
+    """Pull the token out of an `Authorization: Bearer <token>` header."""
+    if not header_value:
+        return None
+    scheme, _, value = header_value.partition(" ")
+    if scheme.lower() != "bearer" or not value.strip():
+        return None
+    return value.strip()
+
+
+# --- Startup reporting ---
+
+def log_enforcement_state() -> None:
+    """Say plainly, once per boot, which gates are live.
+
+    A security control that silently does nothing when misconfigured is worse than one
+    that is absent, because it reads as protection. These lines are how you tell which
+    you have.
+    """
+    if cloudflare_access_configured():
+        logger.info("[tokens] /admin: Cloudflare Access enforced at the origin")
+    else:
+        logger.warning(
+            "[tokens] /admin: Cloudflare Access NOT enforced (CF_ACCESS_TEAM_DOMAIN "
+            "and CF_ACCESS_AUD are not both set). The origin hostname reaches /admin "
+            "without passing Cloudflare."
+        )
+
+    if scrape_token_configured():
+        audience_note = "with audience check" if _scrape_audience_set() else "without audience check"
+        logger.info(
+            f"[tokens] POST /api/scrape: Google OIDC enforced for "
+            f"{len(scrape_allowed_service_accounts())} service account(s), {audience_note}"
+        )
+    else:
+        logger.warning(
+            "[tokens] POST /api/scrape: NOT enforced "
+            "(SCRAPE_ALLOWED_SERVICE_ACCOUNTS is empty). Anyone who knows the origin "
+            "hostname can trigger a full scrape."
+        )
+
+
+def _scrape_audience_set() -> bool:
+    from app.config import settings
+
+    return bool((settings.SCRAPE_OIDC_AUDIENCE or "").strip())

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -12,3 +12,7 @@ apscheduler==3.10.4
 tzlocal==5.2
 python-dotenv==1.0.1
 icalendar==6.1.3
+# Verifies the Cloudflare Access and Google OIDC tokens that gate /admin and
+# POST /api/scrape (see app/tokens.py). The [crypto] extra pulls in `cryptography`,
+# which is what supports the RS256 signatures both issuers use.
+pyjwt[crypto]==2.10.1

--- a/backend/tests/test_origin_gates.py
+++ b/backend/tests/test_origin_gates.py
@@ -1,0 +1,121 @@
+"""
+Tests that the origin gates are actually wired into the app, not merely implemented.
+
+test_tokens.py covers whether a token verifies. This file covers the separate question
+of whether an unverified request is stopped — which is a property of main.py's middleware
+and dependency, and would break silently if either were unregistered or misordered.
+
+Requests go through TestClient without its context manager on purpose: that skips the
+lifespan handler, so no migrations run and no database is needed. Only routes that answer
+before touching the session are exercised here.
+"""
+
+from fastapi.testclient import TestClient
+
+import pytest
+
+from app.config import settings
+from app.main import app
+
+
+TEAM = "triangleshows.cloudflareaccess.com"
+SCHEDULER_SA = "triangle-shows-scrape@triangle-shows.iam.gserviceaccount.com"
+
+
+@pytest.fixture
+def client():
+    return TestClient(app)
+
+
+@pytest.fixture
+def gates_off(monkeypatch):
+    monkeypatch.setattr(settings, "CF_ACCESS_TEAM_DOMAIN", "")
+    monkeypatch.setattr(settings, "CF_ACCESS_AUD", "")
+    monkeypatch.setattr(settings, "SCRAPE_ALLOWED_SERVICE_ACCOUNTS", "")
+
+
+@pytest.fixture
+def gates_on(monkeypatch):
+    monkeypatch.setattr(settings, "CF_ACCESS_TEAM_DOMAIN", TEAM)
+    monkeypatch.setattr(settings, "CF_ACCESS_AUD", "aud123")
+    monkeypatch.setattr(settings, "SCRAPE_ALLOWED_SERVICE_ACCOUNTS", SCHEDULER_SA)
+    monkeypatch.setattr(settings, "SCRAPE_OIDC_AUDIENCE", "")
+
+
+# --- Unconfigured: both gates inert ---
+
+class TestGatesInertWhenUnconfigured:
+    """Deploying this code must change nothing until the settings are populated.
+
+    That is what lets it ship ahead of the Cloudflare and Cloud Scheduler configuration
+    without breaking local dev, CI, or the running site.
+    """
+
+    def test_admin_is_not_403ed_when_unconfigured(self, client, gates_off):
+        # /admin does not exist on main — the admin subsite arrives with PR #36. A 404
+        # proves the middleware passed the request through rather than rejecting it.
+        assert client.get("/admin").status_code == 404
+
+    def test_admin_login_is_not_403ed_when_unconfigured(self, client, gates_off):
+        assert client.get("/admin/login").status_code == 404
+
+
+# --- Configured: /admin gate ---
+
+class TestAdminGate:
+    def test_no_token_is_rejected(self, client, gates_on):
+        assert client.get("/admin").status_code == 403
+
+    def test_the_login_page_is_gated_too(self, client, gates_on):
+        """Reaching a password prompt on the origin is the exposure being closed, so the
+        gate covers /admin/login rather than only the API beneath it."""
+        assert client.get("/admin/login").status_code == 403
+
+    def test_a_nested_admin_path_is_rejected(self, client, gates_on):
+        assert client.get("/admin/api/events").status_code == 403
+
+    def test_a_garbage_token_is_rejected(self, client, gates_on):
+        response = client.get("/admin", headers={"Cf-Access-Jwt-Assertion": "not-a-token"})
+        assert response.status_code == 403
+
+    def test_the_rejection_does_not_explain_itself(self, client, gates_on):
+        """Why a token failed is reconnaissance; the response says only that the surface
+        is Cloudflare-only."""
+        body = client.get("/admin", headers={"Cf-Access-Jwt-Assertion": "x.y.z"}).json()
+        assert "Cloudflare Access" in body["detail"]
+        for leak in ("signature", "expired", "audience", "issuer", "algorithm"):
+            assert leak not in body["detail"].lower()
+
+
+class TestPublicRoutesAreUnaffected:
+    def test_a_normal_route_is_not_gated(self, client, gates_on):
+        """The /admin gate must key on the path prefix only, and let everything else by.
+
+        /openapi.json rather than /api/health: health queries the database for its counts,
+        so it cannot answer in a test that deliberately skips lifespan and runs without
+        Postgres. This route proves the same thing about the middleware.
+        """
+        assert client.get("/openapi.json").status_code == 200
+
+    def test_a_path_merely_containing_admin_is_not_gated(self, client, gates_on):
+        """Guarding on startswith('/admin') and not on a substring match."""
+        assert client.get("/api/venues/not-admin-really").status_code != 403
+
+
+# --- Configured: scrape gate ---
+
+class TestScrapeGate:
+    def test_no_token_is_rejected(self, client, gates_on):
+        assert client.post("/api/scrape").status_code == 403
+
+    def test_a_bearer_token_that_is_not_a_token_is_rejected(self, client, gates_on):
+        response = client.post("/api/scrape", headers={"Authorization": "Bearer garbage"})
+        assert response.status_code == 403
+
+    def test_a_non_bearer_scheme_is_rejected(self, client, gates_on):
+        response = client.post("/api/scrape", headers={"Authorization": "Basic dXNlcjpwdw=="})
+        assert response.status_code == 403
+
+    def test_the_rejection_does_not_explain_itself(self, client, gates_on):
+        body = client.post("/api/scrape").json()
+        assert body["detail"] == "Not authorized to trigger a scrape."

--- a/backend/tests/test_tokens.py
+++ b/backend/tests/test_tokens.py
@@ -1,0 +1,412 @@
+"""
+Tests for app.tokens — the signed-token gates on /admin/* and POST /api/scrape.
+
+These verify the checks that actually stop a forged request, so each one is written to
+fail if the corresponding check is removed:
+
+  * signature   — a token signed by a different key must not verify
+  * expiry      — an expired token must not verify
+  * audience    — a token minted for another application must not verify
+  * issuer      — a token from an unexpected issuer must not verify
+  * algorithm   — an HMAC-signed token must not verify, even signed with the public key
+
+The last one is the subtle one. RS256 verification uses a *public* key, which anyone can
+fetch. If HS256 were also accepted, a caller could sign their own token using that public
+key as the shared secret and it would verify. Restricting algorithms to RS256 is what
+prevents it, and the test below is the only thing that would catch a regression there.
+
+A real RSA keypair is generated once per module and the JWKS lookup is redirected at it,
+so nothing here touches the network. Key generation costs well under a second.
+"""
+
+import base64
+import hashlib
+import hmac
+import json
+import time
+from typing import Optional
+
+import jwt
+import pytest
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric import rsa
+
+from app import tokens
+
+
+# --- Keys and signing helpers ---
+
+@pytest.fixture(scope="module")
+def keypair():
+    """One RSA keypair for the whole module: generation is the slow part."""
+    private = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    return private, private.public_key()
+
+
+@pytest.fixture(scope="module")
+def other_keypair():
+    """A second, unrelated keypair — stands in for an attacker's own key."""
+    private = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    return private, private.public_key()
+
+
+def _pem_private(key) -> bytes:
+    return key.private_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PrivateFormat.PKCS8,
+        encryption_algorithm=serialization.NoEncryption(),
+    )
+
+
+@pytest.fixture(autouse=True)
+def redirect_jwks(monkeypatch, keypair):
+    """Point every JWKS lookup at the module's public key, with no network access.
+
+    Mirrors what PyJWKClient returns: an object exposing the verification key as `.key`.
+    """
+    _, public = keypair
+
+    class _StubKey:
+        key = public
+
+    class _StubClient:
+        def get_signing_key_from_jwt(self, token):
+            return _StubKey()
+
+    monkeypatch.setattr(tokens, "_jwks_client", lambda url: _StubClient())
+
+
+def make_token(
+    private_key,
+    *,
+    issuer: str,
+    audience: Optional[str],
+    email: Optional[str] = None,
+    expires_in: int = 600,
+) -> str:
+    now = int(time.time())
+    claims = {"iss": issuer, "iat": now, "exp": now + expires_in}
+    if audience is not None:
+        claims["aud"] = audience
+    if email is not None:
+        claims["email"] = email
+    return jwt.encode(claims, _pem_private(private_key), algorithm="RS256")
+
+
+def _public_pem(public_key) -> bytes:
+    return public_key.public_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PublicFormat.SubjectPublicKeyInfo,
+    )
+
+
+def _b64(raw: bytes) -> str:
+    return base64.urlsafe_b64encode(raw).rstrip(b"=").decode()
+
+
+def make_hmac_token(secret: bytes, claims: dict) -> str:
+    """Build an HS256 token by hand, signed with `secret`.
+
+    Assembled manually rather than through jwt.encode(), which refuses a PEM public key
+    as an HMAC secret. That guard protects the signing side; this test is about the
+    verifying side, and an attacker writing 10 lines of base64 and hmac is not constrained
+    by our library's opinions.
+    """
+    header = {"alg": "HS256", "typ": "JWT"}
+    signing_input = f"{_b64(json.dumps(header).encode())}.{_b64(json.dumps(claims).encode())}"
+    signature = hmac.new(secret, signing_input.encode(), hashlib.sha256).digest()
+    return f"{signing_input}.{_b64(signature)}"
+
+
+# --- Cloudflare Access gate (/admin/*) ---
+
+TEAM = "triangleshows.cloudflareaccess.com"
+CF_ISSUER = f"https://{TEAM}"
+CF_AUD = "abc123def456"
+
+
+@pytest.fixture
+def cf_configured(monkeypatch):
+    from app.config import settings
+
+    monkeypatch.setattr(settings, "CF_ACCESS_TEAM_DOMAIN", TEAM)
+    monkeypatch.setattr(settings, "CF_ACCESS_AUD", CF_AUD)
+    return settings
+
+
+class TestCloudflareAccessGate:
+    def test_valid_token_is_accepted_and_carries_the_email(self, keypair, cf_configured):
+        private, _ = keypair
+        token = make_token(private, issuer=CF_ISSUER, audience=CF_AUD, email="a@example.org")
+
+        claims = tokens.verify_cloudflare_access(token)
+
+        assert tokens.access_identity(claims) == "a@example.org"
+
+    def test_missing_token_is_rejected(self, cf_configured):
+        with pytest.raises(tokens.TokenError):
+            tokens.verify_cloudflare_access(None)
+
+    def test_garbage_token_is_rejected(self, cf_configured):
+        with pytest.raises(tokens.TokenError):
+            tokens.verify_cloudflare_access("not-a-token")
+
+    def test_token_signed_by_another_key_is_rejected(self, other_keypair, cf_configured):
+        """The core forgery case: right claims, wrong signer."""
+        private, _ = other_keypair
+        token = make_token(private, issuer=CF_ISSUER, audience=CF_AUD, email="a@example.org")
+
+        with pytest.raises(tokens.TokenError):
+            tokens.verify_cloudflare_access(token)
+
+    def test_expired_token_is_rejected(self, keypair, cf_configured):
+        private, _ = keypair
+        token = make_token(
+            private, issuer=CF_ISSUER, audience=CF_AUD, email="a@example.org", expires_in=-3600
+        )
+
+        with pytest.raises(tokens.TokenError):
+            tokens.verify_cloudflare_access(token)
+
+    def test_token_for_another_access_application_is_rejected(self, keypair, cf_configured):
+        """A Cloudflare team can host several apps; each token names the one it is for."""
+        private, _ = keypair
+        token = make_token(
+            private, issuer=CF_ISSUER, audience="some-other-app", email="a@example.org"
+        )
+
+        with pytest.raises(tokens.TokenError):
+            tokens.verify_cloudflare_access(token)
+
+    def test_token_with_no_audience_at_all_is_rejected(self, keypair, cf_configured):
+        private, _ = keypair
+        token = make_token(private, issuer=CF_ISSUER, audience=None, email="a@example.org")
+
+        with pytest.raises(tokens.TokenError):
+            tokens.verify_cloudflare_access(token)
+
+    def test_token_from_an_unexpected_issuer_is_rejected(self, keypair, cf_configured):
+        private, _ = keypair
+        token = make_token(
+            private, issuer="https://attacker.cloudflareaccess.com", audience=CF_AUD
+        )
+
+        with pytest.raises(tokens.TokenError):
+            tokens.verify_cloudflare_access(token)
+
+    def test_hmac_signed_token_is_rejected(self, keypair, cf_configured):
+        """Algorithm confusion: a token signed with the *public* key as an HMAC secret.
+
+        This is the attack the ALLOWED_ALGORITHMS allowlist exists to prevent — the
+        verification key is published at the issuer's JWKS URL, so if HS256 were accepted
+        an attacker could sign their own tokens with it.
+
+        Honest note on what this test proves. It asserts the property (such a token does
+        not verify), not the mechanism. Widening ALLOWED_ALGORITHMS to include HS256 does
+        *not* make it fail, because PyJWT's own prepare_key refuses a PEM or key-object
+        operand as an HMAC secret, on decode as well as encode. Confirmed by mutation.
+        So the allowlist here is defense in depth behind a library guarantee rather than
+        the sole control, and no test in this file can pin it while that guarantee holds.
+        Keep the allowlist regardless: it is explicit, and it is what would still hold if
+        the key handling or the library ever changed underneath.
+        """
+        now = int(time.time())
+        _, public = keypair
+        forged = make_hmac_token(
+            _public_pem(public),
+            {"iss": CF_ISSUER, "aud": CF_AUD, "email": "x@example.org", "iat": now, "exp": now + 600},
+        )
+
+        with pytest.raises(tokens.TokenError):
+            tokens.verify_cloudflare_access(forged)
+
+    def test_team_domain_with_a_scheme_is_tolerated(self, keypair, monkeypatch):
+        """The Cloudflare dashboard shows the domain bare; pasting a URL must still work."""
+        from app.config import settings
+
+        monkeypatch.setattr(settings, "CF_ACCESS_TEAM_DOMAIN", f"https://{TEAM}/")
+        monkeypatch.setattr(settings, "CF_ACCESS_AUD", CF_AUD)
+        private, _ = keypair
+        token = make_token(private, issuer=CF_ISSUER, audience=CF_AUD, email="a@example.org")
+
+        assert tokens.verify_cloudflare_access(token)["email"] == "a@example.org"
+
+
+class TestCloudflareAccessConfiguration:
+    def test_not_configured_when_both_unset(self, monkeypatch):
+        from app.config import settings
+
+        monkeypatch.setattr(settings, "CF_ACCESS_TEAM_DOMAIN", "")
+        monkeypatch.setattr(settings, "CF_ACCESS_AUD", "")
+        assert tokens.cloudflare_access_configured() is False
+
+    def test_not_configured_when_only_the_domain_is_set(self, monkeypatch):
+        """Half-configured must read as off, not as on — otherwise the audience check,
+        which is the one that matters, would be silently skipped."""
+        from app.config import settings
+
+        monkeypatch.setattr(settings, "CF_ACCESS_TEAM_DOMAIN", TEAM)
+        monkeypatch.setattr(settings, "CF_ACCESS_AUD", "")
+        assert tokens.cloudflare_access_configured() is False
+
+    def test_configured_when_both_are_set(self, cf_configured):
+        assert tokens.cloudflare_access_configured() is True
+
+
+# --- Google OIDC gate (POST /api/scrape) ---
+
+SCHEDULER_SA = "triangle-shows-scrape@triangle-shows.iam.gserviceaccount.com"
+SCRAPE_AUD = "https://triangle-shows.net/api/scrape"
+
+
+@pytest.fixture
+def scrape_configured(monkeypatch):
+    from app.config import settings
+
+    monkeypatch.setattr(settings, "SCRAPE_ALLOWED_SERVICE_ACCOUNTS", SCHEDULER_SA)
+    monkeypatch.setattr(settings, "SCRAPE_OIDC_AUDIENCE", SCRAPE_AUD)
+    return settings
+
+
+class TestScrapeGate:
+    def test_valid_token_from_the_allowlisted_account_is_accepted(self, keypair, scrape_configured):
+        private, _ = keypair
+        token = make_token(
+            private, issuer="https://accounts.google.com", audience=SCRAPE_AUD, email=SCHEDULER_SA
+        )
+
+        assert tokens.verify_scrape_token(token)["email"] == SCHEDULER_SA
+
+    def test_the_bare_issuer_spelling_is_accepted(self, keypair, scrape_configured):
+        """Google has emitted both 'accounts.google.com' and the https:// form."""
+        private, _ = keypair
+        token = make_token(
+            private, issuer="accounts.google.com", audience=SCRAPE_AUD, email=SCHEDULER_SA
+        )
+
+        assert tokens.verify_scrape_token(token)["email"] == SCHEDULER_SA
+
+    def test_a_different_service_account_is_rejected(self, keypair, scrape_configured):
+        """A validly signed Google token is not enough — it must name an allowlisted
+        account, or any Google customer could trigger a scrape."""
+        private, _ = keypair
+        token = make_token(
+            private,
+            issuer="https://accounts.google.com",
+            audience=SCRAPE_AUD,
+            email="someone-else@other-project.iam.gserviceaccount.com",
+        )
+
+        with pytest.raises(tokens.TokenError):
+            tokens.verify_scrape_token(token)
+
+    def test_a_token_with_no_email_claim_is_rejected(self, keypair, scrape_configured):
+        private, _ = keypair
+        token = make_token(private, issuer="https://accounts.google.com", audience=SCRAPE_AUD)
+
+        with pytest.raises(tokens.TokenError):
+            tokens.verify_scrape_token(token)
+
+    def test_wrong_audience_is_rejected_when_the_audience_is_configured(self, keypair, scrape_configured):
+        private, _ = keypair
+        token = make_token(
+            private,
+            issuer="https://accounts.google.com",
+            audience="https://example.org/something-else",
+            email=SCHEDULER_SA,
+        )
+
+        with pytest.raises(tokens.TokenError):
+            tokens.verify_scrape_token(token)
+
+    def test_audience_is_not_checked_when_left_unconfigured(self, keypair, monkeypatch):
+        """Documented trade in verify_scrape_token: the service-account check still
+        applies, so this stays useful, but set the audience when the value is known."""
+        from app.config import settings
+
+        monkeypatch.setattr(settings, "SCRAPE_ALLOWED_SERVICE_ACCOUNTS", SCHEDULER_SA)
+        monkeypatch.setattr(settings, "SCRAPE_OIDC_AUDIENCE", "")
+        private, _ = keypair
+        token = make_token(
+            private,
+            issuer="https://accounts.google.com",
+            audience="whatever-audience",
+            email=SCHEDULER_SA,
+        )
+
+        assert tokens.verify_scrape_token(token)["email"] == SCHEDULER_SA
+
+    def test_expired_token_is_rejected(self, keypair, scrape_configured):
+        private, _ = keypair
+        token = make_token(
+            private,
+            issuer="https://accounts.google.com",
+            audience=SCRAPE_AUD,
+            email=SCHEDULER_SA,
+            expires_in=-60,
+        )
+
+        with pytest.raises(tokens.TokenError):
+            tokens.verify_scrape_token(token)
+
+    def test_token_signed_by_another_key_is_rejected(self, other_keypair, scrape_configured):
+        private, _ = other_keypair
+        token = make_token(
+            private, issuer="https://accounts.google.com", audience=SCRAPE_AUD, email=SCHEDULER_SA
+        )
+
+        with pytest.raises(tokens.TokenError):
+            tokens.verify_scrape_token(token)
+
+
+class TestScrapeConfiguration:
+    def test_not_configured_when_the_allowlist_is_empty(self, monkeypatch):
+        from app.config import settings
+
+        monkeypatch.setattr(settings, "SCRAPE_ALLOWED_SERVICE_ACCOUNTS", "")
+        assert tokens.scrape_token_configured() is False
+        assert tokens.scrape_allowed_service_accounts() == ()
+
+    def test_multiple_accounts_are_parsed_and_trimmed(self, monkeypatch):
+        """Granting a second caller is a config change, not a code change."""
+        from app.config import settings
+
+        monkeypatch.setattr(
+            settings, "SCRAPE_ALLOWED_SERVICE_ACCOUNTS", f" {SCHEDULER_SA} , other@x.iam.gserviceaccount.com "
+        )
+
+        assert tokens.scrape_allowed_service_accounts() == (
+            SCHEDULER_SA,
+            "other@x.iam.gserviceaccount.com",
+        )
+        assert tokens.scrape_token_configured() is True
+
+    def test_blank_entries_are_ignored(self, monkeypatch):
+        """A trailing comma must not allowlist an empty email, which would then match a
+        token carrying no email claim."""
+        from app.config import settings
+
+        monkeypatch.setattr(settings, "SCRAPE_ALLOWED_SERVICE_ACCOUNTS", f"{SCHEDULER_SA},,")
+        assert tokens.scrape_allowed_service_accounts() == (SCHEDULER_SA,)
+
+
+# --- Authorization header parsing ---
+
+class TestBearerToken:
+    def test_reads_a_bearer_token(self):
+        assert tokens.bearer_token("Bearer abc.def.ghi") == "abc.def.ghi"
+
+    def test_scheme_is_case_insensitive(self):
+        assert tokens.bearer_token("bearer abc.def.ghi") == "abc.def.ghi"
+
+    def test_missing_header_yields_none(self):
+        assert tokens.bearer_token(None) is None
+
+    def test_empty_header_yields_none(self):
+        assert tokens.bearer_token("") is None
+
+    def test_another_scheme_yields_none(self):
+        assert tokens.bearer_token("Basic dXNlcjpwYXNz") is None
+
+    def test_bearer_with_no_value_yields_none(self):
+        assert tokens.bearer_token("Bearer ") is None

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -84,6 +84,20 @@ steps:
       - --min-instances=0
       - --max-instances=2
       - --timeout=300
+      # Origin gates (backend/app/tokens.py) are OFF until these env vars are set, and
+      # the boot log says which are live on every start. None of these values is a
+      # secret — a team domain, an application id, and a service-account email — so they
+      # belong here rather than in Secret Manager.
+      #
+      # Turn them on by extending the line below in place. gcloud rejects
+      # --set-env-vars alongside --update-env-vars, so append rather than adding a line:
+      #
+      #   - --set-env-vars=APP_ENV=production,ENABLE_SCHEDULER=false,LOG_LEVEL=INFO,CF_ACCESS_TEAM_DOMAIN=<team>.cloudflareaccess.com,CF_ACCESS_AUD=<aud-tag>,SCRAPE_ALLOWED_SERVICE_ACCOUNTS=<scheduler-sa-email>,SCRAPE_OIDC_AUDIENCE=<audience-on-the-scheduler-job>
+      #
+      # Enable the scrape gate first: its token already arrives, so it can be verified
+      # with nothing else in place. The /admin gate needs a Cloudflare Access application
+      # to exist first, or /admin becomes unreachable — which is safe (it fails closed)
+      # but not useful.
       - --set-env-vars=APP_ENV=production,ENABLE_SCHEDULER=false,LOG_LEVEL=INFO
       - --update-secrets=DATABASE_URL=triangle-shows-db-url:latest
       - --update-secrets=TICKETMASTER_API_KEY=triangle-shows-tm-api-key:latest


### PR DESCRIPTION
Closes the origin bypass that [#53](https://github.com/triangle-shows/triangle-shows/pull/53) only documented.

## The problem

The Cloud Run service sets no `--ingress` restriction, so it defaults to `ingress=all` and its `.run.app` hostnames reach the app **directly, skipping Cloudflare** — and therefore skipping any Cloudflare Access policy on `/admin`. Verified: the origin returns `200` on `/api/health` with Cloudflare out of the path.

Redacting the hostname helps, but isn't a control — it's derived from the service name (same as the public repo) and project number, not from anything secret. The durable fix is for the app to require proof that a request came through a trusted issuer.

## How it works

`backend/app/tokens.py` verifies both issuers through one path: fetch the issuer's published public keys, then check **signature, expiry, audience, issuer**. Verification is local arithmetic against cached keys — no callback to the issuer on the request path.

| Route | Issuer | Header | Identifies |
|---|---|---|---|
| `/admin/*` | Cloudflare Access | `Cf-Access-Jwt-Assertion` | a person (email) |
| `POST /api/scrape` | Google | `Authorization: Bearer …` | a service account |

**The scrape token already arrives.** Cloud Scheduler is configured with OIDC, so nothing changes on the scheduler side — the endpoint just starts reading what's been sent all along. Cloud Run can't enforce it, because the service must accept unauthenticated requests for the public site to work.

**`/admin` is guarded by path in middleware**, not inside the admin router. The admin subsite arrives with #36, so a path check puts the gate in front of those routes from the moment they land — the admin surface cannot reach production without it. Until then it's inert (`/admin` merely 404s), and the two orderings don't conflict. The login page is gated too: reaching a password prompt on the origin is the exposure being closed.

## Safe to ship before it's configured

Both gates are **inert until their settings are populated**, so this merges and deploys without touching local dev, CI, or the running site. You then turn them on with env vars — `cloudbuild.yaml` carries the exact line, and none of the values is a secret (a team domain, an application id, a service-account email).

Because a security control that silently does nothing is worse than an absent one, `log_enforcement_state()` states on every boot which gates are live *and what's exposed while they aren't*.

Recommended order: **scrape gate first** — its token already exists, so it needs nothing else. The `/admin` gate needs a Cloudflare Access application first, or `/admin` becomes unreachable (safe, since it fails closed, but not useful).

## Testing

**130 passing, no database, no network.** A real RSA keypair is generated per module and the key lookup is redirected at it. 31 unit tests on verification, 13 on the wiring — the latter because unit-testing `tokens.py` says nothing about whether the middleware is actually registered.

**Mutation-checked.** Each of these fails at least one test: removing the issuer check, disabling the audience check, dropping the service-account allowlist, disabling expiry, bypassing the `/admin` middleware, removing the scrape dependency.

**One honest exception,** recorded in the test's own docstring: the HMAC-forgery test passes even with `HS256` added to `ALLOWED_ALGORITHMS`, because PyJWT's `prepare_key` refuses a PEM or key-object operand as an HMAC secret on decode as well as encode. The property holds, but the allowlist is defense in depth behind a library guarantee rather than the sole control, and no test here can pin it while that holds. Worth keeping anyway — it's explicit, and it's what survives a change of library or key handling.

## Notes

- Rejections are uniform: every failure mode becomes one 403 whose body never says which check failed. Why a token was rejected is free reconnaissance.
- **Break-glass:** with the `/admin` gate on, an Access outage locks you out too. Clear `CF_ACCESS_AUD` and redeploy. Deliberately not a runtime bypass flag — that would be a second door.
- Once this is configured, the origin hostname stops being load-bearing, so rotating the Cloud Run service name becomes optional housekeeping rather than a fix.
- Adds one dependency, `pyjwt[crypto]==2.10.1`.

Does not touch `docs/ARCHITECTURE.md`, to avoid conflicting with #53. Docs follow once that merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)