### PR TITLE
Stop allowing credentials on cross-origin requests; unpin a status in the gate test

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -114,10 +114,30 @@ app = FastAPI(
 )
 
 # CORS
+#
+# allow_credentials is False, and that single flag is what makes the "*" safe. The exact
+# mechanics, measured rather than assumed (see tests/test_cors.py):
+#
+#   Starlette replaces the "*" with the caller's own Origin whenever the request carries a
+#   Cookie header. That happens either way and is not the problem. The problem was pairing
+#   it with allow_credentials=True, which adds Access-Control-Allow-Credentials: true —
+#   the header a browser requires before it will hand a credentialed cross-origin response
+#   back to the page that asked for it. Origin echo plus that header is what let a hostile
+#   page read authenticated responses, leaving the admin cookie's samesite="lax" as the
+#   only control. Without the header the echo is inert: the browser discards the response.
+#
+# Nothing here needs cross-origin credentials, or cross-origin requests of any kind.
+# frontend/js/config.js sets API_BASE to window.location.origin and the admin UI fetches
+# relative paths, so every in-app request is same-origin, where CORS does not apply.
+#
+# Keeping "*" rather than an allowlist is deliberate: the read API is public, so leaving it
+# usable from any page costs nothing once credentials are off. Narrowing allow_origins to
+# the real site origins would stop third parties consuming it from a browser — a product
+# decision, not a security one.
 app.add_middleware(
     CORSMiddleware,
     allow_origins=["*"],
-    allow_credentials=True,
+    allow_credentials=False,
     allow_methods=["*"],
     allow_headers=["*"],
 )

--- a/backend/tests/test_cors.py
+++ b/backend/tests/test_cors.py
@@ -1,0 +1,70 @@
+"""
+Tests for the CORS configuration in main.py — review item #11.
+
+The setting that matters is allow_credentials. `allow_origins=["*"]` alongside
+allow_credentials=True let a hostile page read authenticated responses; with credentials
+off, the same "*" is harmless.
+
+Written against measured behavior rather than assumption, because the mechanism is not the
+obvious one. Starlette substitutes the caller's Origin for the "*" whenever the request
+carries a Cookie header, and it does that regardless of allow_credentials — so the origin
+echo is not the vulnerability and removing it is not the fix. What a browser actually
+requires before exposing a credentialed cross-origin response is the
+Access-Control-Allow-Credentials header, and that is what is now absent.
+
+These assertions therefore pin the header that carries the security property, and
+deliberately do not pin the echo, which is Starlette's business and may change.
+"""
+
+from fastapi.testclient import TestClient
+
+import pytest
+
+from app.main import app
+
+
+HOSTILE = "https://evil.example"
+
+
+@pytest.fixture
+def client():
+    return TestClient(app)
+
+
+class TestCredentialsAreNeverAllowed:
+    """The load-bearing assertion. If this fails, a cross-origin page can read
+    authenticated responses and review item #11 has regressed."""
+
+    def test_no_credentials_header_on_a_plain_cross_origin_request(self, client):
+        response = client.get("/openapi.json", headers={"Origin": HOSTILE})
+        assert response.headers.get("access-control-allow-credentials") is None
+
+    def test_no_credentials_header_when_the_request_carries_a_cookie(self, client):
+        """The case that mattered: a hostile page causing the victim's browser to send its
+        session cookie. The response must not be readable by that page."""
+        response = client.get(
+            "/openapi.json",
+            headers={"Origin": HOSTILE, "Cookie": "ts_admin=stolen-or-ambient"},
+        )
+        assert response.headers.get("access-control-allow-credentials") is None
+
+    def test_no_credentials_header_on_a_preflight(self, client):
+        response = client.options(
+            "/api/events",
+            headers={
+                "Origin": HOSTILE,
+                "Access-Control-Request-Method": "POST",
+                "Access-Control-Request-Headers": "content-type",
+            },
+        )
+        assert response.headers.get("access-control-allow-credentials") is None
+
+
+class TestThePublicApiStaysBrowserConsumable:
+    """The other half of the decision: dropping credentials rather than narrowing origins
+    keeps the public read API usable from any page. If someone later swaps to an origin
+    allowlist, these are the tests that should be updated on purpose rather than deleted."""
+
+    def test_a_cross_origin_read_is_permitted(self, client):
+        response = client.get("/openapi.json", headers={"Origin": HOSTILE})
+        assert response.headers.get("access-control-allow-origin") is not None

--- a/backend/tests/test_origin_gates.py
+++ b/backend/tests/test_origin_gates.py
@@ -51,13 +51,17 @@ class TestGatesInertWhenUnconfigured:
     without breaking local dev, CI, or the running site.
     """
 
+    # Asserted as "not 403" rather than as a specific status on purpose. What matters is
+    # that the middleware passed the request through; what it then meets is not this
+    # test's business. Pinning an exact code here once meant pinning 404 — the code you
+    # get when /admin does not exist — which broke as soon as PR #36 added the admin
+    # subsite and /admin started answering 303 and 200.
+
     def test_admin_is_not_403ed_when_unconfigured(self, client, gates_off):
-        # /admin does not exist on main — the admin subsite arrives with PR #36. A 404
-        # proves the middleware passed the request through rather than rejecting it.
-        assert client.get("/admin").status_code == 404
+        assert client.get("/admin", follow_redirects=False).status_code != 403
 
     def test_admin_login_is_not_403ed_when_unconfigured(self, client, gates_off):
-        assert client.get("/admin/login").status_code == 404
+        assert client.get("/admin/login", follow_redirects=False).status_code != 403
 
 
 # --- Configured: /admin gate ---


### PR DESCRIPTION
Two small main-only changes, independent of each other and of #36. Split out of the #36 review cluster because both live in files that exist on `main`.

## Review item #11 — `allow_origins=["*"]` with `allow_credentials=True`

The mechanism turned out not to be the one the review assumed, so here it is measured rather than inferred:

| | `Access-Control-Allow-Origin` | `Access-Control-Allow-Credentials` |
|---|---|---|
| **before**, no cookie | `*` | `true` |
| **before**, with cookie | `https://evil.example` | `true` |
| **after**, no cookie | `*` | *absent* |
| **after**, with cookie | `https://evil.example` | *absent* |

Starlette substitutes the caller's Origin for the `*` whenever the request carries a `Cookie` header — **regardless of `allow_credentials`**. So the origin echo isn't the vulnerability and removing it isn't the fix. What a browser requires before handing a credentialed cross-origin response back to the page that requested it is `Access-Control-Allow-Credentials`, and that's what `allow_credentials=True` was supplying. Echo *plus* that header is what left the admin cookie's `samesite="lax"` carrying the whole load.

**Dropped credentials rather than narrowing origins.** Nothing in the app makes a cross-origin request at all — `frontend/js/config.js` sets `API_BASE = window.location.origin`, and the admin UI fetches relative paths, so every in-app request is same-origin, where CORS doesn't apply. The read API is public, so leaving it browser-consumable costs nothing once credentials are off.

Narrowing `allow_origins` to the real site origins would stop third parties consuming the API from a browser. That's a product decision about who may use the API, not a security fix — worth making deliberately rather than as a side effect. Relevant given you were just asking about granting API access.

`tests/test_cors.py` pins the credentials header specifically and deliberately *not* the echo, which is Starlette's business and may change. Restoring `allow_credentials=True` fails all three assertions.

## A defect in my own #54 test

`test_origin_gates.py` asserted `/admin` returns **404** when the gate is unconfigured. That pinned the status you get when `/admin` *doesn't exist*, rather than the property under test. #36 adds the admin subsite, so `/admin` starts answering 303 and `/admin/login` 200 — and both assertions break.

Now asserted as **not 403**, which is what "the middleware passed the request through" actually means.

Worth noting how this surfaced: **neither branch shows it alone.** It passes on `main` and it passes on #36 in isolation; it only fails once they combine. I found it rehearsing the #36 rebase in a throwaway clone, not in CI. Fixing it here rather than on #36 keeps that PR free of unrelated churn, and it needs to land first or #36's CI goes red.

134 tests passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)