### PR TITLE
Run CI on every pull request, not only those targeting main or prod

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,14 @@
 name: CI
 
 on:
+  # Every pull request, whatever it targets. The previous `branches: [main, prod]` filter
+  # meant a PR into a feature branch ran nothing at all, and reported "no checks" rather
+  # than a failure — so an unverified PR looked the same as a passing one.
+  #
+  # That shape comes up when a review-fix branch is opened against the feature branch it
+  # fixes rather than against main (PR #56 onto #36 was the first). Under the old filter
+  # the first CI run over that code happened only after it had already been merged once.
   pull_request:
-    branches: [main, prod]
 
 jobs:
   smoke-test:


### PR DESCRIPTION
`branches: [main, prod]` meant a PR into a feature branch triggered **no workflow at all**. GitHub then reports "no checks" rather than a failure — so an unverified PR looks the same as a passing one, which is the worse of the two failure modes.

That shape came up immediately: [#56](https://github.com/triangle-shows/triangle-shows/pull/56) was opened against `feature/filter-non-live-music` to fix review items on #36, and got no CI. Its 208 tests had only ever run on my machine, and the first CI pass over that code would have happened *after* it was already merged into #36.

## Cost

None on the existing paths — the workflow already ran for `main`- and `prod`-targeting PRs, and there's no `push` trigger to duplicate. A run is ~40s.

## Fork safety is unchanged

`pull_request` still withholds repository secrets from fork-authored code, which is what makes CI on a fork PR safe (see `_ADMIN-ACCESS-GUIDE.md`). This change widens *which* PRs run, not *what* they can read. The thing not to do is switch to `pull_request_target`, which would expose secrets to code the fork author controls — noted in the commit message so it survives.

## One caveat about #56 specifically

This doesn't retroactively give #56 a CI run. For `pull_request`, GitHub evaluates the workflow from the merge of base and head — and neither `feature/filter-non-live-music` nor `fix/review-cluster-36` contains this change yet. Getting #56 actually checked means merging this, then rebasing #36 onto `main`, then rebasing #56 onto #36.

Happy to do that chain if you want #56 verified by CI before it merges. Otherwise the benefit starts with the next stacked PR, and #56's code gets its first CI pass when it lands in #36 and that PR re-runs against `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)