### PR TITLE
Resolve review items 4, 5, 6, 9 and 12

### DIFF
--- a/backend/alembic/versions/0004_add_series_overrides.py
+++ b/backend/alembic/versions/0004_add_series_overrides.py
@@ -27,7 +27,11 @@ def upgrade() -> None:
         sa.Column('note', sa.String(500), nullable=True),
         sa.Column('created_at', sa.DateTime(), nullable=False),
         sa.Column('updated_at', sa.DateTime(), nullable=False),
-        sa.ForeignKeyConstraint(['venue_id'], ['venues.id']),
+        # ON DELETE CASCADE so retiring a venue cannot be blocked by its series rules.
+        # Edited into this migration rather than added by a later one: 0003-0005 have never
+        # been applied anywhere (both main and prod sit at 0002), so there is no deployed
+        # constraint to alter.
+        sa.ForeignKeyConstraint(['venue_id'], ['venues.id'], ondelete='CASCADE'),
         sa.PrimaryKeyConstraint('id'),
         sa.UniqueConstraint('venue_id', 'normalized_name', name='uq_series_override_key'),
     )

--- a/backend/app/api/admin.py
+++ b/backend/app/api/admin.py
@@ -106,7 +106,16 @@ async def login_page() -> HTMLResponse:
 async def login_submit(body: LoginBody):
     # compare_digest guards against timing attacks; also fails closed when no
     # password is configured (compare against "" would otherwise accept "").
-    if _admin_enabled() and secrets.compare_digest(body.password, settings.ADMIN_PASSWORD):
+    #
+    # Both operands are encoded to bytes because compare_digest rejects a str containing
+    # any non-ASCII character, raising TypeError rather than returning False. Passed
+    # strings directly, a password with an accented character turned a wrong-password
+    # attempt into a 500 instead of a clean 401 — and, since the message differs, told the
+    # caller something about the configured password. UTF-8 on both sides compares the
+    # same bytes the client sent.
+    if _admin_enabled() and secrets.compare_digest(
+        body.password.encode("utf-8"), settings.ADMIN_PASSWORD.encode("utf-8")
+    ):
         response = JSONResponse({"ok": True})
         _issue_cookie(response)
         return response

--- a/backend/app/api/events.py
+++ b/backend/app/api/events.py
@@ -28,12 +28,28 @@ router = APIRouter(prefix="/api/events", tags=["events"])
 # --- Helpers ---
 
 def _completeness(event: Event) -> tuple:
-    """Rank two listings of the same show: richer record wins, then most recently scraped.
+    """Rank two listings of the same show, most authoritative key first.
+
+    Classification comes before metadata richness, because this guard runs before any
+    live-music filtering and so decides which row's verdict the calendar sees. Two rows for
+    one show can classify differently — most plausibly when an admin has hand-set one of
+    them, or when the dedup key and the recurrence key normalize a name differently. Ranking
+    only on field counts let the richer row win and silently discard the other's verdict,
+    which could drop a real show off the default calendar.
+
+    1. is_manual_override — an admin looked at this row and decided; that outranks anything
+       computed.
+    2. is_live_music — between two automatic verdicts, prefer the visible one. Consistent
+       with the feature's chosen failure direction: showing something that should have been
+       hidden is recoverable, hiding a real show is what users never see.
+    3. field count, then recency, then id — the original ordering, now as tiebreakers.
 
     Every component is total and the id breaks the last tie, so the winner does not depend
     on the order the database returned rows in.
     """
     return (
+        bool(getattr(event, "is_manual_override", False)),
+        bool(event.is_live_music),
         bool(event.image_url) + bool(event.ticket_url) + (event.price_min is not None),
         event.updated_at or datetime.min,
         event.id,
@@ -223,21 +239,24 @@ async def get_event(
     return _event_to_response(event)
 
 
-@router.get("")
-async def list_events(
-    start: Optional[str] = Query(None),
-    end: Optional[str] = Query(None),
-    search: Optional[str] = Query(None),
-    genre: Optional[str] = Query(None),
-    status: Optional[str] = Query(None),
-    page: int = Query(1, ge=1),
-    per_page: int = Query(50, ge=1, le=200),
-    session: AsyncSession = Depends(get_session),
-) -> EventListResponse:
-    """List events with filters and pagination."""
-    query = select(Event).options(joinedload(Event.venue)).order_by(Event.date)
-    count_query = select(func.count(Event.id))
+def _list_conditions(
+    *,
+    start: Optional[str] = None,
+    end: Optional[str] = None,
+    search: Optional[str] = None,
+    genre: Optional[str] = None,
+    status: Optional[str] = None,
+    include_non_music: bool = False,
+) -> list:
+    """Build the WHERE clauses for the events list, as data.
 
+    Split out of list_events so the filtering can be tested without a database. Declaring
+    the query parameter and then failing to apply it is a silent bug — the endpoint keeps
+    answering, just with the wrong rows — and an endpoint-level test cannot catch it
+    without Postgres.
+
+    Malformed dates are ignored rather than rejected, matching the previous behavior.
+    """
     conditions = []
 
     if start:
@@ -260,6 +279,45 @@ async def list_events(
         conditions.append(Event.genre.ilike(f"%{genre}%"))
     if status:
         conditions.append(Event.status == status)
+    # Default to live music only, so this endpoint stops being the one place the filter does
+    # not apply. /feeds/events.ics already behaves this way; the FullCalendar endpoint
+    # deliberately still returns everything, because filters.js toggles visibility in the
+    # browser without refetching, and filtering there server-side would empty the calendar
+    # when the toggle is switched on.
+    if not include_non_music:
+        conditions.append(Event.is_live_music.is_(True))
+
+    return conditions
+
+
+@router.get("")
+async def list_events(
+    start: Optional[str] = Query(None),
+    end: Optional[str] = Query(None),
+    search: Optional[str] = Query(None),
+    genre: Optional[str] = Query(None),
+    status: Optional[str] = Query(None),
+    include_non_music: bool = Query(
+        False,
+        description="Include non-live-music events (karaoke, trivia, theme nights, etc.). "
+                    "Off by default, matching /feeds/events.ics and the on-site calendar.",
+    ),
+    page: int = Query(1, ge=1),
+    per_page: int = Query(50, ge=1, le=200),
+    session: AsyncSession = Depends(get_session),
+) -> EventListResponse:
+    """List events with filters and pagination."""
+    query = select(Event).options(joinedload(Event.venue)).order_by(Event.date)
+    count_query = select(func.count(Event.id))
+
+    conditions = _list_conditions(
+        start=start,
+        end=end,
+        search=search,
+        genre=genre,
+        status=status,
+        include_non_music=include_non_music,
+    )
 
     if conditions:
         query = query.where(and_(*conditions))

--- a/backend/app/classifier.py
+++ b/backend/app/classifier.py
@@ -351,7 +351,8 @@ def classification_updates(
     mapping — a series-level rule that overrides automatic classification for every
     event whose (venue, name) key matches.
     exempt_venue_ids: optional set of venue ids assumed to be entirely live music
-    (see ALWAYS_LIVE_VENUE_SLUGS, e.g. DPAC) — forced live, skipping auto/series.
+    (see ALWAYS_LIVE_VENUE_SLUGS, e.g. DPAC) — forced live unless a series override says
+    otherwise, so the exemption is a default rather than an absolute.
 
     Returns {event_id: (is_live_music, reason)} for every event EXCEPT those with
     is_manual_override=True, which are omitted so a re-scrape never overwrites a
@@ -359,8 +360,8 @@ def classification_updates(
 
     Precedence, most specific first:
       1. per-event manual override  -> omitted here (caller leaves the row untouched)
-      2. always-live venue exemption -> forced live music
-      3. series override            -> forces the series value
+      2. series override            -> forces the series value
+      3. always-live venue exemption -> forced live music
       4. automatic classification   -> recurrence / keyword / genre
     This is the pure decision function behind ScrapeManager.reclassify_all().
     """
@@ -373,14 +374,19 @@ def classification_updates(
     for ev in events:
         if getattr(ev, "is_manual_override", False):
             continue  # per-event override wins; leave the hand-set value in place
-        if ev.venue_id in exempt_venue_ids:
-            updates[ev.id] = (True, "venue: always live music")
-            continue
+
+        # Series override is consulted before the venue exemption, so the exemption acts
+        # as a default rather than as an absolute. The other order made an exempt venue's
+        # series impossible to mark non-live through the series UI, on every future
+        # instance, forever — and DPAC, the only exempt venue, hosts Broadway and comedy
+        # alongside music, which is exactly the case the series UI is for.
         key = (ev.venue_id, normalize_series_name(ev.name))
         if key in series_overrides:
             is_live, _note = series_overrides[key]
             label = "live music" if is_live else "non-live"
             updates[ev.id] = (is_live, f"series override: {label}")
+        elif ev.venue_id in exempt_venue_ids:
+            updates[ev.id] = (True, "venue: always live music")
         else:
             updates[ev.id] = classified[ev.id]
     return updates

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -56,6 +56,14 @@ class Venue(Base):
 
     events: Mapped[list["Event"]] = relationship(back_populates="venue", cascade="all, delete-orphan")
     scrape_logs: Mapped[list["ScrapeLog"]] = relationship(back_populates="venue", cascade="all, delete-orphan")
+    # Retiring a venue must not be blocked by its series rules. seed_venues() deletes
+    # venues listed in REMOVED_SLUGS on every startup via session.delete(), which cascades
+    # only through relationships SQLAlchemy knows about — so without this, the first
+    # retirement of a venue holding a series override raises ForeignKeyViolation inside the
+    # lifespan handler and the container never becomes healthy.
+    series_overrides: Mapped[list["SeriesOverride"]] = relationship(
+        back_populates="venue", cascade="all, delete-orphan"
+    )
 
 
 class Event(Base):
@@ -140,13 +148,20 @@ class SeriesOverride(Base):
     __tablename__ = "series_overrides"
 
     id: Mapped[int] = mapped_column(primary_key=True)
-    venue_id: Mapped[int] = mapped_column(ForeignKey("venues.id"), index=True)
+    # ondelete="CASCADE" as well as the ORM relationship on Venue: the relationship covers
+    # session.delete(), the database constraint covers everything else (a manual DELETE, a
+    # future bulk query that bypasses the ORM's cascade).
+    venue_id: Mapped[int] = mapped_column(
+        ForeignKey("venues.id", ondelete="CASCADE"), index=True
+    )
     normalized_name: Mapped[str] = mapped_column(String(200))  # matches app.classifier.normalize_series_name(event.name)
     display_name: Mapped[Optional[str]] = mapped_column(String(500), nullable=True)  # a readable example name for the admin UI
     is_live_music: Mapped[bool] = mapped_column(Boolean)  # the value forced onto every event in the series
     note: Mapped[Optional[str]] = mapped_column(String(500), nullable=True)  # optional admin note explaining the decision
     created_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow)
     updated_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow, onupdate=datetime.utcnow)
+
+    venue: Mapped["Venue"] = relationship(back_populates="series_overrides")
 
     # One rule per (venue, series name); the admin endpoint upserts on this key.
     __table_args__ = (

--- a/backend/tests/test_admin_login.py
+++ b/backend/tests/test_admin_login.py
@@ -1,0 +1,106 @@
+"""
+Tests for the admin login check — review item #12.
+
+secrets.compare_digest raises TypeError when handed a str containing any non-ASCII
+character, rather than returning False. So a password with an accented character turned a
+wrong-password attempt into a 500. Two problems with that: the endpoint stops failing
+cleanly, and because the response differs from the normal 401 it tells an unauthenticated
+caller something about the configured password.
+
+No database is touched — the login route only compares a string and sets a cookie.
+"""
+
+from fastapi.testclient import TestClient
+
+import pytest
+
+from app.config import settings
+from app.main import app
+
+
+ASCII_PASSWORD = "s3cret-ascii-only"
+ACCENTED_PASSWORD = "contraseña-café"
+
+
+@pytest.fixture
+def client():
+    return TestClient(app)
+
+
+@pytest.fixture(autouse=True)
+def gates_off(monkeypatch):
+    """The origin gate would 403 /admin before the login handler ever ran."""
+    monkeypatch.setattr(settings, "CF_ACCESS_TEAM_DOMAIN", "")
+    monkeypatch.setattr(settings, "CF_ACCESS_AUD", "")
+
+
+def _configure(monkeypatch, password):
+    monkeypatch.setattr(settings, "ADMIN_PASSWORD", password)
+    monkeypatch.setattr(settings, "SESSION_SECRET", "test-signing-key")
+
+
+class TestNonAsciiPasswords:
+    def test_a_wrong_guess_against_an_accented_password_is_a_clean_401(
+        self, client, monkeypatch
+    ):
+        """The regression: this raised TypeError inside compare_digest and returned 500."""
+        _configure(monkeypatch, ACCENTED_PASSWORD)
+
+        response = client.post("/admin/login", json={"password": "wrong"})
+
+        assert response.status_code == 401
+        assert response.json()["ok"] is False
+
+    def test_an_accented_guess_against_an_ascii_password_is_a_clean_401(
+        self, client, monkeypatch
+    ):
+        """The other direction — the non-ASCII operand can arrive from the client."""
+        _configure(monkeypatch, ASCII_PASSWORD)
+
+        response = client.post("/admin/login", json={"password": ACCENTED_PASSWORD})
+
+        assert response.status_code == 401
+
+    def test_the_correct_accented_password_still_authenticates(self, client, monkeypatch):
+        """Encoding both sides must not break the passwords it was meant to support."""
+        _configure(monkeypatch, ACCENTED_PASSWORD)
+
+        response = client.post("/admin/login", json={"password": ACCENTED_PASSWORD})
+
+        assert response.status_code == 200
+        assert response.json()["ok"] is True
+
+    def test_wrong_and_right_are_indistinguishable_apart_from_the_verdict(
+        self, client, monkeypatch
+    ):
+        """The reason a 500 mattered: a differing failure mode is an oracle. Both a wrong
+        ASCII guess and a wrong non-ASCII guess must produce the same 401 shape."""
+        _configure(monkeypatch, ACCENTED_PASSWORD)
+
+        ascii_guess = client.post("/admin/login", json={"password": "wrong"})
+        unicode_guess = client.post("/admin/login", json={"password": "wröng"})
+
+        assert ascii_guess.status_code == unicode_guess.status_code == 401
+        assert ascii_guess.json() == unicode_guess.json()
+
+
+class TestOrdinaryCases:
+    def test_the_correct_ascii_password_authenticates(self, client, monkeypatch):
+        _configure(monkeypatch, ASCII_PASSWORD)
+
+        response = client.post("/admin/login", json={"password": ASCII_PASSWORD})
+
+        assert response.status_code == 200
+
+    def test_an_empty_guess_is_rejected(self, client, monkeypatch):
+        _configure(monkeypatch, ASCII_PASSWORD)
+
+        assert client.post("/admin/login", json={"password": ""}).status_code == 401
+
+    def test_login_is_disabled_when_no_password_is_configured(self, client, monkeypatch):
+        """Fails closed. Notably an empty guess must not match an empty configured
+        password — _admin_enabled() is what prevents compare_digest("", "") succeeding."""
+        _configure(monkeypatch, "")
+
+        assert client.post("/admin/login", json={"password": ""}).status_code == 401
+        assert client.post("/admin/login", json={"password": "anything"}).status_code == 401

--- a/backend/tests/test_classifier.py
+++ b/backend/tests/test_classifier.py
@@ -385,16 +385,60 @@ def test_series_key_matches_dated_name_variants():
 
 # --- always-live venue exemption (e.g. DPAC) ---
 
-def test_exempt_venue_forced_live_over_auto_and_series():
-    # Venue 9 is exempt. Even a recurring, keyword-y name at that venue stays live;
-    # a series override on it is also ignored (venue is out of the filter pass).
+def test_exempt_venue_forced_live_over_automatic_classification():
+    # Venue 9 is exempt, so a recurring, keyword-y name there stays live music instead of
+    # being flagged as a series.
+    events = [FakeEvent(i, 9, "Karaoke Night", d) for i, d in enumerate(_weekly(4))]
+    updates = classification_updates(events, exempt_venue_ids={9})
+    for eid in range(4):
+        assert updates[eid] == (True, "venue: always live music")
+
+
+def test_series_override_beats_the_venue_exemption():
+    """Review item #6. This assertion is the reverse of what it was.
+
+    The exemption used to return before series overrides were consulted, which made an
+    exempt venue's series impossible to mark non-live through the series UI — on every
+    future instance, permanently. DPAC is the only exempt venue and it hosts Broadway and
+    comedy alongside music, so that is precisely the case the series UI exists for. The
+    exemption is now a default that a deliberate series decision can override.
+    """
     events = [FakeEvent(i, 9, "Karaoke Night", d) for i, d in enumerate(_weekly(4))]
     overrides = {_series_key(9, "Karaoke Night"): (False, None)}
+
     updates = classification_updates(
         events, series_overrides=overrides, exempt_venue_ids={9}
     )
+
     for eid in range(4):
-        assert updates[eid] == (True, "venue: always live music")
+        assert updates[eid] == (False, "series override: non-live")
+
+
+def test_a_series_override_can_also_keep_an_exempt_venues_series_live():
+    """The override wins in both directions — it is not a special case for hiding."""
+    events = [FakeEvent(i, 9, "Karaoke Night", d) for i, d in enumerate(_weekly(4))]
+    overrides = {_series_key(9, "Karaoke Night"): (True, None)}
+
+    updates = classification_updates(
+        events, series_overrides=overrides, exempt_venue_ids={9}
+    )
+
+    for eid in range(4):
+        assert updates[eid] == (True, "series override: live music")
+
+
+def test_an_unrelated_series_at_an_exempt_venue_still_gets_the_exemption():
+    """Only the overridden series changes; the rest of the venue keeps its default."""
+    events = [FakeEvent(i, 9, "Karaoke Night", d) for i, d in enumerate(_weekly(4))]
+    events += [FakeEvent(100 + i, 9, "Trivia Night", d) for i, d in enumerate(_weekly(4))]
+    overrides = {_series_key(9, "Karaoke Night"): (False, None)}
+
+    updates = classification_updates(
+        events, series_overrides=overrides, exempt_venue_ids={9}
+    )
+
+    assert updates[0] == (False, "series override: non-live")
+    assert updates[100] == (True, "venue: always live music")
 
 
 def test_exempt_venue_still_respects_per_event_override():

--- a/backend/tests/test_events_api.py
+++ b/backend/tests/test_events_api.py
@@ -1,0 +1,172 @@
+"""
+Tests for two review items in app.api.events — #4 (dedup ranking) and #5 (list filtering).
+
+#4 is a pure function, so it is tested directly. #5 builds a SQL WHERE clause and would
+need a database to exercise end to end; what is asserted here is the parameter contract,
+with the gap stated plainly rather than papered over. See the note on TestListFiltering.
+"""
+
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Optional
+
+from fastapi.testclient import TestClient
+
+import pytest
+
+from app.api.events import _completeness, _list_conditions
+from app.main import app
+
+
+@dataclass
+class Row:
+    """Stand-in for an ORM Event with only the attributes _completeness reads."""
+
+    id: int
+    is_live_music: bool = True
+    is_manual_override: bool = False
+    image_url: Optional[str] = None
+    ticket_url: Optional[str] = None
+    price_min: Optional[float] = None
+    updated_at: Optional[datetime] = None
+
+
+def _winner(a: Row, b: Row) -> Row:
+    """Whichever row the display-time dedup would keep, order-independently."""
+    forward = a if _completeness(a) > _completeness(b) else b
+    backward = b if _completeness(b) > _completeness(a) else a
+    assert forward is backward, "ranking depends on comparison order — not a total order"
+    return forward
+
+
+# --- #4: dedup must not discard the visible copy ---
+
+class TestDedupRanking:
+    def test_a_live_row_beats_a_non_live_row_with_richer_metadata(self):
+        """The regression. Ranking on field counts alone let the richer row win, and if
+        that row was classified non-live the show vanished from the default calendar."""
+        live_but_sparse = Row(id=1, is_live_music=True)
+        non_live_but_rich = Row(
+            id=2, is_live_music=False, image_url="x", ticket_url="y", price_min=10.0
+        )
+
+        assert _winner(live_but_sparse, non_live_but_rich).id == 1
+
+    def test_an_admin_override_beats_an_automatic_live_verdict(self):
+        """An admin looked at this row and decided; that outranks anything computed —
+        including a computed verdict that happens to be more permissive."""
+        hand_set_hidden = Row(id=1, is_live_music=False, is_manual_override=True)
+        auto_live = Row(id=2, is_live_music=True, image_url="x", ticket_url="y")
+
+        assert _winner(hand_set_hidden, auto_live).id == 1
+
+    def test_metadata_still_decides_between_two_equal_verdicts(self):
+        """The original behavior survives as a tiebreaker rather than being replaced."""
+        sparse = Row(id=1, is_live_music=True)
+        rich = Row(id=2, is_live_music=True, image_url="x", ticket_url="y", price_min=5.0)
+
+        assert _winner(sparse, rich).id == 2
+
+    def test_recency_breaks_a_tie_on_metadata(self):
+        older = Row(id=1, image_url="x", updated_at=datetime(2026, 1, 1))
+        newer = Row(id=2, image_url="y", updated_at=datetime(2026, 6, 1))
+
+        assert _winner(older, newer).id == 2
+
+    def test_id_breaks_a_total_tie(self):
+        """Without a final total key the winner would depend on row order from the
+        database, which is how the earlier version picked a surviving venue at random."""
+        assert _winner(Row(id=1), Row(id=2)).id == 2
+
+    def test_a_missing_updated_at_does_not_raise(self):
+        """Rows inserted but never re-scraped have updated_at unset."""
+        assert _winner(Row(id=1, updated_at=None), Row(id=2, updated_at=None)).id == 2
+
+    def test_is_manual_override_absent_is_treated_as_false(self):
+        """_completeness reads it with getattr, so a stand-in or a partially loaded row
+        lacking the attribute must rank as not-overridden rather than blow up."""
+
+        class NoOverrideAttr:
+            id = 1
+            is_live_music = True
+            image_url = ticket_url = None
+            price_min = None
+            updated_at = None
+
+        assert _completeness(NoOverrideAttr())[0] is False
+
+
+# --- #5: the list endpoint gains the opt-in the other consumers already have ---
+
+class TestListConditions:
+    """The clauses themselves, via _list_conditions.
+
+    An earlier version of this file only checked the OpenAPI parameter contract below.
+    Mutation-testing showed that was not enough: deleting the line that appends the
+    live-music clause left every assertion passing, because a declared-but-unused query
+    parameter still appears in the schema. That is exactly the bug worth catching, so the
+    clause building was split out of the endpoint to make it reachable without Postgres.
+    """
+
+    @staticmethod
+    def _sql(conditions) -> str:
+        return " ".join(str(c) for c in conditions)
+
+    def test_live_music_is_filtered_by_default(self):
+        assert "is_live_music" in self._sql(_list_conditions())
+
+    def test_opting_in_removes_the_filter(self):
+        assert "is_live_music" not in self._sql(_list_conditions(include_non_music=True))
+
+    def test_the_filter_is_added_alongside_other_filters(self):
+        """Regression shape: an early return or an if/elif could drop it whenever another
+        filter was supplied."""
+        sql = self._sql(_list_conditions(search="band", genre="rock", status="onsale"))
+        assert "is_live_music" in sql
+
+    def test_other_filters_are_unaffected_by_the_opt_in(self):
+        """Opting in drops only the live-music clause, not the caller's own filters."""
+        opted_in = self._sql(_list_conditions(search="band", include_non_music=True))
+        assert "events.name" in opted_in and "events.artist" in opted_in
+        assert "is_live_music" not in opted_in
+
+    def test_a_malformed_date_is_ignored_rather_than_raising(self):
+        """Pre-existing behavior, preserved through the extraction."""
+        conditions = _list_conditions(start="not-a-date", include_non_music=True)
+        assert conditions == []
+
+
+class TestListFiltering:
+    """The parameter contract, as it appears to callers."""
+
+    @pytest.fixture
+    def schema(self):
+        return TestClient(app).get("/openapi.json").json()
+
+    def _params(self, schema, path):
+        return {p["name"]: p for p in schema["paths"][path]["get"]["parameters"]}
+
+    def test_the_list_endpoint_offers_the_opt_in(self, schema):
+        assert "include_non_music" in self._params(schema, "/api/events")
+
+    def test_it_defaults_to_live_music_only(self, schema):
+        """Default off is the point: before this, the list endpoint was the one consumer
+        that served the events the feature exists to hide."""
+        param = self._params(schema, "/api/events")["include_non_music"]
+        assert param["schema"]["default"] is False
+
+    def test_it_matches_the_ical_feed_by_name_and_default(self, schema):
+        """Review item #5 is about consistency across consumers, so the two endpoints
+        agreeing is the property worth pinning — a rename of one would break this."""
+        events = self._params(schema, "/api/events")["include_non_music"]
+        feed = self._params(schema, "/feeds/events.ics")["include_non_music"]
+
+        assert events["schema"]["default"] == feed["schema"]["default"] is False
+
+    def test_the_fullcalendar_endpoint_deliberately_has_no_such_parameter(self, schema):
+        """Left returning everything on purpose: filters.js toggles visibility in the
+        browser without refetching, so filtering server-side would empty the calendar the
+        moment someone switched the toggle on. Asserted so the omission reads as a decision
+        rather than as an oversight."""
+        params = self._params(schema, "/api/events/fullcalendar")
+        assert "include_non_music" not in params

--- a/backend/tests/test_series_override_cascade.py
+++ b/backend/tests/test_series_override_cascade.py
@@ -1,0 +1,77 @@
+"""
+Tests that retiring a venue cannot be blocked by its series rules — review item #9.
+
+seed_venues() deletes venues named in REMOVED_SLUGS on every startup, via
+session.delete(). That cascades only through relationships SQLAlchemy knows about. Venue
+had them for events and scrape_logs but not for series_overrides, and the foreign key had
+no ON DELETE, so the first retirement of a venue holding a series override would raise
+ForeignKeyViolation inside the lifespan handler — and the container would never become
+healthy. REMOVED_SLUGS is [""] today, which is why nothing has broken yet.
+
+The fix has two halves and this file checks both, because either alone leaves a hole:
+
+  * an ORM relationship with delete-orphan, which covers session.delete()
+  * ON DELETE CASCADE on the constraint, which covers anything bypassing the ORM
+
+Asserted against mapper metadata and the migration source rather than a live database.
+The model being right while the migration is wrong is the realistic drift — the model
+governs nothing at runtime, since the table is created by the migration — so the migration
+is checked too. Neither check needs Postgres.
+"""
+
+import pathlib
+import re
+
+from app.models import SeriesOverride, Venue
+
+
+MIGRATION = (
+    pathlib.Path(__file__).resolve().parent.parent
+    / "alembic" / "versions" / "0004_add_series_overrides.py"
+)
+
+
+class TestOrmCascade:
+    """Covers session.delete(venue), which is how seed_venues() retires a venue."""
+
+    def test_venue_has_a_series_overrides_relationship(self):
+        assert "series_overrides" in Venue.__mapper__.relationships
+
+    def test_it_cascades_deletes_like_events_and_scrape_logs(self):
+        rel = Venue.__mapper__.relationships["series_overrides"]
+        assert rel.cascade.delete
+        assert rel.cascade.delete_orphan
+
+    def test_it_matches_the_cascade_on_the_other_two_collections(self):
+        """Consistency is the point — a venue's dependents should not have three different
+        deletion behaviors depending on which was added when."""
+        cascades = {
+            name: (Venue.__mapper__.relationships[name].cascade.delete,
+                   Venue.__mapper__.relationships[name].cascade.delete_orphan)
+            for name in ("events", "scrape_logs", "series_overrides")
+        }
+        assert len(set(cascades.values())) == 1, cascades
+
+    def test_the_reverse_relationship_is_wired(self):
+        """back_populates on Venue requires the matching attribute here, or SQLAlchemy
+        raises at mapper configuration time."""
+        assert "venue" in SeriesOverride.__mapper__.relationships
+
+
+class TestDatabaseConstraint:
+    """Covers deletions that never pass through the ORM's cascade."""
+
+    def test_the_model_declares_on_delete_cascade(self):
+        fks = list(SeriesOverride.__table__.c.venue_id.foreign_keys)
+        assert len(fks) == 1
+        assert fks[0].ondelete == "CASCADE"
+
+    def test_the_migration_declares_it_too(self):
+        """The migration, not the model, is what creates the constraint in the database.
+        A model-only fix would look correct here and change nothing in production."""
+        source = MIGRATION.read_text(encoding="utf-8")
+        fk = re.search(
+            r"ForeignKeyConstraint\(\s*\['venue_id'\][^)]*\)", source, re.DOTALL
+        )
+        assert fk is not None, "venue_id foreign key not found in 0004"
+        assert "ondelete='CASCADE'" in fk.group(0) or 'ondelete="CASCADE"' in fk.group(0)


### PR DESCRIPTION
Stacked onto `feature/filter-non-live-music` — **base is #36, not `main`**. Five of the eight items left open on that review, grouped because each is small and none depends on the others.

Not here: **#10** (login rate limiting) and **#8** (wiring the admin secrets, which is configuration rather than code). **#11** went to `main` separately as [#55](https://github.com/triangle-shows/triangle-shows/pull/55), since `main.py` exists there and it had nothing to do with live music.

## #6 — series override now outranks the venue exemption

The exemption `return`ed before overrides were consulted, so an exempt venue's series could **never** be marked non-live through the series UI — on every future instance, permanently. DPAC is the only exempt venue, and it hosts Broadway and comedy alongside music, which is exactly the case the series UI exists for. The exemption is now a default a deliberate decision can override.

The existing test asserted the old order, so it's rewritten rather than added to — it was encoding the bug.

## #12 — `compare_digest` gets bytes

It rejects a `str` containing any non-ASCII character by raising `TypeError` rather than returning `False`, so an accented password turned a wrong guess into a 500. Beyond the crash: a failure mode that differs from the normal 401 is an oracle. Tests assert a wrong ASCII guess and a wrong non-ASCII guess are indistinguishable.

## #9 — retiring a venue can't be blocked by its series rules

Both halves, because either alone leaves a hole:

- an **ORM relationship** with `delete-orphan`, matching `events` and `scrape_logs`, covering the `session.delete()` that `seed_venues()` uses
- **`ON DELETE CASCADE`** on the constraint, covering anything that bypasses the ORM

Edited into migration **0004 in place** rather than added as an 0006 — `0003`–`0005` have never been applied anywhere, since `main` and `prod` both sit at `0002`. The tests check the migration source as well as the model, because a model-only fix would look correct and change nothing in production: the migration is what creates the constraint.

## #5 — `/api/events` gains `include_non_music`

Defaults to live music only, matching `/feeds/events.ics`. It was the one consumer still serving the events the feature exists to hide.

The FullCalendar endpoint still returns everything **on purpose**, and there's a test asserting the omission so it reads as a decision: `filters.js` toggles visibility in the browser without refetching, so filtering server-side would empty the calendar the moment someone switched the toggle on.

## #4 — dedup ranks classification above metadata

The display-time guard runs before any live-music filtering, so it decides which row's verdict the calendar sees. Ranking on field counts alone could keep a non-live row and discard a live one — dropping a real show off the default calendar.

Order is now: manual override → live-music → previous keys as tiebreakers. Preferring the visible row matches the feature's chosen failure direction (showing too much is recoverable; hiding a real show is what users never see). The cross-venue half of this item was already resolved by #51.

## Testing

**208 passing, 4 skipped, no database required.**

Every fix is mutation-checked — reverting any one of them fails at least one test.

That caught a **vacuous test** on the way, which is worth calling out. The #5 tests originally asserted only the OpenAPI parameter contract. Deleting the line that *applies* the filter left all of them passing, because a declared-but-unused query parameter still shows up in the schema — the endpoint keeps answering, just with the wrong rows. So the clause building is now split into `_list_conditions()`, making the filtering reachable without Postgres, and the mutation fails as it should.

## After this

#36 drops from 8 open items to 2: **#10** and **#8**. Sequencing worth remembering — don't do #8 until a Cloudflare Access application exists, or `/admin` goes live with only a shared password on a directly reachable origin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)