### PR TITLE
Release: live-music filter, dedup rewrite, origin token gates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,14 @@
 name: CI
 
 on:
+  # Every pull request, whatever it targets. The previous `branches: [main, prod]` filter
+  # meant a PR into a feature branch ran nothing at all, and reported "no checks" rather
+  # than a failure — so an unverified PR looked the same as a passing one.
+  #
+  # That shape comes up when a review-fix branch is opened against the feature branch it
+  # fixes rather than against main (PR #56 onto #36 was the first). Under the old filter
+  # the first CI run over that code happened only after it had already been merged once.
   pull_request:
-    branches: [main, prod]
 
 jobs:
   smoke-test:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,9 @@ jobs:
         with:
           python-version: "3.12"
           cache: pip
-          cache-dependency-path: backend/requirements.txt
+          cache-dependency-path: |
+            backend/requirements.txt
+            backend/requirements-dev.txt
 
       - name: Install dependencies
         run: pip install -r backend/requirements-dev.txt

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,11 @@ jobs:
           cache-dependency-path: backend/requirements.txt
 
       - name: Install dependencies
-        run: pip install -r backend/requirements.txt
+        run: pip install -r backend/requirements-dev.txt
+
+      - name: Run unit tests
+        working-directory: backend
+        run: python -m pytest tests -q
 
       - name: Run migrations
         working-directory: backend

--- a/.gitignore
+++ b/.gitignore
@@ -27,7 +27,7 @@ _context-history/
 .claude*
 CLAUDE.md
 
-# Claude-managed session files. `_*.md` above covers _SESSION-CONTEXT.md and the
-# archived copies inside _context-history/, but not the directory itself or _todo.
+# Claude-managed session files. `_*.md` above covers _SESSION-CONTEXT.md, _todo.md,
+# and the archived copies inside _context-history/ — it does not match the directory
+# itself, hence this line.
 _context-history/
-_todo

--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,9 @@ _context-history/
 .claude/
 .claude*
 CLAUDE.md
+
+# Claude-managed session files. These moved from a `_` prefix to a `.` prefix,
+# which `_*.md` above no longer covers.
+.SESSION-CONTEXT.md
+.context-history/
+.todo

--- a/.gitignore
+++ b/.gitignore
@@ -27,8 +27,7 @@ _context-history/
 .claude*
 CLAUDE.md
 
-# Claude-managed session files. These moved from a `_` prefix to a `.` prefix,
-# which `_*.md` above no longer covers.
-.SESSION-CONTEXT.md
-.context-history/
-.todo
+# Claude-managed session files. `_*.md` above covers _SESSION-CONTEXT.md and the
+# archived copies inside _context-history/, but not the directory itself or _todo.
+_context-history/
+_todo

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,9 @@
-FROM python:3.12-slim
+# Multi-stage so local development can have test dependencies without shipping them
+# to Cloud Run. `prod` is deliberately the LAST stage: an untargeted `docker build`
+# — which is what cloudbuild.yaml runs — resolves to the final stage, so production
+# stays lean by default and nobody has to remember a flag.
+
+FROM python:3.12-slim AS base
 
 WORKDIR /app
 
@@ -18,3 +23,15 @@ ENV GIT_COMMIT=$GIT_COMMIT
 EXPOSE 8000
 
 CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000"]
+
+
+# Development image — adds pytest and anything else in requirements-dev.txt.
+# Selected by docker-compose.yml via `target: dev`, so `docker-compose up --build`
+# gives you a container you can run the test suite in without a manual pip install.
+FROM base AS dev
+RUN pip install --no-cache-dir -r requirements-dev.txt
+
+
+# Production image. An alias of `base` with no test dependencies, kept last so it
+# is what an untargeted build produces.
+FROM base AS prod

--- a/README.md
+++ b/README.md
@@ -157,6 +157,12 @@ See [CONTRIBUTING.md](.github/CONTRIBUTING.md) for the branch/PR workflow if you
 
 ## License / contact me
 
-GNU General Public License v3. See [LICENSE](LICENSE).
+Functional Source License 1.1 with an Apache 2.0 future license ([FSL-1.1-ALv2](LICENSE)).
+Source-available: use, modify and redistribute it for any purpose except competing use, and
+each version becomes Apache 2.0 two years after its release.
+
+The license covers the code. It does not cover the event data the API serves — that is
+aggregated from venues' own public listings and from the Ticketmaster Discovery API, and
+remains the property of the respective venues and rights holders.
 
 Contact me at [@tyfi](https://bsky.app/profile/tyfi.bsky.social) on Bluesky, or you can email [mail@triangle-shows.net](mailto:mail@triangle-shows.net)

--- a/backend/alembic/env.py
+++ b/backend/alembic/env.py
@@ -13,7 +13,7 @@ import os
 import sys
 from logging.config import fileConfig
 
-from sqlalchemy import engine_from_config, pool
+from sqlalchemy import engine_from_config, pool, text
 from alembic import context
 
 # Add parent directory to path so we can import app modules
@@ -41,6 +41,11 @@ if config.config_file_name is not None:
 # Point Alembic at the full set of ORM models so it can diff against the live schema
 target_metadata = Base.metadata
 
+# Advisory lock held while migrations run, so two processes cannot apply them at once.
+# The value is arbitrary but must never change: processes serialize only if they ask
+# for the same key.
+MIGRATION_LOCK_KEY = 4021755
+
 
 # --- Migration Runners ---
 
@@ -53,7 +58,28 @@ def run_migrations_offline():
 
 
 def run_migrations_online():
-    """Run migrations against a live database connection."""
+    """Run migrations against a live database connection, one process at a time.
+
+    Migrations run from the FastAPI lifespan handler (app/main.py), not as a deploy
+    step, so with Cloud Run at max-instances=2 two containers can boot together and
+    both call `upgrade head` against the same database. Both read alembic_version,
+    both decide the same work is outstanding, and whichever loses the race then fails
+    on an object the winner has already created. The exception escapes `lifespan`, so
+    that container never becomes healthy — a deploy that half-succeeds.
+
+    Taking an advisory lock *before* run_migrations() reads the version table
+    serializes them. The loser waits at the lock, then re-reads alembic_version and
+    correctly finds nothing to do.
+
+    pg_advisory_xact_lock rather than pg_advisory_lock, for two reasons. It releases
+    on commit or rollback with no explicit unlock, so a crashed or killed migration
+    cannot leave a lock wedging every future boot. And it stays correct through Neon's
+    transaction-mode pooler, which pins a transaction to a single backend but is free
+    to route the next statement of a *session* somewhere else — where a session-scoped
+    lock would be invisible.
+
+    Postgres-only, like the rest of this project.
+    """
     connectable = engine_from_config(
         config.get_section(config.config_ini_section, {}),
         prefix="sqlalchemy.",
@@ -62,6 +88,13 @@ def run_migrations_online():
     with connectable.connect() as connection:
         context.configure(connection=connection, target_metadata=target_metadata)
         with context.begin_transaction():
+            # Must precede run_migrations(): the point is to hold the lock across the
+            # read of alembic_version *and* the migrations themselves, so the decision
+            # about what is outstanding cannot go stale between the two.
+            connection.execute(
+                text("SELECT pg_advisory_xact_lock(:key)"),
+                {"key": MIGRATION_LOCK_KEY},
+            )
             context.run_migrations()
 
 

--- a/backend/alembic/versions/0003_add_live_music_classification.py
+++ b/backend/alembic/versions/0003_add_live_music_classification.py
@@ -1,0 +1,48 @@
+"""Alembic migration 0003: add live-music classification columns to events.
+
+Role: Adds the three columns that drive the live-music filter and admin override
+feature — is_live_music (the effective flag the calendar/feeds read),
+is_manual_override (protects admin decisions from being overwritten by re-scrapes),
+and classification_reason (human-readable explanation). Additive and safe on an
+existing DB: every current row defaults to is_live_music=True (visible) until the
+first post-migration scrape runs ScrapeManager.reclassify_all().
+Requires: A live PostgreSQL database at revision 0002.
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = '0003'
+down_revision = '0002'
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # server_default is set so the columns backfill on existing rows without a
+    # rewrite; the ORM-level Python default (models.py) handles new inserts.
+    op.add_column(
+        'events',
+        sa.Column('is_live_music', sa.Boolean(), nullable=False, server_default=sa.true()),
+    )
+    op.add_column(
+        'events',
+        sa.Column('is_manual_override', sa.Boolean(), nullable=False, server_default=sa.false()),
+    )
+    op.add_column(
+        'events',
+        sa.Column('classification_reason', sa.String(200), nullable=True),
+    )
+    op.create_index('ix_events_is_live_music', 'events', ['is_live_music'])
+
+    # Drop the server_defaults now that existing rows are backfilled; going forward
+    # the application layer supplies these values explicitly.
+    op.alter_column('events', 'is_live_music', server_default=None)
+    op.alter_column('events', 'is_manual_override', server_default=None)
+
+
+def downgrade() -> None:
+    op.drop_index('ix_events_is_live_music', table_name='events')
+    op.drop_column('events', 'classification_reason')
+    op.drop_column('events', 'is_manual_override')
+    op.drop_column('events', 'is_live_music')

--- a/backend/alembic/versions/0004_add_series_overrides.py
+++ b/backend/alembic/versions/0004_add_series_overrides.py
@@ -27,7 +27,11 @@ def upgrade() -> None:
         sa.Column('note', sa.String(500), nullable=True),
         sa.Column('created_at', sa.DateTime(), nullable=False),
         sa.Column('updated_at', sa.DateTime(), nullable=False),
-        sa.ForeignKeyConstraint(['venue_id'], ['venues.id']),
+        # ON DELETE CASCADE so retiring a venue cannot be blocked by its series rules.
+        # Edited into this migration rather than added by a later one: 0003-0005 have never
+        # been applied anywhere (both main and prod sit at 0002), so there is no deployed
+        # constraint to alter.
+        sa.ForeignKeyConstraint(['venue_id'], ['venues.id'], ondelete='CASCADE'),
         sa.PrimaryKeyConstraint('id'),
         sa.UniqueConstraint('venue_id', 'normalized_name', name='uq_series_override_key'),
     )

--- a/backend/alembic/versions/0004_add_series_overrides.py
+++ b/backend/alembic/versions/0004_add_series_overrides.py
@@ -1,0 +1,39 @@
+"""Alembic migration 0004: add the series_overrides table.
+
+Role: Backs admin series-level overrides for the live-music filter. A row keyed by
+(venue_id, normalized_name) forces is_live_music for every event in a recurring
+series, including future scraped instances (applied in ScrapeManager.reclassify_all).
+Additive and safe: creates a new empty table, touches no existing data.
+Requires: A live PostgreSQL database at revision 0003.
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = '0004'
+down_revision = '0003'
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        'series_overrides',
+        sa.Column('id', sa.Integer(), nullable=False),
+        sa.Column('venue_id', sa.Integer(), nullable=False),
+        sa.Column('normalized_name', sa.String(200), nullable=False),
+        sa.Column('display_name', sa.String(500), nullable=True),
+        sa.Column('is_live_music', sa.Boolean(), nullable=False),
+        sa.Column('note', sa.String(500), nullable=True),
+        sa.Column('created_at', sa.DateTime(), nullable=False),
+        sa.Column('updated_at', sa.DateTime(), nullable=False),
+        sa.ForeignKeyConstraint(['venue_id'], ['venues.id']),
+        sa.PrimaryKeyConstraint('id'),
+        sa.UniqueConstraint('venue_id', 'normalized_name', name='uq_series_override_key'),
+    )
+    op.create_index('ix_series_overrides_venue_id', 'series_overrides', ['venue_id'])
+
+
+def downgrade() -> None:
+    op.drop_index('ix_series_overrides_venue_id', table_name='series_overrides')
+    op.drop_table('series_overrides')

--- a/backend/alembic/versions/0005_add_event_approved_at.py
+++ b/backend/alembic/versions/0005_add_event_approved_at.py
@@ -1,0 +1,37 @@
+"""Alembic migration 0005: add events.approved_at.
+
+Role: Backs admin review tracking for the live-music filter. A non-null approved_at
+means someone has checked that event's classification and agreed with it; the admin
+list hides approved events by default so the queue only shows unreviewed work.
+
+Approval records agreement with a *specific verdict*, not the event as a whole:
+ScrapeManager.reclassify_all clears approved_at whenever it changes an event's
+is_live_music, so a re-classified event returns to the queue instead of staying
+hidden behind a stale approval.
+
+Additive and safe: adds one nullable column, so existing rows are simply unapproved
+and a rollback to the previous revision leaves the column unread rather than broken.
+Requires: A live PostgreSQL database at revision 0004.
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = '0005'
+down_revision = '0004'
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # Nullable with no server_default: every existing event starts unapproved, which
+    # is the correct starting state for a review queue.
+    op.add_column('events', sa.Column('approved_at', sa.DateTime(), nullable=True))
+    # Partial index — the common query filters approved_at IS NULL, and only a
+    # minority of rows will ever be non-null.
+    op.create_index('ix_events_approved_at', 'events', ['approved_at'])
+
+
+def downgrade() -> None:
+    op.drop_index('ix_events_approved_at', table_name='events')
+    op.drop_column('events', 'approved_at')

--- a/backend/app/admin_ui.py
+++ b/backend/app/admin_ui.py
@@ -16,16 +16,18 @@ LOGIN_HTML = """<!doctype html>
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>admin · triangle-shows</title>
 <style>
-  :root { color-scheme: dark; }
+  /* Deliberately green, not the public site's amber (--accent in frontend/css/styles.css),
+     so the admin surface is visually distinct from the live site at a glance. */
+  :root { color-scheme: dark; --accent:#4fae7a; }
   body { margin:0; min-height:100vh; display:grid; place-items:center;
          background:#0e0e10; color:#e8e6e3; font-family:'Space Mono',ui-monospace,monospace; }
   .box { width:min(90vw,340px); border:1px solid #2a2a2e; padding:1.6rem; border-radius:2px; }
-  h1 { font-size:0.95rem; letter-spacing:0.08em; text-transform:uppercase; color:#c87941; margin:0 0 1.2rem; }
+  h1 { font-size:0.95rem; letter-spacing:0.08em; text-transform:uppercase; color:var(--accent); margin:0 0 1.2rem; }
   input, button { width:100%; font-family:inherit; font-size:0.85rem; padding:0.55rem 0.6rem;
                   box-sizing:border-box; border-radius:2px; }
   input { background:#17171a; border:1px solid #2a2a2e; color:#e8e6e3; margin-bottom:0.7rem; }
-  input:focus { outline:none; border-color:#c87941; }
-  button { background:#c87941; border:1px solid #c87941; color:#0e0e10; cursor:pointer; font-weight:700; }
+  input:focus { outline:none; border-color:var(--accent); }
+  button { background:var(--accent); border:1px solid var(--accent); color:#0e0e10; cursor:pointer; font-weight:700; }
   button:hover { filter:brightness(1.1); }
   .err { color:#e0625f; font-size:0.75rem; min-height:1em; margin:0.7rem 0 0; }
 </style>
@@ -66,21 +68,24 @@ ADMIN_HTML = """<!doctype html>
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>admin · triangle-shows</title>
 <style>
-  :root { color-scheme: dark; }
+  /* Deliberately green, not the public site's amber (--accent in frontend/css/styles.css),
+     so the admin surface is visually distinct from the live site at a glance. */
+  :root { color-scheme: dark; --accent:#4fae7a; }
   * { box-sizing:border-box; }
   body { margin:0; background:#0e0e10; color:#e8e6e3;
          font-family:'Space Mono',ui-monospace,monospace; font-size:0.82rem; }
   header { display:flex; align-items:center; gap:1rem; padding:0.8rem 1.1rem;
            border-bottom:1px solid #2a2a2e; position:sticky; top:0; background:#0e0e10; z-index:2; }
-  header h1 { font-size:0.9rem; letter-spacing:0.08em; text-transform:uppercase; color:#c87941; margin:0; }
+  header h1 { font-size:0.9rem; letter-spacing:0.08em; text-transform:uppercase; color:var(--accent); margin:0; }
   header .sp { flex:1; }
-  a { color:#c87941; }
+  a { color:var(--accent); }
   main { padding:1.1rem; max-width:1100px; margin:0 auto; }
   .controls { display:flex; flex-wrap:wrap; gap:0.5rem; align-items:center; margin-bottom:1rem; }
   .fbtn, button.link { font-family:inherit; font-size:0.72rem; text-transform:uppercase; letter-spacing:0.06em;
           padding:0.3rem 0.6rem; border:1px solid #3a3a3e; background:transparent; color:#a8a6a3;
           cursor:pointer; border-radius:2px; }
-  .fbtn.on { background:#c87941; border-color:#c87941; color:#0e0e10; font-weight:700; }
+  .fbtn.on, button.link.on { background:var(--accent); border-color:var(--accent); color:#0e0e10; font-weight:700; }
+  button.link.on::after { content:' ×'; }
   #search { flex:1; min-width:160px; font-family:inherit; font-size:0.8rem; padding:0.35rem 0.6rem;
             background:#17171a; border:1px solid #2a2a2e; color:#e8e6e3; border-radius:2px; }
   #count { color:#8a8a8e; font-size:0.72rem; margin-left:auto; }
@@ -92,11 +97,36 @@ ADMIN_HTML = """<!doctype html>
   .b.live { background:#1f3d2a; color:#7fd69a; }
   .b.nonlive { background:#3d2020; color:#e08a88; }
   .b.manual { background:#3a2f12; color:#e0b45f; }
+  .b.mixed { background:#2a2a3d; color:#9a9ad6; }
   .reason { color:#8a8a8e; font-size:0.7rem; }
+  tr.grow { cursor:pointer; }
+  tr.grow:hover > td { background:#17171a; }
+  tr.grow td:first-child { color:#c8c6c3; }
+  .caret { display:inline-block; width:1em; color:var(--accent); }
+  .gcount { color:#8a8a8e; font-size:0.72rem; }
+  .divider { width:1px; align-self:stretch; background:#2a2a2e; margin:0 0.2rem; }
+  .warn { color:#e0b45f; }
+  tr.erow { cursor:pointer; }
+  tr.erow:hover > td { background:#17171a; }
+  tr.eopen > td { background:#17171a; }
+  tr.detail > td { background:#141417; border-bottom:1px solid #1e1e22; padding-top:0.4rem; }
+  tr.detail .dk { color:#8a8a8e; text-transform:uppercase; font-size:0.64rem; letter-spacing:0.06em; margin-right:0.4rem; }
+  tr.detail .desc { color:#c8c6c3; margin:0.35rem 0; max-width:60ch; line-height:1.45; }
+  tr.detail div { margin:0.12rem 0; }
+  td.actions button.ok { border-color:#2f5c40; color:#7fd69a; }
+  #help { background:#17171a; border:1px solid #2a2a2e; border-radius:2px;
+          padding:0.4rem 1rem 1rem; margin-top:1rem; max-width:76ch; }
+  #help h2 { font-size:0.72rem; text-transform:uppercase; letter-spacing:0.08em;
+             color:var(--accent); margin:1.1rem 0 0.3rem; }
+  #help p { color:#b8b6b3; line-height:1.55; margin:0.4rem 0; }
+  #help b { color:#e8e6e3; }
+  tr.child > td { border-bottom:1px solid #1a1a1e; }
+  tr.child td:first-child { padding-left:1.6rem; color:#8a8a8e; }
+  tr.child > td:first-child { border-left:2px solid #2a2a2e; }
   td.actions { white-space:nowrap; }
   td.actions button { font-family:inherit; font-size:0.68rem; margin:0.1rem 0.15rem 0.1rem 0; padding:0.22rem 0.45rem;
           border:1px solid #3a3a3e; background:transparent; color:#c8c6c3; cursor:pointer; border-radius:2px; }
-  td.actions button:hover { border-color:#c87941; color:#c87941; }
+  td.actions button:hover { border-color:var(--accent); color:var(--accent); }
   .series { color:#8a8a8e; }
   .empty { color:#8a8a8e; text-align:center; padding:1.5rem; }
   #rules { white-space:pre-wrap; background:#17171a; border:1px solid #2a2a2e; padding:0.8rem;
@@ -106,7 +136,8 @@ ADMIN_HTML = """<!doctype html>
 </head><body>
   <header>
     <h1>triangle-shows admin</h1>
-    <button class="link" onclick="showRules()">detection rules</button>
+    <button class="link" id="rulesBtn" aria-expanded="false" onclick="showRules()">detection rules</button>
+    <button class="link" id="helpBtn" aria-expanded="false" onclick="showHelp()">how this works</button>
     <span class="sp"></span>
     <a href="/admin/logout">log out</a>
   </header>
@@ -115,10 +146,58 @@ ADMIN_HTML = """<!doctype html>
       <button class="fbtn on" data-f="non_live" onclick="setFilter('non_live')">non-live</button>
       <button class="fbtn" data-f="live" onclick="setFilter('live')">live</button>
       <button class="fbtn" data-f="all" onclick="setFilter('all')">all</button>
+      <span class="divider"></span>
+      <button class="fbtn tog" id="futureBtn" aria-pressed="false" onclick="toggleFuture()">future dates only</button>
+      <button class="fbtn tog" id="approvedBtn" aria-pressed="false" onclick="toggleApproved()">show approved</button>
       <input id="search" placeholder="search name / artist...">
       <span id="count"></span>
     </div>
     <pre id="rules" class="hidden"></pre>
+    <div id="help" class="hidden">
+      <h2>What this page is for</h2>
+      <p>Every event is flagged <b>live music</b> or <b>non-live</b>. The public calendar
+      uses that flag to let visitors hide karaoke, trivia, DJ nights and the like. This page
+      is where wrong guesses get corrected.</p>
+      <p>The list is a <b>review queue</b>: it opens on non-live events, because those are
+      the ones the detector had to make a judgement call about. Click any row to see its
+      description, genre and a link to the venue page — often the only way to settle an
+      ambiguous one.</p>
+
+      <h2>The two kinds of correction</h2>
+      <p><b>mark live / mark non-live</b> fixes one event. It sets a manual override, which
+      survives re-scrapes and reclassification — the detector will never overwrite it.</p>
+      <p><b>series live / series non-live</b> creates a standing rule for a repeating event
+      at one venue, matched on its name. It applies to every date in the series <i>and to
+      future instances that haven't been scraped yet</i>. The number on the button is how
+      many events it currently affects. Use this for anything recurring: one rule beats
+      twenty corrections.</p>
+
+      <h2>Approving</h2>
+      <p><b>approve</b> means "I checked this and the flag is right". It doesn't change the
+      flag — it just removes the event from the queue so you can tell reviewed work from
+      work you haven't looked at yet. On a collapsed series row it approves every date at
+      once.</p>
+      <p>An approval applies to <i>that verdict</i>, not the event forever. If something
+      later changes the flag — a new series rule, or the detector spotting a recurrence it
+      had missed — the approval is dropped and the event comes back to the queue. Marking an
+      event live or non-live by hand also approves it, since you've just made the call.</p>
+
+      <h2>Reading the list</h2>
+      <p>Repeating events collapse into one row showing a date range and a count; click to
+      expand. A collapsed row sits at the series' <i>first</i> date, so the dates in the
+      left column aren't a straight timeline — a row near the top may run for months.</p>
+      <p><b>mixed</b> means some dates in a series are flagged differently from others,
+      usually because one was overridden by hand.</p>
+      <p>The list covers the last 30 days as well as everything upcoming, because the
+      calendar can be scrolled back. <b>future dates only</b> narrows it; <b>show approved</b>
+      brings reviewed events back into view. Neither changes what a series action affects —
+      that always reaches every matching event, shown or not.</p>
+
+      <h2>Where the guesses come from</h2>
+      <p><b>detection rules</b> lists the automatic criteria: keyword matches, and how many
+      repeats at one venue count as a recurring series. Anything auto-flagged shows its
+      reason next to the badge.</p>
+    </div>
     <table>
       <thead><tr><th>date</th><th>event</th><th>status</th><th>actions</th></tr></thead>
       <tbody id="tbody"></tbody>
@@ -127,7 +206,7 @@ ADMIN_HTML = """<!doctype html>
 <script>
   let RULES = null;
   const $ = (s) => document.querySelector(s);
-  const state = { filter: 'non_live', search: '' };
+  const state = { filter: 'non_live', search: '', futureOnly: false, showApproved: false };
 
   async function api(path, opts) {
     const r = await fetch(path, Object.assign({ headers: { 'Content-Type': 'application/json' } }, opts));
@@ -148,8 +227,17 @@ ADMIN_HTML = """<!doctype html>
            '<span class="reason">' + esc(ev.classification_reason || '') + '</span>';
   }
 
+  function approveAction(ev, isSeries, n) {
+    const suffix = (isSeries && n > 1) ? ' (' + n + ')' : '';
+    if (ev.is_approved && !isSeries) {
+      return '<button class="ok" onclick="unapprove(' + ev.id + ',false)">approved ✓</button>';
+    }
+    const fn = isSeries ? 'approve(' + ev.id + ',true)' : 'approve(' + ev.id + ',false)';
+    return '<button onclick="' + fn + '">approve' + suffix + '</button>';
+  }
+
   function actions(ev) {
-    let a = '';
+    let a = approveAction(ev, false, 1) + ' ';
     if (ev.is_manual_override) {
       a += '<button onclick="clearOv(' + ev.id + ')">clear override</button>';
     } else {
@@ -166,20 +254,152 @@ ADMIN_HTML = """<!doctype html>
     return a;
   }
 
-  function render(evs, count) {
-    $('#count').textContent = count + ' event(s)';
-    $('#tbody').innerHTML = evs.length ? evs.map((ev) =>
-      '<tr><td>' + ev.date + '</td>' +
+  // Grouping. Events sharing a venue and series_key collapse into one expandable
+  // row. series_key comes from the server's normalize_series_name, the same key a
+  // series override matches on — so what you see grouped is exactly what a series
+  // action will affect. GROUPS is rebuilt on every load; `expanded` is keyed by
+  // series so open rows survive the re-render that follows an action.
+  let GROUPS = [];
+  const expanded = new Set();
+
+  function groupKeyOf(ev) {
+    // A blank series_key would otherwise collapse unrelated events into one row.
+    if (!ev.series_key) return 'ev||' + ev.id;
+    return 'series||' + (ev.venue_slug || '') + '||' + ev.series_key;
+  }
+
+  function buildGroups(evs) {
+    const map = new Map();
+    evs.forEach((ev) => {
+      const k = groupKeyOf(ev);
+      if (!map.has(k)) map.set(k, []);
+      map.get(k).push(ev);
+    });
+    return Array.from(map.entries());
+  }
+
+  function groupBadge(evs) {
+    const live = evs.filter((e) => e.is_live_music).length;
+    if (live === evs.length) return '<span class="b live">live</span>';
+    if (live === 0) return '<span class="b nonlive">non-live</span>';
+    return '<span class="b mixed">mixed</span> <span class="reason">' +
+           live + ' live / ' + (evs.length - live) + ' non-live</span>';
+  }
+
+  function seriesActions(ev) {
+    if (ev.series_override_id) {
+      return '<span class="series">series: ' + (ev.series_override_is_live ? 'live' : 'non-live') +
+             ' <button onclick="delSeries(' + ev.series_override_id + ')">remove</button></span>';
+    }
+    // Put the blast radius on the button. series_size counts every matching event in
+    // the reclassify range, not just the rows on screen, so a collapsed or filtered
+    // view can't make the action look smaller than it is. Omitted at 1, where there
+    // is no series to speak of.
+    const n = ev.series_size > 1 ? ' (' + ev.series_size + ')' : '';
+    const t = ev.series_size > 1
+      ? ' title="applies to ' + ev.series_size + ' events at this venue, including ones not shown"'
+      : '';
+    return '<button' + t + ' onclick="series(' + ev.id + ',true)">series live' + n + '</button>' +
+           '<button' + t + ' onclick="series(' + ev.id + ',false)">series non-live' + n + '</button>';
+  }
+
+  // Event ids whose detail panel is open. Like `expanded`, this is keyed by id so
+  // open panels survive the re-render that follows every action.
+  const detailOpen = new Set();
+
+  function toggleDetail(id) {
+    if (detailOpen.has(id)) detailOpen.delete(id); else detailOpen.add(id);
+    renderGroups();
+  }
+
+  function detailRow(ev) {
+    let bits = '';
+    if (ev.genre) bits += '<div><span class="dk">genre</span> ' + esc(ev.genre) + '</div>';
+    if (ev.age_restriction) bits += '<div><span class="dk">ages</span> ' + esc(ev.age_restriction) + '</div>';
+    if (ev.artist && ev.artist !== ev.name) bits += '<div><span class="dk">listed as</span> ' + esc(ev.name) + '</div>';
+    if (ev.description) bits += '<div class="desc">' + esc(ev.description) + '</div>';
+    if (ev.ticket_url) {
+      bits += '<div><a href="' + esc(ev.ticket_url) + '" target="_blank" rel="noopener noreferrer">open venue page</a></div>';
+    }
+    // Most events carry no description at all, so say so rather than opening an
+    // empty panel that looks broken.
+    if (!bits) bits = '<div class="dk">no description, genre, or link on this event</div>';
+    return '<tr class="detail"><td></td><td colspan="3">' + bits + '</td></tr>';
+  }
+
+  function eventRow(ev, cls) {
+    const open = detailOpen.has(ev.id);
+    return '<tr class="' + cls + ' erow' + (open ? ' eopen' : '') + '" onclick="toggleDetail(' + ev.id + ')">' +
+      '<td>' + ev.date + '</td>' +
       '<td>' + esc(ev.artist || ev.name) + '<div class="sub">' + esc(ev.venue_name || '') + '</div></td>' +
       '<td>' + badge(ev) + '</td>' +
-      '<td class="actions">' + actions(ev) + '</td></tr>'
-    ).join('') : '<tr><td colspan="4" class="empty">no events</td></tr>';
+      '<td class="actions" onclick="event.stopPropagation()">' + actions(ev) + '</td></tr>' +
+      (open ? detailRow(ev) : '');
+  }
+
+  function groupRow(i, evs) {
+    const first = evs[0], last = evs[evs.length - 1];
+    const open = expanded.has(GROUPS[i][0]);
+    const dates = first.date === last.date ? first.date : first.date + ' - ' + last.date;
+    return '<tr class="grow" onclick="toggleGroup(' + i + ')">' +
+      '<td><span class="caret">' + (open ? 'v' : '>') + '</span>' + dates + '</td>' +
+      '<td>' + esc(first.name) + ' <span class="gcount">(' + evs.length + ' dates)</span>' +
+        '<div class="sub">' + esc(first.venue_name || '') + '</div></td>' +
+      '<td>' + groupBadge(evs) + '</td>' +
+      '<td class="actions" onclick="event.stopPropagation()">' +
+        approveAction(first, true, first.series_size) + ' ' + seriesActions(first) +
+      '</td></tr>';
+  }
+
+  function renderGroups() {
+    if (!GROUPS.length) {
+      $('#tbody').innerHTML = '<tr><td colspan="4" class="empty">no events</td></tr>';
+      return;
+    }
+    let html = '';
+    GROUPS.forEach((entry, i) => {
+      const evs = entry[1];
+      // A one-off event has nothing to collapse, so render it as a plain row.
+      if (evs.length === 1) { html += eventRow(evs[0], ''); return; }
+      html += groupRow(i, evs);
+      if (expanded.has(entry[0])) {
+        evs.forEach((ev) => { html += eventRow(ev, 'child'); });
+      }
+    });
+    $('#tbody').innerHTML = html;
+  }
+
+  function toggleGroup(i) {
+    const k = GROUPS[i][0];
+    if (expanded.has(k)) expanded.delete(k); else expanded.add(k);
+    renderGroups();
+  }
+
+  function render(evs, count, total, approvedHidden) {
+    GROUPS = buildGroups(evs);
+    const seriesCount = GROUPS.filter((g) => g[1].length > 1).length;
+    const hidden = approvedHidden ? ' · ' + approvedHidden + ' approved hidden' : '';
+    // Say when the view is partial. A series action reaches every matching event,
+    // including ones cut off by the row cap or hidden by future-only, so a silent
+    // count would understate what a series button affects.
+    const truncated = total > count;
+    $('#count').innerHTML =
+      (truncated ? '<span class="warn">' + count + ' of ' + total + ' shown</span>'
+                 : count + ' event(s)') +
+      (seriesCount ? ', ' + seriesCount + ' series' : '') +
+      (state.futureOnly ? ' · past dates hidden' : '') + hidden;
+    renderGroups();
   }
 
   async function load() {
-    const q = new URLSearchParams({ filter: state.filter, search: state.search });
+    const q = new URLSearchParams({
+      filter: state.filter,
+      search: state.search,
+      future_only: state.futureOnly ? 'true' : 'false',
+      show_approved: state.showApproved ? 'true' : 'false',
+    });
     const data = await api('/admin/api/events?' + q.toString());
-    render(data.events, data.count);
+    render(data.events, data.count, data.total, data.approved_hidden);
   }
 
   async function ov(id, isLive) {
@@ -200,13 +420,55 @@ ADMIN_HTML = """<!doctype html>
   }
   function setFilter(f) {
     state.filter = f;
-    document.querySelectorAll('.fbtn').forEach((b) => b.classList.toggle('on', b.dataset.f === f));
+    // Only the data-f buttons are a radio group; the future-only toggle is
+    // independent and must not be cleared when the classification filter changes.
+    document.querySelectorAll('.fbtn[data-f]').forEach((b) => b.classList.toggle('on', b.dataset.f === f));
     load();
   }
+
+  function toggleFuture() {
+    state.futureOnly = !state.futureOnly;
+    $('#futureBtn').classList.toggle('on', state.futureOnly);
+    $('#futureBtn').setAttribute('aria-pressed', state.futureOnly ? 'true' : 'false');
+    load();
+  }
+
+  function toggleApproved() {
+    state.showApproved = !state.showApproved;
+    $('#approvedBtn').classList.toggle('on', state.showApproved);
+    $('#approvedBtn').setAttribute('aria-pressed', state.showApproved ? 'true' : 'false');
+    load();
+  }
+
+  async function approve(id, isSeries) {
+    await api('/admin/api/events/' + id + '/approve?series=' + (isSeries ? 'true' : 'false'), { method: 'POST' });
+    load();
+  }
+  async function unapprove(id, isSeries) {
+    await api('/admin/api/events/' + id + '/unapprove?series=' + (isSeries ? 'true' : 'false'), { method: 'POST' });
+    load();
+  }
+  // Panel toggles. Reflect open/closed on the button itself, so each reads as a
+  // toggle rather than a one-way action and it's obvious how to dismiss it. The two
+  // panels are mutually exclusive — opening one closes the other.
+  function setPanel(panelId, btnId, shown) {
+    $(panelId).classList.toggle('hidden', !shown);
+    $(btnId).classList.toggle('on', shown);
+    $(btnId).setAttribute('aria-expanded', shown ? 'true' : 'false');
+  }
+
   async function showRules() {
     if (!RULES) RULES = await api('/admin/api/rules');
     $('#rules').textContent = JSON.stringify(RULES, null, 2);
-    $('#rules').classList.toggle('hidden');
+    const shown = $('#rules').classList.contains('hidden');
+    setPanel('#rules', '#rulesBtn', shown);
+    if (shown) setPanel('#help', '#helpBtn', false);
+  }
+
+  function showHelp() {
+    const shown = $('#help').classList.contains('hidden');
+    setPanel('#help', '#helpBtn', shown);
+    if (shown) setPanel('#rules', '#rulesBtn', false);
   }
 
   let t;

--- a/backend/app/admin_ui.py
+++ b/backend/app/admin_ui.py
@@ -1,0 +1,222 @@
+"""
+Static HTML/JS for the admin subsite, served by app.api.admin.
+
+Role: Two self-contained pages — a login screen and the moderation dashboard —
+returned as strings by the admin routes. Kept out of the public `frontend/` static
+mount so the dashboard is only reachable through the auth-guarded route. All data
+is loaded from the guarded /admin/api/* endpoints via fetch; these strings contain
+no secrets. Plain triple-quoted strings (NOT f-strings) so JS `${}`/`{}` are literal.
+"""
+
+# --- Login page ---
+
+LOGIN_HTML = """<!doctype html>
+<html lang="en"><head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>admin · triangle-shows</title>
+<style>
+  :root { color-scheme: dark; }
+  body { margin:0; min-height:100vh; display:grid; place-items:center;
+         background:#0e0e10; color:#e8e6e3; font-family:'Space Mono',ui-monospace,monospace; }
+  .box { width:min(90vw,340px); border:1px solid #2a2a2e; padding:1.6rem; border-radius:2px; }
+  h1 { font-size:0.95rem; letter-spacing:0.08em; text-transform:uppercase; color:#c87941; margin:0 0 1.2rem; }
+  input, button { width:100%; font-family:inherit; font-size:0.85rem; padding:0.55rem 0.6rem;
+                  box-sizing:border-box; border-radius:2px; }
+  input { background:#17171a; border:1px solid #2a2a2e; color:#e8e6e3; margin-bottom:0.7rem; }
+  input:focus { outline:none; border-color:#c87941; }
+  button { background:#c87941; border:1px solid #c87941; color:#0e0e10; cursor:pointer; font-weight:700; }
+  button:hover { filter:brightness(1.1); }
+  .err { color:#e0625f; font-size:0.75rem; min-height:1em; margin:0.7rem 0 0; }
+</style>
+</head><body>
+  <div class="box">
+    <h1>triangle-shows admin</h1>
+    <form id="f">
+      <input type="password" id="pw" placeholder="password" autocomplete="current-password" autofocus>
+      <button type="submit">log in</button>
+    </form>
+    <p id="err" class="err"></p>
+  </div>
+<script>
+  const f = document.getElementById('f'), err = document.getElementById('err');
+  f.addEventListener('submit', async (e) => {
+    e.preventDefault();
+    err.textContent = '';
+    try {
+      const r = await fetch('/admin/login', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ password: document.getElementById('pw').value }),
+      });
+      if (r.ok) { location.href = '/admin'; }
+      else { err.textContent = 'invalid password'; }
+    } catch (_) { err.textContent = 'something went wrong'; }
+  });
+</script>
+</body></html>
+"""
+
+
+# --- Dashboard page ---
+
+ADMIN_HTML = """<!doctype html>
+<html lang="en"><head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>admin · triangle-shows</title>
+<style>
+  :root { color-scheme: dark; }
+  * { box-sizing:border-box; }
+  body { margin:0; background:#0e0e10; color:#e8e6e3;
+         font-family:'Space Mono',ui-monospace,monospace; font-size:0.82rem; }
+  header { display:flex; align-items:center; gap:1rem; padding:0.8rem 1.1rem;
+           border-bottom:1px solid #2a2a2e; position:sticky; top:0; background:#0e0e10; z-index:2; }
+  header h1 { font-size:0.9rem; letter-spacing:0.08em; text-transform:uppercase; color:#c87941; margin:0; }
+  header .sp { flex:1; }
+  a { color:#c87941; }
+  main { padding:1.1rem; max-width:1100px; margin:0 auto; }
+  .controls { display:flex; flex-wrap:wrap; gap:0.5rem; align-items:center; margin-bottom:1rem; }
+  .fbtn, button.link { font-family:inherit; font-size:0.72rem; text-transform:uppercase; letter-spacing:0.06em;
+          padding:0.3rem 0.6rem; border:1px solid #3a3a3e; background:transparent; color:#a8a6a3;
+          cursor:pointer; border-radius:2px; }
+  .fbtn.on { background:#c87941; border-color:#c87941; color:#0e0e10; font-weight:700; }
+  #search { flex:1; min-width:160px; font-family:inherit; font-size:0.8rem; padding:0.35rem 0.6rem;
+            background:#17171a; border:1px solid #2a2a2e; color:#e8e6e3; border-radius:2px; }
+  #count { color:#8a8a8e; font-size:0.72rem; margin-left:auto; }
+  table { width:100%; border-collapse:collapse; }
+  th, td { text-align:left; padding:0.5rem 0.5rem; border-bottom:1px solid #1e1e22; vertical-align:top; }
+  th { color:#8a8a8e; font-size:0.66rem; text-transform:uppercase; letter-spacing:0.08em; }
+  td .sub { color:#8a8a8e; font-size:0.72rem; margin-top:0.15rem; }
+  .b { display:inline-block; padding:0.05rem 0.4rem; border-radius:2px; font-size:0.68rem; font-weight:700; text-transform:uppercase; }
+  .b.live { background:#1f3d2a; color:#7fd69a; }
+  .b.nonlive { background:#3d2020; color:#e08a88; }
+  .b.manual { background:#3a2f12; color:#e0b45f; }
+  .reason { color:#8a8a8e; font-size:0.7rem; }
+  td.actions { white-space:nowrap; }
+  td.actions button { font-family:inherit; font-size:0.68rem; margin:0.1rem 0.15rem 0.1rem 0; padding:0.22rem 0.45rem;
+          border:1px solid #3a3a3e; background:transparent; color:#c8c6c3; cursor:pointer; border-radius:2px; }
+  td.actions button:hover { border-color:#c87941; color:#c87941; }
+  .series { color:#8a8a8e; }
+  .empty { color:#8a8a8e; text-align:center; padding:1.5rem; }
+  #rules { white-space:pre-wrap; background:#17171a; border:1px solid #2a2a2e; padding:0.8rem;
+           border-radius:2px; font-size:0.72rem; margin-top:1rem; color:#b8b6b3; }
+  .hidden { display:none; }
+</style>
+</head><body>
+  <header>
+    <h1>triangle-shows admin</h1>
+    <button class="link" onclick="showRules()">detection rules</button>
+    <span class="sp"></span>
+    <a href="/admin/logout">log out</a>
+  </header>
+  <main>
+    <div class="controls">
+      <button class="fbtn on" data-f="non_live" onclick="setFilter('non_live')">non-live</button>
+      <button class="fbtn" data-f="live" onclick="setFilter('live')">live</button>
+      <button class="fbtn" data-f="all" onclick="setFilter('all')">all</button>
+      <input id="search" placeholder="search name / artist...">
+      <span id="count"></span>
+    </div>
+    <pre id="rules" class="hidden"></pre>
+    <table>
+      <thead><tr><th>date</th><th>event</th><th>status</th><th>actions</th></tr></thead>
+      <tbody id="tbody"></tbody>
+    </table>
+  </main>
+<script>
+  let RULES = null;
+  const $ = (s) => document.querySelector(s);
+  const state = { filter: 'non_live', search: '' };
+
+  async function api(path, opts) {
+    const r = await fetch(path, Object.assign({ headers: { 'Content-Type': 'application/json' } }, opts));
+    if (r.status === 401) { location.href = '/admin/login'; throw new Error('unauth'); }
+    if (!r.ok) throw new Error('http ' + r.status);
+    return r.status === 204 ? null : r.json();
+  }
+
+  function esc(s) {
+    return (s || '').replace(/[&<>"]/g, (c) => ({ '&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;' }[c]));
+  }
+
+  function badge(ev) {
+    if (ev.is_manual_override)
+      return '<span class="b manual">manual: ' + (ev.is_live_music ? 'live' : 'non-live') + '</span>';
+    return '<span class="b ' + (ev.is_live_music ? 'live' : 'nonlive') + '">' +
+           (ev.is_live_music ? 'live' : 'non-live') + '</span> ' +
+           '<span class="reason">' + esc(ev.classification_reason || '') + '</span>';
+  }
+
+  function actions(ev) {
+    let a = '';
+    if (ev.is_manual_override) {
+      a += '<button onclick="clearOv(' + ev.id + ')">clear override</button>';
+    } else {
+      a += '<button onclick="ov(' + ev.id + ',true)">mark live</button>';
+      a += '<button onclick="ov(' + ev.id + ',false)">mark non-live</button>';
+    }
+    if (ev.series_override_id) {
+      a += ' <span class="series">series: ' + (ev.series_override_is_live ? 'live' : 'non-live') +
+           ' <button onclick="delSeries(' + ev.series_override_id + ')">remove</button></span>';
+    } else {
+      a += ' <button onclick="series(' + ev.id + ',true)">series live</button>';
+      a += '<button onclick="series(' + ev.id + ',false)">series non-live</button>';
+    }
+    return a;
+  }
+
+  function render(evs, count) {
+    $('#count').textContent = count + ' event(s)';
+    $('#tbody').innerHTML = evs.length ? evs.map((ev) =>
+      '<tr><td>' + ev.date + '</td>' +
+      '<td>' + esc(ev.artist || ev.name) + '<div class="sub">' + esc(ev.venue_name || '') + '</div></td>' +
+      '<td>' + badge(ev) + '</td>' +
+      '<td class="actions">' + actions(ev) + '</td></tr>'
+    ).join('') : '<tr><td colspan="4" class="empty">no events</td></tr>';
+  }
+
+  async function load() {
+    const q = new URLSearchParams({ filter: state.filter, search: state.search });
+    const data = await api('/admin/api/events?' + q.toString());
+    render(data.events, data.count);
+  }
+
+  async function ov(id, isLive) {
+    await api('/admin/api/events/' + id + '/override', { method: 'POST', body: JSON.stringify({ is_live_music: isLive }) });
+    load();
+  }
+  async function clearOv(id) {
+    await api('/admin/api/events/' + id + '/clear-override', { method: 'POST' });
+    load();
+  }
+  async function series(eventId, isLive) {
+    await api('/admin/api/series', { method: 'POST', body: JSON.stringify({ event_id: eventId, is_live_music: isLive }) });
+    load();
+  }
+  async function delSeries(id) {
+    await api('/admin/api/series/' + id, { method: 'DELETE' });
+    load();
+  }
+  function setFilter(f) {
+    state.filter = f;
+    document.querySelectorAll('.fbtn').forEach((b) => b.classList.toggle('on', b.dataset.f === f));
+    load();
+  }
+  async function showRules() {
+    if (!RULES) RULES = await api('/admin/api/rules');
+    $('#rules').textContent = JSON.stringify(RULES, null, 2);
+    $('#rules').classList.toggle('hidden');
+  }
+
+  let t;
+  document.addEventListener('DOMContentLoaded', () => {
+    $('#search').addEventListener('input', (e) => {
+      clearTimeout(t);
+      t = setTimeout(() => { state.search = e.target.value.trim(); load(); }, 300);
+    });
+    load();
+  });
+</script>
+</body></html>
+"""

--- a/backend/app/api/admin.py
+++ b/backend/app/api/admin.py
@@ -1,0 +1,287 @@
+"""
+Admin subsite mounted at /admin: password-gated UI + JSON API for reviewing and
+overriding live-music classification.
+
+Role: Lets a site admin flip an event's is_live_music flag (per-event manual
+override), manage series-level overrides (SeriesOverride), and view the automatic
+detection criteria. Auth is a single shared password (settings.ADMIN_PASSWORD)
+exchanged for an itsdangerous-signed session cookie; if ADMIN_PASSWORD is blank the
+admin is disabled (fails closed). Must be registered before the "/" static mount in
+main.py so these routes take priority over the catch-all.
+Requires: async PostgreSQL session, app.classifier, app.scrapers.manager, itsdangerous.
+"""
+import secrets
+from datetime import date
+from typing import Optional
+
+from fastapi import APIRouter, Depends, HTTPException, Request, Query
+from fastapi.responses import HTMLResponse, JSONResponse, RedirectResponse
+from itsdangerous import URLSafeTimedSerializer, BadSignature, SignatureExpired
+from pydantic import BaseModel
+from sqlalchemy import select, and_, or_
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import joinedload
+
+from app.config import settings
+from app.database import get_session
+from app.models import Event, Venue, SeriesOverride
+from app.classifier import normalize_series_name, criteria_summary
+from app.scrapers.manager import ScrapeManager
+from app.admin_ui import LOGIN_HTML, ADMIN_HTML
+
+router = APIRouter(prefix="/admin", tags=["admin"])
+
+# --- Session cookie handling ---
+
+COOKIE_NAME = "ts_admin"
+SESSION_MAX_AGE = 60 * 60 * 12  # 12 hours
+
+# Prefer the configured secret; fall back to an ephemeral per-process key for local
+# dev (cookies won't survive a restart and won't validate across multiple Cloud Run
+# instances — SESSION_SECRET must be set in production).
+_signing_key = settings.SESSION_SECRET or secrets.token_urlsafe(32)
+_serializer = URLSafeTimedSerializer(_signing_key, salt="ts-admin-session")
+
+
+def _admin_enabled() -> bool:
+    """Admin is reachable only when a password is configured."""
+    return bool(settings.ADMIN_PASSWORD)
+
+
+def _issue_cookie(response) -> None:
+    token = _serializer.dumps("admin")
+    response.set_cookie(
+        COOKIE_NAME,
+        token,
+        max_age=SESSION_MAX_AGE,
+        httponly=True,
+        samesite="lax",  # blocks the cookie on cross-site POSTs -> basic CSRF protection
+        secure=(settings.APP_ENV == "production"),
+        path="/admin",
+    )
+
+
+def _is_authenticated(request: Request) -> bool:
+    token = request.cookies.get(COOKIE_NAME)
+    if not token:
+        return False
+    try:
+        _serializer.loads(token, max_age=SESSION_MAX_AGE)
+        return True
+    except (BadSignature, SignatureExpired):
+        return False
+
+
+async def require_admin(request: Request) -> bool:
+    """Dependency guarding /admin/api/* — raises 401 for the frontend to redirect on."""
+    if not _is_authenticated(request):
+        raise HTTPException(status_code=401, detail="Not authenticated")
+    return True
+
+
+# --- Request bodies ---
+
+class LoginBody(BaseModel):
+    password: str
+
+
+class OverrideBody(BaseModel):
+    is_live_music: bool
+
+
+class SeriesBody(BaseModel):
+    event_id: int
+    is_live_music: bool
+    note: Optional[str] = None
+
+
+# --- Auth + page routes ---
+
+@router.get("/login", response_class=HTMLResponse)
+async def login_page() -> HTMLResponse:
+    return HTMLResponse(LOGIN_HTML)
+
+
+@router.post("/login")
+async def login_submit(body: LoginBody):
+    # compare_digest guards against timing attacks; also fails closed when no
+    # password is configured (compare against "" would otherwise accept "").
+    if _admin_enabled() and secrets.compare_digest(body.password, settings.ADMIN_PASSWORD):
+        response = JSONResponse({"ok": True})
+        _issue_cookie(response)
+        return response
+    return JSONResponse({"ok": False, "error": "invalid"}, status_code=401)
+
+
+@router.get("/logout")
+async def logout() -> RedirectResponse:
+    response = RedirectResponse("/admin/login", status_code=303)
+    response.delete_cookie(COOKIE_NAME, path="/admin")
+    return response
+
+
+@router.get("", response_class=HTMLResponse)
+async def admin_page(request: Request):
+    if not _is_authenticated(request):
+        return RedirectResponse("/admin/login", status_code=303)
+    return HTMLResponse(ADMIN_HTML)
+
+
+# --- JSON API (all guarded) ---
+
+@router.get("/api/rules", dependencies=[Depends(require_admin)])
+async def admin_rules() -> dict:
+    """Return the current automatic detection criteria for display."""
+    return criteria_summary()
+
+
+@router.get("/api/events", dependencies=[Depends(require_admin)])
+async def admin_events(
+    filter: str = Query("non_live", pattern="^(non_live|live|all)$"),
+    search: Optional[str] = None,
+    limit: int = Query(200, ge=1, le=1000),
+    session: AsyncSession = Depends(get_session),
+) -> dict:
+    """List upcoming events with classification + override state for moderation."""
+    conditions = [Event.date >= date.today()]
+    if filter == "non_live":
+        conditions.append(Event.is_live_music.is_(False))
+    elif filter == "live":
+        conditions.append(Event.is_live_music.is_(True))
+    if search:
+        term = f"%{search}%"
+        conditions.append(or_(Event.name.ilike(term), Event.artist.ilike(term)))
+
+    result = await session.execute(
+        select(Event)
+        .options(joinedload(Event.venue))
+        .where(and_(*conditions))
+        .order_by(Event.date)
+        .limit(limit)
+    )
+    events = result.unique().scalars().all()
+
+    # Annotate each event with any matching series override.
+    so_result = await session.execute(select(SeriesOverride))
+    series = {(s.venue_id, s.normalized_name): s for s in so_result.scalars().all()}
+
+    out = []
+    for e in events:
+        so = series.get((e.venue_id, normalize_series_name(e.name)))
+        out.append({
+            "id": e.id,
+            "name": e.name,
+            "artist": e.artist,
+            "date": e.date.isoformat(),
+            "venue_name": e.venue.name if e.venue else None,
+            "venue_slug": e.venue.slug if e.venue else None,
+            "is_live_music": e.is_live_music,
+            "is_manual_override": e.is_manual_override,
+            "classification_reason": e.classification_reason,
+            "series_override_id": so.id if so else None,
+            "series_override_is_live": so.is_live_music if so else None,
+        })
+    return {"events": out, "count": len(out)}
+
+
+@router.post("/api/events/{event_id}/override", dependencies=[Depends(require_admin)])
+async def set_override(
+    event_id: int,
+    body: OverrideBody,
+    session: AsyncSession = Depends(get_session),
+) -> dict:
+    """Force a single event's flag. Marked as a manual override so re-scrapes keep it."""
+    event = await session.get(Event, event_id)
+    if not event:
+        raise HTTPException(status_code=404, detail="Event not found")
+    event.is_live_music = body.is_live_music
+    event.is_manual_override = True
+    event.classification_reason = "manual"
+    await session.commit()
+    return {"ok": True, "id": event_id, "is_live_music": body.is_live_music}
+
+
+@router.post("/api/events/{event_id}/clear-override", dependencies=[Depends(require_admin)])
+async def clear_override(
+    event_id: int,
+    session: AsyncSession = Depends(get_session),
+) -> dict:
+    """Drop a per-event override and recompute automatic/series/venue classification."""
+    event = await session.get(Event, event_id)
+    if not event:
+        raise HTTPException(status_code=404, detail="Event not found")
+    event.is_manual_override = False
+    await session.commit()
+    # Recompute now so the UI reflects the automatic result immediately.
+    await ScrapeManager(session).reclassify_all()
+    return {"ok": True, "id": event_id}
+
+
+@router.get("/api/series", dependencies=[Depends(require_admin)])
+async def list_series(session: AsyncSession = Depends(get_session)) -> dict:
+    """List all series-level overrides with their venue name."""
+    result = await session.execute(
+        select(SeriesOverride, Venue)
+        .join(Venue, SeriesOverride.venue_id == Venue.id)
+        .order_by(SeriesOverride.created_at.desc())
+    )
+    return {"series": [{
+        "id": so.id,
+        "venue_id": so.venue_id,
+        "venue_name": venue.name,
+        "normalized_name": so.normalized_name,
+        "display_name": so.display_name,
+        "is_live_music": so.is_live_music,
+        "note": so.note,
+    } for so, venue in result.all()]}
+
+
+@router.post("/api/series", dependencies=[Depends(require_admin)])
+async def upsert_series(
+    body: SeriesBody,
+    session: AsyncSession = Depends(get_session),
+) -> dict:
+    """Create/update a series override from an example event, then reclassify so all
+    matching instances (present and future) pick it up."""
+    event = await session.get(Event, body.event_id)
+    if not event:
+        raise HTTPException(status_code=404, detail="Event not found")
+
+    normalized = normalize_series_name(event.name)
+    existing = (await session.execute(
+        select(SeriesOverride).where(
+            SeriesOverride.venue_id == event.venue_id,
+            SeriesOverride.normalized_name == normalized,
+        )
+    )).scalar_one_or_none()
+
+    if existing:
+        existing.is_live_music = body.is_live_music
+        existing.note = body.note
+        existing.display_name = event.name
+    else:
+        session.add(SeriesOverride(
+            venue_id=event.venue_id,
+            normalized_name=normalized,
+            display_name=event.name,
+            is_live_music=body.is_live_music,
+            note=body.note,
+        ))
+    await session.commit()
+    await ScrapeManager(session).reclassify_all()
+    return {"ok": True}
+
+
+@router.delete("/api/series/{series_id}", dependencies=[Depends(require_admin)])
+async def delete_series(
+    series_id: int,
+    session: AsyncSession = Depends(get_session),
+) -> dict:
+    """Remove a series override, then reclassify so its events revert to automatic."""
+    override = await session.get(SeriesOverride, series_id)
+    if not override:
+        raise HTTPException(status_code=404, detail="Series override not found")
+    await session.delete(override)
+    await session.commit()
+    await ScrapeManager(session).reclassify_all()
+    return {"ok": True}

--- a/backend/app/api/admin.py
+++ b/backend/app/api/admin.py
@@ -11,21 +11,21 @@ main.py so these routes take priority over the catch-all.
 Requires: async PostgreSQL session, app.classifier, app.scrapers.manager, itsdangerous.
 """
 import secrets
-from datetime import date
+from datetime import date, datetime
 from typing import Optional
 
 from fastapi import APIRouter, Depends, HTTPException, Request, Query
 from fastapi.responses import HTMLResponse, JSONResponse, RedirectResponse
 from itsdangerous import URLSafeTimedSerializer, BadSignature, SignatureExpired
 from pydantic import BaseModel
-from sqlalchemy import select, and_, or_
+from sqlalchemy import select, and_, or_, func
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import joinedload
 
 from app.config import settings
 from app.database import get_session
 from app.models import Event, Venue, SeriesOverride
-from app.classifier import normalize_series_name, criteria_summary
+from app.classifier import normalize_series_name, criteria_summary, reclassify_floor
 from app.scrapers.manager import ScrapeManager
 from app.admin_ui import LOGIN_HTML, ADMIN_HTML
 
@@ -139,18 +139,34 @@ async def admin_rules() -> dict:
 async def admin_events(
     filter: str = Query("non_live", pattern="^(non_live|live|all)$"),
     search: Optional[str] = None,
-    limit: int = Query(200, ge=1, le=1000),
+    future_only: bool = Query(False, description="Hide events before today"),
+    show_approved: bool = Query(False, description="Include events already reviewed"),
+    limit: int = Query(1000, ge=1, le=5000),
     session: AsyncSession = Depends(get_session),
 ) -> dict:
-    """List upcoming events with classification + override state for moderation."""
-    conditions = [Event.date >= date.today()]
+    """List events with classification + override state for moderation.
+
+    Defaults to the same floor reclassification uses, so a series row shows every
+    event a series action will actually affect — listing only future dates would
+    understate scope. future_only narrows the view to today onward; it does not
+    change what a series action touches.
+    """
+    floor = date.today() if future_only else reclassify_floor()
+
+    # Split so the approved filter can be counted separately: `base` is everything the
+    # user asked for, `conditions` adds the approved exclusion actually applied.
+    base = [Event.date >= floor]
     if filter == "non_live":
-        conditions.append(Event.is_live_music.is_(False))
+        base.append(Event.is_live_music.is_(False))
     elif filter == "live":
-        conditions.append(Event.is_live_music.is_(True))
+        base.append(Event.is_live_music.is_(True))
     if search:
         term = f"%{search}%"
-        conditions.append(or_(Event.name.ilike(term), Event.artist.ilike(term)))
+        base.append(or_(Event.name.ilike(term), Event.artist.ilike(term)))
+
+    conditions = list(base)
+    if not show_approved:
+        conditions.append(Event.approved_at.is_(None))
 
     result = await session.execute(
         select(Event)
@@ -161,13 +177,47 @@ async def admin_events(
     )
     events = result.unique().scalars().all()
 
+    # Total matching rows, ignoring `limit`. Without this the response could only
+    # report how many rows came back, so a truncated page was indistinguishable from
+    # a complete one — the UI would say "1000 event(s)" whether that was all of them
+    # or the first 1000 of several thousand.
+    total = (
+        await session.execute(
+            select(func.count()).select_from(Event).where(and_(*conditions))
+        )
+    ).scalar_one()
+
+    # How many rows the approved filter is holding back, so that omission is visible
+    # too rather than silently shrinking the queue.
+    approved_hidden = 0
+    if not show_approved:
+        approved_hidden = (
+            await session.execute(
+                select(func.count()).select_from(Event)
+                .where(and_(*base, Event.approved_at.is_not(None)))
+            )
+        ).scalar_one()
+
     # Annotate each event with any matching series override.
     so_result = await session.execute(select(SeriesOverride))
     series = {(s.venue_id, s.normalized_name): s for s in so_result.scalars().all()}
 
+    # Series sizes across the whole reclassify range, deliberately ignoring both
+    # `future_only` and `limit`: a series action reaches every matching event, so the
+    # button label must count them all or it understates its own blast radius.
+    # Grouping happens in Python because normalize_series_name has no SQL equivalent.
+    span_rows = await session.execute(
+        select(Event.venue_id, Event.name).where(Event.date >= reclassify_floor())
+    )
+    series_sizes: dict[tuple[int, str], int] = {}
+    for venue_id, name in span_rows.all():
+        key = (venue_id, normalize_series_name(name))
+        series_sizes[key] = series_sizes.get(key, 0) + 1
+
     out = []
     for e in events:
-        so = series.get((e.venue_id, normalize_series_name(e.name)))
+        series_key = normalize_series_name(e.name)
+        so = series.get((e.venue_id, series_key))
         out.append({
             "id": e.id,
             "name": e.name,
@@ -178,10 +228,28 @@ async def admin_events(
             "is_live_music": e.is_live_music,
             "is_manual_override": e.is_manual_override,
             "classification_reason": e.classification_reason,
+            "is_approved": e.approved_at is not None,
+            # Detail shown when a row is expanded, to judge live-vs-not by hand.
+            # Descriptions are sparse (~10% of events), so the ticket link is often
+            # the only way to settle an ambiguous one.
+            "description": e.description,
+            "genre": e.genre,
+            "ticket_url": e.ticket_url,
+            "age_restriction": e.age_restriction,
+            # Exposed so the dashboard can collapse a series into one row using the
+            # same key a series override matches on — group and override stay in sync.
+            "series_key": series_key,
+            # How many events a series action on this row would actually affect.
+            "series_size": series_sizes.get((e.venue_id, series_key), 1),
             "series_override_id": so.id if so else None,
             "series_override_is_live": so.is_live_music if so else None,
         })
-    return {"events": out, "count": len(out)}
+    return {
+        "events": out,
+        "count": len(out),
+        "total": total,
+        "approved_hidden": approved_hidden,
+    }
 
 
 @router.post("/api/events/{event_id}/override", dependencies=[Depends(require_admin)])
@@ -197,6 +265,9 @@ async def set_override(
     event.is_live_music = body.is_live_music
     event.is_manual_override = True
     event.classification_reason = "manual"
+    # Setting the flag by hand *is* the review, so approve it too rather than asking
+    # the admin to confirm a decision they just made.
+    event.approved_at = datetime.utcnow()
     await session.commit()
     return {"ok": True, "id": event_id, "is_live_music": body.is_live_music}
 
@@ -211,10 +282,85 @@ async def clear_override(
     if not event:
         raise HTTPException(status_code=404, detail="Event not found")
     event.is_manual_override = False
+    # Dropping the override returns the event to unreviewed automatic classification,
+    # so the approval that came with the override goes too.
+    event.approved_at = None
     await session.commit()
     # Recompute now so the UI reflects the automatic result immediately.
     await ScrapeManager(session).reclassify_all()
     return {"ok": True, "id": event_id}
+
+
+@router.post("/api/events/{event_id}/approve", dependencies=[Depends(require_admin)])
+async def approve_event(
+    event_id: int,
+    series: bool = Query(False, description="Approve every event in this event's series"),
+    session: AsyncSession = Depends(get_session),
+) -> dict:
+    """Mark a classification as reviewed and correct, hiding it from the default queue.
+
+    With series=true the event acts as a sample: every event sharing its venue and
+    normalized name is approved too. Classification is largely per-series, so
+    approving 20-odd recurring dates one at a time would be punishing.
+    """
+    event = await session.get(Event, event_id)
+    if not event:
+        raise HTTPException(status_code=404, detail="Event not found")
+
+    now = datetime.utcnow()
+    if not series:
+        event.approved_at = now
+        await session.commit()
+        return {"ok": True, "id": event_id, "approved": 1}
+
+    # Same key the series overrides and the dashboard's grouping use, so "approve
+    # series" covers exactly the rows the group row displays.
+    key = normalize_series_name(event.name)
+    rows = (await session.execute(
+        select(Event).where(
+            Event.venue_id == event.venue_id,
+            Event.date >= reclassify_floor(),
+        )
+    )).scalars().all()
+    approved = 0
+    for ev in rows:
+        if normalize_series_name(ev.name) == key and ev.approved_at is None:
+            ev.approved_at = now
+            approved += 1
+    await session.commit()
+    return {"ok": True, "id": event_id, "approved": approved}
+
+
+@router.post("/api/events/{event_id}/unapprove", dependencies=[Depends(require_admin)])
+async def unapprove_event(
+    event_id: int,
+    series: bool = Query(False, description="Un-approve every event in this event's series"),
+    session: AsyncSession = Depends(get_session),
+) -> dict:
+    """Return an event (or its whole series) to the review queue."""
+    event = await session.get(Event, event_id)
+    if not event:
+        raise HTTPException(status_code=404, detail="Event not found")
+
+    if not series:
+        event.approved_at = None
+        await session.commit()
+        return {"ok": True, "id": event_id, "unapproved": 1}
+
+    key = normalize_series_name(event.name)
+    rows = (await session.execute(
+        select(Event).where(
+            Event.venue_id == event.venue_id,
+            Event.date >= reclassify_floor(),
+        )
+    )).scalars().all()
+    unapproved = 0
+    for ev in rows:
+        if normalize_series_name(ev.name) == key and ev.approved_at is not None:
+            ev.approved_at = None
+            unapproved += 1
+    await session.commit()
+    return {"ok": True, "id": event_id, "unapproved": unapproved}
 
 
 @router.get("/api/series", dependencies=[Depends(require_admin)])

--- a/backend/app/api/admin.py
+++ b/backend/app/api/admin.py
@@ -106,7 +106,16 @@ async def login_page() -> HTMLResponse:
 async def login_submit(body: LoginBody):
     # compare_digest guards against timing attacks; also fails closed when no
     # password is configured (compare against "" would otherwise accept "").
-    if _admin_enabled() and secrets.compare_digest(body.password, settings.ADMIN_PASSWORD):
+    #
+    # Both operands are encoded to bytes because compare_digest rejects a str containing
+    # any non-ASCII character, raising TypeError rather than returning False. Passed
+    # strings directly, a password with an accented character turned a wrong-password
+    # attempt into a 500 instead of a clean 401 — and, since the message differs, told the
+    # caller something about the configured password. UTF-8 on both sides compares the
+    # same bytes the client sent.
+    if _admin_enabled() and secrets.compare_digest(
+        body.password.encode("utf-8"), settings.ADMIN_PASSWORD.encode("utf-8")
+    ):
         response = JSONResponse({"ok": True})
         _issue_cookie(response)
         return response

--- a/backend/app/api/events.py
+++ b/backend/app/api/events.py
@@ -27,6 +27,19 @@ router = APIRouter(prefix="/api/events", tags=["events"])
 
 # --- Helpers ---
 
+def _completeness(event: Event) -> tuple:
+    """Rank two listings of the same show: richer record wins, then most recently scraped.
+
+    Every component is total and the id breaks the last tie, so the winner does not depend
+    on the order the database returned rows in.
+    """
+    return (
+        bool(event.image_url) + bool(event.ticket_url) + (event.price_min is not None),
+        event.updated_at or datetime.min,
+        event.id,
+    )
+
+
 def _event_to_response(event: Event) -> EventResponse:
     """Map an ORM Event (with venue eagerly loaded) to the EventResponse schema."""
     return EventResponse(
@@ -110,26 +123,24 @@ async def get_fullcalendar_events(
     # unique() is required when using joinedload to collapse duplicate rows from the JOIN.
     events = result.unique().scalars().all()
 
-    # --- Cross-venue deduplication ---
-    # Cross-venue dedup: if the same artist performs on the same date at two
-    # different venues (e.g. listed on both a venue's own site and Ticketmaster),
-    # keep only the entry with the most complete metadata.
+    # --- Same-venue duplicate guard ---
+    # scrapers/manager.py is where duplicates are actually prevented; this is a display-time
+    # backstop covering the window between a venue editing an event and the next scrape.
+    #
+    # The key is scoped to the venue deliberately. An earlier version keyed only on
+    # (date, artist), which also collapsed listings at *different* venues — and two venues
+    # showing the same artist on one night is a moved or miscopied show, not a duplicate.
+    # Discarding one of them hid a real listing, and picked which venue survived from
+    # whichever row the database happened to return first.
     _dedup_best: dict[tuple, Event] = {}
-    _dedup_score: dict[tuple, int] = {}
     for event in events:
         label = event.artist or event.name
         # Normalize to lowercase alphanumeric so minor name differences don't prevent matching.
         norm = re.sub(r"[^a-z0-9]", "", label.lower())
-        key = (event.date, norm)
-        # Score based on how many key fields are populated; prefer richer records.
-        score = bool(event.image_url) + bool(event.ticket_url) + (event.price_min is not None)
-        if key not in _dedup_best:
+        key = (event.venue_id, event.date, norm)
+        incumbent = _dedup_best.get(key)
+        if incumbent is None or _completeness(event) > _completeness(incumbent):
             _dedup_best[key] = event
-            _dedup_score[key] = score
-        elif event.venue_id != _dedup_best[key].venue_id and score > _dedup_score[key]:
-            # Different venue but same artist/date — keep the more complete record.
-            _dedup_best[key] = event
-            _dedup_score[key] = score
     kept = {ev.id for ev in _dedup_best.values()}
     events = [e for e in events if e.id in kept]
 

--- a/backend/app/api/events.py
+++ b/backend/app/api/events.py
@@ -61,6 +61,7 @@ def _event_to_response(event: Event) -> EventResponse:
         age_restriction=event.age_restriction,
         description=event.description,
         source=event.source,
+        is_live_music=event.is_live_music,
         venue_name=event.venue.name if event.venue else None,
         venue_slug=event.venue.slug if event.venue else None,
         venue_city=event.venue.city if event.venue else None,
@@ -199,6 +200,8 @@ async def get_fullcalendar_events(
                 "status": event.status,
                 "age_restriction": event.age_restriction,
                 "description": event.description,
+                # Drives the client-side "Include non-live music?" toggle (filters.js).
+                "is_live_music": event.is_live_music,
             },
         })
 

--- a/backend/app/api/events.py
+++ b/backend/app/api/events.py
@@ -28,12 +28,28 @@ router = APIRouter(prefix="/api/events", tags=["events"])
 # --- Helpers ---
 
 def _completeness(event: Event) -> tuple:
-    """Rank two listings of the same show: richer record wins, then most recently scraped.
+    """Rank two listings of the same show, most authoritative key first.
+
+    Classification comes before metadata richness, because this guard runs before any
+    live-music filtering and so decides which row's verdict the calendar sees. Two rows for
+    one show can classify differently — most plausibly when an admin has hand-set one of
+    them, or when the dedup key and the recurrence key normalize a name differently. Ranking
+    only on field counts let the richer row win and silently discard the other's verdict,
+    which could drop a real show off the default calendar.
+
+    1. is_manual_override — an admin looked at this row and decided; that outranks anything
+       computed.
+    2. is_live_music — between two automatic verdicts, prefer the visible one. Consistent
+       with the feature's chosen failure direction: showing something that should have been
+       hidden is recoverable, hiding a real show is what users never see.
+    3. field count, then recency, then id — the original ordering, now as tiebreakers.
 
     Every component is total and the id breaks the last tie, so the winner does not depend
     on the order the database returned rows in.
     """
     return (
+        bool(getattr(event, "is_manual_override", False)),
+        bool(event.is_live_music),
         bool(event.image_url) + bool(event.ticket_url) + (event.price_min is not None),
         event.updated_at or datetime.min,
         event.id,
@@ -223,21 +239,24 @@ async def get_event(
     return _event_to_response(event)
 
 
-@router.get("")
-async def list_events(
-    start: Optional[str] = Query(None),
-    end: Optional[str] = Query(None),
-    search: Optional[str] = Query(None),
-    genre: Optional[str] = Query(None),
-    status: Optional[str] = Query(None),
-    page: int = Query(1, ge=1),
-    per_page: int = Query(50, ge=1, le=200),
-    session: AsyncSession = Depends(get_session),
-) -> EventListResponse:
-    """List events with filters and pagination."""
-    query = select(Event).options(joinedload(Event.venue)).order_by(Event.date)
-    count_query = select(func.count(Event.id))
+def _list_conditions(
+    *,
+    start: Optional[str] = None,
+    end: Optional[str] = None,
+    search: Optional[str] = None,
+    genre: Optional[str] = None,
+    status: Optional[str] = None,
+    include_non_music: bool = False,
+) -> list:
+    """Build the WHERE clauses for the events list, as data.
 
+    Split out of list_events so the filtering can be tested without a database. Declaring
+    the query parameter and then failing to apply it is a silent bug — the endpoint keeps
+    answering, just with the wrong rows — and an endpoint-level test cannot catch it
+    without Postgres.
+
+    Malformed dates are ignored rather than rejected, matching the previous behavior.
+    """
     conditions = []
 
     if start:
@@ -260,6 +279,45 @@ async def list_events(
         conditions.append(Event.genre.ilike(f"%{genre}%"))
     if status:
         conditions.append(Event.status == status)
+    # Default to live music only, so this endpoint stops being the one place the filter does
+    # not apply. /feeds/events.ics already behaves this way; the FullCalendar endpoint
+    # deliberately still returns everything, because filters.js toggles visibility in the
+    # browser without refetching, and filtering there server-side would empty the calendar
+    # when the toggle is switched on.
+    if not include_non_music:
+        conditions.append(Event.is_live_music.is_(True))
+
+    return conditions
+
+
+@router.get("")
+async def list_events(
+    start: Optional[str] = Query(None),
+    end: Optional[str] = Query(None),
+    search: Optional[str] = Query(None),
+    genre: Optional[str] = Query(None),
+    status: Optional[str] = Query(None),
+    include_non_music: bool = Query(
+        False,
+        description="Include non-live-music events (karaoke, trivia, theme nights, etc.). "
+                    "Off by default, matching /feeds/events.ics and the on-site calendar.",
+    ),
+    page: int = Query(1, ge=1),
+    per_page: int = Query(50, ge=1, le=200),
+    session: AsyncSession = Depends(get_session),
+) -> EventListResponse:
+    """List events with filters and pagination."""
+    query = select(Event).options(joinedload(Event.venue)).order_by(Event.date)
+    count_query = select(func.count(Event.id))
+
+    conditions = _list_conditions(
+        start=start,
+        end=end,
+        search=search,
+        genre=genre,
+        status=status,
+        include_non_music=include_non_music,
+    )
 
     if conditions:
         query = query.where(and_(*conditions))

--- a/backend/app/api/feeds.py
+++ b/backend/app/api/feeds.py
@@ -33,6 +33,11 @@ router = APIRouter(prefix="/feeds", tags=["feeds"])
 @router.get("/events.ics", response_class=Response)
 async def get_ical_feed(
     venue: Optional[str] = Query(None, description="Comma-separated venue slugs. Omit for all venues."),
+    include_non_music: bool = Query(
+        False,
+        description="Include non-live-music events (karaoke, trivia, theme nights, etc.). "
+                    "Off by default so subscribers get live music only.",
+    ),
     session: AsyncSession = Depends(get_session),
 ) -> Response:
     """Live iCal subscription feed. Add to Apple Calendar, Google Calendar, or Outlook once;
@@ -41,6 +46,9 @@ async def get_ical_feed(
     today = date.today()
     # Only include upcoming events — no historical clutter in subscribers' calendars
     conditions = [Event.date >= today]
+    # Mirror the on-site calendar: hide non-live-music events unless opted in.
+    if not include_non_music:
+        conditions.append(Event.is_live_music.is_(True))
 
     needs_join = bool(venue)
     if venue:

--- a/backend/app/classifier.py
+++ b/backend/app/classifier.py
@@ -11,10 +11,12 @@ the caller, so nothing here can clobber a manual decision. Pure Python — no DB
 network access — so it is cheap to run and trivial to unit-test.
 
 Detection criteria, in priority order (highest wins):
-  1. Recurrence — a name that repeats on >= RECURRENCE_THRESHOLD future dates at
-     the same venue is treated as a recurring series (weekly karaoke, trivia, DJ
+  1. Recurrence — a name that repeats on >= RECURRENCE_THRESHOLD separate occasions
+     at the same venue is treated as a recurring series (weekly karaoke, trivia, DJ
      nights, etc.) and flagged non-live. This is the strongest signal per the
-     product decision, so it wins over keywords and genre.
+     product decision, so it wins over keywords and genre. Dates within
+     RUN_GAP_DAYS of each other count as one occasion, so a multi-night residency
+     stays live music instead of reading as a series.
   2. Keywords — the event name matches a known non-music keyword, OR a
      "<word> night" phrase (any word except days-of-week / NIGHT_EXCEPTIONS, so
      "Emo Night" and "Hyperpop Night" match but "Saturday Night" does not), OR a
@@ -37,9 +39,21 @@ from typing import Iterable, Optional
 
 # --- Tunable criteria ---
 
-# An event whose (venue, name) repeats on at least this many distinct future
-# dates is treated as a recurring, non-live series.
+# An event whose (venue, name) repeats on at least this many separate occasions at
+# the same venue is treated as a recurring, non-live series.
 RECURRENCE_THRESHOLD = 3
+
+# Dates within this many days of each other count as ONE occasion, not several.
+#
+# Without this, recurrence cannot tell a weekly karaoke night from a band booked for
+# a three-night run — both produce three distinct dates at one venue. A residency is
+# exactly what someone opens the calendar to find, so counting raw dates hid the
+# site's best listings. Grouping nearby dates collapses a run to a single occasion
+# while leaving a weekly series at one occasion per week.
+#
+# 2 days keeps a Fri/Sat/Sun run together, and a Fri/Sun booking with Saturday off,
+# while still splitting anything on a weekly-or-sparser cadence.
+RUN_GAP_DAYS = 2
 
 # How far into the past reclassification and admin moderation reach. The calendar can
 # be scrolled back into recent past dates, and those events carry is_live_music too, so
@@ -181,6 +195,23 @@ def _normalize_for_grouping(name: str) -> str:
     return re.sub(r"[^a-z]", "", (name or "").lower())
 
 
+def _count_occasions(dates: Iterable[date], gap_days: int = RUN_GAP_DAYS) -> int:
+    """Collapse dates into separate occasions, merging any that form one run.
+
+    Sorts the distinct dates and starts a new occasion whenever the gap from the
+    previous date exceeds `gap_days`. A three-night residency returns 1; a weekly
+    series returns one per week. See RUN_GAP_DAYS for why this matters.
+    """
+    ordered = sorted(set(dates))
+    if not ordered:
+        return 0
+    occasions = 1
+    for previous, current in zip(ordered, ordered[1:]):
+        if (current - previous).days > gap_days:
+            occasions += 1
+    return occasions
+
+
 def _match_non_music_genre(genre: Optional[str], subgenre: Optional[str]) -> Optional[str]:
     """Return the matched non-music genre token, or None."""
     haystack = " ".join(filter(None, [genre, subgenre])).lower()
@@ -245,8 +276,13 @@ def find_recurring_event_ids(
     """Identify events that belong to a recurring series.
 
     events: iterable of objects with `id`, `venue_id`, `name`, and `date`.
-    Returns {event_id: occurrence_count} for every event whose (venue, name) key
-    appears on at least `threshold` distinct dates.
+    Returns {event_id: date_count} for every event whose (venue, name) key recurs on
+    at least `threshold` separate occasions.
+
+    The threshold is applied to occasions, not raw dates — consecutive dates are one
+    run, not a series (see RUN_GAP_DAYS). The returned count is still the number of
+    distinct dates, because that is what the admin UI and classification_reason
+    report and it is the more useful number to read.
     """
     dates_by_key: dict = defaultdict(set)
     ids_by_key: dict = defaultdict(list)
@@ -257,9 +293,21 @@ def find_recurring_event_ids(
 
     recurring: dict = {}
     for key, dates in dates_by_key.items():
-        if len(dates) >= threshold:
-            for event_id in ids_by_key[key]:
-                recurring[event_id] = len(dates)
+        _venue_id, normalized_name = key
+
+        # An empty key means the name normalized away entirely — an event with no
+        # name, or one named only in digits and punctuation ("2/14", "$5"). Those are
+        # unrelated events sharing an empty key, not a series, and a broken scraper
+        # emits them in bunches: three at one venue was enough to flag all three as
+        # recurring and hide them. See the malformed Squarespace records in #35.
+        if not normalized_name:
+            continue
+
+        if _count_occasions(dates) < threshold:
+            continue
+
+        for event_id in ids_by_key[key]:
+            recurring[event_id] = len(dates)
     return recurring
 
 
@@ -346,6 +394,12 @@ def criteria_summary() -> dict:
     """
     return {
         "recurrence_threshold": RECURRENCE_THRESHOLD,
+        "run_gap_days": RUN_GAP_DAYS,
+        "recurrence_rule": (
+            f"a name repeating on {RECURRENCE_THRESHOLD}+ separate occasions at one "
+            f"venue is a series; dates within {RUN_GAP_DAYS} days of each other count "
+            "as one occasion, so a multi-night run stays live music"
+        ),
         "always_live_venues": sorted(ALWAYS_LIVE_VENUE_SLUGS),
         "keywords": list(NON_MUSIC_KEYWORDS),
         "night_rule": "'<word> night' is non-live unless <word> is a day of the "

--- a/backend/app/classifier.py
+++ b/backend/app/classifier.py
@@ -351,7 +351,8 @@ def classification_updates(
     mapping — a series-level rule that overrides automatic classification for every
     event whose (venue, name) key matches.
     exempt_venue_ids: optional set of venue ids assumed to be entirely live music
-    (see ALWAYS_LIVE_VENUE_SLUGS, e.g. DPAC) — forced live, skipping auto/series.
+    (see ALWAYS_LIVE_VENUE_SLUGS, e.g. DPAC) — forced live unless a series override says
+    otherwise, so the exemption is a default rather than an absolute.
 
     Returns {event_id: (is_live_music, reason)} for every event EXCEPT those with
     is_manual_override=True, which are omitted so a re-scrape never overwrites a
@@ -359,8 +360,8 @@ def classification_updates(
 
     Precedence, most specific first:
       1. per-event manual override  -> omitted here (caller leaves the row untouched)
-      2. always-live venue exemption -> forced live music
-      3. series override            -> forces the series value
+      2. series override            -> forces the series value
+      3. always-live venue exemption -> forced live music
       4. automatic classification   -> recurrence / keyword / genre
     This is the pure decision function behind ScrapeManager.reclassify_all().
     """
@@ -373,14 +374,19 @@ def classification_updates(
     for ev in events:
         if getattr(ev, "is_manual_override", False):
             continue  # per-event override wins; leave the hand-set value in place
-        if ev.venue_id in exempt_venue_ids:
-            updates[ev.id] = (True, "venue: always live music")
-            continue
+
+        # Series override is consulted before the venue exemption, so the exemption acts
+        # as a default rather than as an absolute. The other order made an exempt venue's
+        # series impossible to mark non-live through the series UI, on every future
+        # instance, forever — and DPAC, the only exempt venue, hosts Broadway and comedy
+        # alongside music, which is exactly the case the series UI is for.
         key = (ev.venue_id, normalize_series_name(ev.name))
         if key in series_overrides:
             is_live, _note = series_overrides[key]
             label = "live music" if is_live else "non-live"
             updates[ev.id] = (is_live, f"series override: {label}")
+        elif ev.venue_id in exempt_venue_ids:
+            updates[ev.id] = (True, "venue: always live music")
         else:
             updates[ev.id] = classified[ev.id]
     return updates

--- a/backend/app/classifier.py
+++ b/backend/app/classifier.py
@@ -31,6 +31,7 @@ surfaced verbatim to the admin UI via criteria_summary().
 # --- Imports ---
 import re
 from collections import defaultdict
+from datetime import date, timedelta
 from typing import Iterable, Optional
 
 
@@ -39,6 +40,21 @@ from typing import Iterable, Optional
 # An event whose (venue, name) repeats on at least this many distinct future
 # dates is treated as a recurring, non-live series.
 RECURRENCE_THRESHOLD = 3
+
+# How far into the past reclassification and admin moderation reach. The calendar can
+# be scrolled back into recent past dates, and those events carry is_live_music too, so
+# they need to respond to live/non-live changes rather than staying frozen at whatever
+# they were last set to. Older events are settled and left alone.
+#
+# Note this also widens the recurrence window: instances just behind today now count
+# toward RECURRENCE_THRESHOLD, so a series is recognised sooner than it would be from
+# future dates alone.
+RECLASSIFY_PAST_DAYS = 30
+
+
+def reclassify_floor(today: Optional[date] = None) -> date:
+    """Earliest event date that reclassification and admin moderation still touch."""
+    return (today or date.today()) - timedelta(days=RECLASSIFY_PAST_DAYS)
 
 # Venues assumed to be entirely live music — exempt from non-live flagging.
 # DPAC hosts touring concerts/Broadway/comedy, but per product decision it is

--- a/backend/app/classifier.py
+++ b/backend/app/classifier.py
@@ -1,0 +1,344 @@
+"""
+Live-music classifier — decides whether an event is live music or something else
+(karaoke, trivia, theme nights, comedy, film screenings, ...). This module is the
+single source of truth for the detection criteria used to declutter the public
+calendar.
+
+Role: Called by ScrapeManager.reclassify_all() after every scrape to (re)compute
+each event's `is_live_music` flag and a human-readable `classification_reason`.
+Events an admin has manually overridden (is_manual_override=True) are skipped by
+the caller, so nothing here can clobber a manual decision. Pure Python — no DB or
+network access — so it is cheap to run and trivial to unit-test.
+
+Detection criteria, in priority order (highest wins):
+  1. Recurrence — a name that repeats on >= RECURRENCE_THRESHOLD future dates at
+     the same venue is treated as a recurring series (weekly karaoke, trivia, DJ
+     nights, etc.) and flagged non-live. This is the strongest signal per the
+     product decision, so it wins over keywords and genre.
+  2. Keywords — the event name matches a known non-music keyword, OR a
+     "<word> night" phrase (any word except days-of-week / NIGHT_EXCEPTIONS, so
+     "Emo Night" and "Hyperpop Night" match but "Saturday Night" does not), OR a
+     "<theme> party" phrase whose leading word is in the PARTY_THEMES allowlist
+     (see PARTY_THEMES for why "party" is allowlisted rather than matched bare).
+  3. Genre — where the source provides one (currently only the Ticketmaster
+     scraper), a non-music genre (Comedy, Theatre, Film, Sports, ...) flags it.
+Anything matching none of these is assumed to be live music.
+
+To tune detection, edit the lists below — they are intentionally readable and are
+surfaced verbatim to the admin UI via criteria_summary().
+"""
+
+# --- Imports ---
+import re
+from collections import defaultdict
+from typing import Iterable, Optional
+
+
+# --- Tunable criteria ---
+
+# An event whose (venue, name) repeats on at least this many distinct future
+# dates is treated as a recurring, non-live series.
+RECURRENCE_THRESHOLD = 3
+
+# Venues assumed to be entirely live music — exempt from non-live flagging.
+# DPAC hosts touring concerts/Broadway/comedy, but per product decision it is
+# treated as all live music and excluded from the filter pass entirely.
+ALWAYS_LIVE_VENUE_SLUGS = {"dpac"}
+
+# Whole-word matches anywhere in the event name flag it as non-live music.
+# Word-boundary matched, case-insensitive (so "class" does not match "classic").
+# Note: "<theme> night" and "<theme> party" are handled by their own broader
+# patterns below, not this list.
+NON_MUSIC_KEYWORDS = [
+    "karaoke",
+    "trivia",
+    "bingo",
+    "quizzo",
+    "quiz",
+    "open mic",
+    "open-mic",
+    "open decks",
+    "comedy",
+    "stand-up",
+    "standup",
+    "improv",
+    "drag",
+    "burlesque",
+    "silent disco",
+    "screening",
+    "film screening",
+    "movie",
+    "market",
+    "pop-up",
+    "popup",
+    "yoga",
+    "brunch",
+    "book club",
+    "poetry",
+    "spoken word",
+    "workshop",
+    "meetup",
+    "networking",
+    "speed dating",
+    "sing-along",
+    "singalong",
+]
+
+# "<word> night" (or "nights") is treated as a themed DJ/dance/recurring night —
+# a strong non-live signal — for ANY preceding word EXCEPT these. Days of the week
+# and a few common phrases ("Last Night", "One Night Only", "A Hard Day's Night")
+# are excluded so real show titles aren't caught. Single-letter matches (e.g. the
+# "s" left by a possessive like "Day's Night") are ignored in classify_one().
+NIGHT_EXCEPTIONS = {
+    "monday",
+    "tuesday",
+    "wednesday",
+    "thursday",
+    "friday",
+    "saturday",
+    "sunday",
+    "last",
+    "one",
+    "good",
+    "hard",
+}
+
+# "<theme> party" (or "parties") — listening/release/album parties, etc. This is an
+# allowlist rather than "any word" because band names contain "party" (e.g. the
+# band Bloc Party), so a bare "party" match would produce false positives.
+PARTY_THEMES = [
+    "listening",
+    "release",
+    "album",
+    "single",
+    "launch",
+    "block",
+    "dance",
+    "watch",
+    "viewing",
+    "after",
+    "silent",
+]
+
+# Substrings of a source-provided genre/subgenre that indicate non-music.
+# Kept conservative: "Dance/Electronic" is a legitimate live-music genre, so
+# "dance" is NOT listed here (only "dance party"/"dance night" via keywords).
+NON_MUSIC_GENRES = [
+    "comedy",
+    "theatre",
+    "theater",
+    "film",
+    "sports",
+    "family",
+    "magic",
+    "illusion",
+    "spoken word",
+]
+
+
+# --- Compiled matchers (built once at import) ---
+
+_KEYWORD_PATTERNS = [
+    (kw, re.compile(r"\b" + re.escape(kw) + r"\b", re.IGNORECASE))
+    for kw in NON_MUSIC_KEYWORDS
+]
+
+# Broad "<word> night(s)"; the word is filtered against NIGHT_EXCEPTIONS in code.
+_NIGHT_PATTERN = re.compile(r"\b(\w+)\s+nights?\b", re.IGNORECASE)
+
+# "<theme> party" / "<theme> parties" for an allowlisted set of themes.
+_PARTY_PATTERN = re.compile(
+    r"\b(" + "|".join(re.escape(t) for t in PARTY_THEMES) + r")\s+part(?:y|ies)\b",
+    re.IGNORECASE,
+)
+
+
+# --- Helpers ---
+
+def _normalize_for_grouping(name: str) -> str:
+    """Collapse a name to a comparison key for recurrence grouping.
+
+    Lowercases and strips punctuation, whitespace, AND digits so that dated
+    variants of the same series collapse together (e.g. "Trivia Night 7/8" and
+    "Trivia Night 7/15" both become "trivianight").
+    """
+    return re.sub(r"[^a-z]", "", (name or "").lower())
+
+
+def _match_non_music_genre(genre: Optional[str], subgenre: Optional[str]) -> Optional[str]:
+    """Return the matched non-music genre token, or None."""
+    haystack = " ".join(filter(None, [genre, subgenre])).lower()
+    if not haystack:
+        return None
+    for token in NON_MUSIC_GENRES:
+        if token in haystack:
+            return token
+    return None
+
+
+# --- Public API ---
+
+def normalize_series_name(name: str) -> str:
+    """Public series key for a name — the value stored in SeriesOverride.normalized_name.
+
+    Must stay identical to the grouping used by recurrence detection so an admin's
+    series override matches the same events the detector groups together.
+    """
+    return _normalize_for_grouping(name)
+
+
+def classify_one(
+    name: str,
+    genre: Optional[str] = None,
+    subgenre: Optional[str] = None,
+) -> tuple[bool, Optional[str]]:
+    """Classify a single event by name + genre (no recurrence context).
+
+    Returns (is_live_music, reason). `reason` is None when the event is treated as
+    live music; otherwise it is a short human-readable explanation.
+    """
+    text = name or ""
+
+    for kw, pattern in _KEYWORD_PATTERNS:
+        if pattern.search(text):
+            return False, f"keyword: {kw}"
+
+    party = _PARTY_PATTERN.search(text)
+    if party:
+        return False, f"keyword: {party.group(1).lower()} party"
+
+    # "<word> night" for any word that isn't a day-of-week / excepted phrase.
+    # finditer (not search) so a leading excepted match doesn't mask a later
+    # real one, e.g. "Saturday Night: Emo Night".
+    for m in _NIGHT_PATTERN.finditer(text):
+        word = m.group(1).lower()
+        if len(word) >= 2 and word not in NIGHT_EXCEPTIONS:
+            return False, f"keyword: {word} night"
+
+    genre_hit = _match_non_music_genre(genre, subgenre)
+    if genre_hit:
+        return False, f"genre: {genre_hit}"
+
+    return True, None
+
+
+def find_recurring_event_ids(
+    events: Iterable,
+    threshold: int = RECURRENCE_THRESHOLD,
+) -> dict:
+    """Identify events that belong to a recurring series.
+
+    events: iterable of objects with `id`, `venue_id`, `name`, and `date`.
+    Returns {event_id: occurrence_count} for every event whose (venue, name) key
+    appears on at least `threshold` distinct dates.
+    """
+    dates_by_key: dict = defaultdict(set)
+    ids_by_key: dict = defaultdict(list)
+    for ev in events:
+        key = (ev.venue_id, _normalize_for_grouping(ev.name))
+        dates_by_key[key].add(ev.date)
+        ids_by_key[key].append(ev.id)
+
+    recurring: dict = {}
+    for key, dates in dates_by_key.items():
+        if len(dates) >= threshold:
+            for event_id in ids_by_key[key]:
+                recurring[event_id] = len(dates)
+    return recurring
+
+
+def classify_batch(
+    events: Iterable,
+    threshold: int = RECURRENCE_THRESHOLD,
+) -> dict:
+    """Classify a batch of events, applying recurrence + keyword + genre signals.
+
+    events: iterable of objects with `id`, `venue_id`, `name`, `date`, and
+    optionally `genre`/`subgenre`. Returns {event_id: (is_live_music, reason)}.
+    """
+    events = list(events)
+    recurring = find_recurring_event_ids(events, threshold)
+
+    results: dict = {}
+    for ev in events:
+        count = recurring.get(ev.id)
+        if count is not None:
+            results[ev.id] = (False, f"recurring: {count} dates")
+            continue
+        results[ev.id] = classify_one(
+            ev.name,
+            getattr(ev, "genre", None),
+            getattr(ev, "subgenre", None),
+        )
+    return results
+
+
+def classification_updates(
+    events: Iterable,
+    series_overrides: Optional[dict] = None,
+    exempt_venue_ids: Optional[set] = None,
+    threshold: int = RECURRENCE_THRESHOLD,
+) -> dict:
+    """Compute the classification values to persist, honoring all override layers.
+
+    events: iterable of objects with the classify_batch attributes plus
+    `is_manual_override`.
+    series_overrides: optional {(venue_id, normalized_name): (is_live_music, note)}
+    mapping — a series-level rule that overrides automatic classification for every
+    event whose (venue, name) key matches.
+    exempt_venue_ids: optional set of venue ids assumed to be entirely live music
+    (see ALWAYS_LIVE_VENUE_SLUGS, e.g. DPAC) — forced live, skipping auto/series.
+
+    Returns {event_id: (is_live_music, reason)} for every event EXCEPT those with
+    is_manual_override=True, which are omitted so a re-scrape never overwrites a
+    decision an admin made on a single instance.
+
+    Precedence, most specific first:
+      1. per-event manual override  -> omitted here (caller leaves the row untouched)
+      2. always-live venue exemption -> forced live music
+      3. series override            -> forces the series value
+      4. automatic classification   -> recurrence / keyword / genre
+    This is the pure decision function behind ScrapeManager.reclassify_all().
+    """
+    events = list(events)
+    series_overrides = series_overrides or {}
+    exempt_venue_ids = exempt_venue_ids or set()
+    classified = classify_batch(events, threshold)
+
+    updates: dict = {}
+    for ev in events:
+        if getattr(ev, "is_manual_override", False):
+            continue  # per-event override wins; leave the hand-set value in place
+        if ev.venue_id in exempt_venue_ids:
+            updates[ev.id] = (True, "venue: always live music")
+            continue
+        key = (ev.venue_id, normalize_series_name(ev.name))
+        if key in series_overrides:
+            is_live, _note = series_overrides[key]
+            label = "live music" if is_live else "non-live"
+            updates[ev.id] = (is_live, f"series override: {label}")
+        else:
+            updates[ev.id] = classified[ev.id]
+    return updates
+
+
+def criteria_summary() -> dict:
+    """Machine-readable snapshot of the current detection criteria.
+
+    Surfaced to the admin UI (GET /admin/api/rules) so the rules can be reviewed
+    without reading the source.
+    """
+    return {
+        "recurrence_threshold": RECURRENCE_THRESHOLD,
+        "always_live_venues": sorted(ALWAYS_LIVE_VENUE_SLUGS),
+        "keywords": list(NON_MUSIC_KEYWORDS),
+        "night_rule": "'<word> night' is non-live unless <word> is a day of the "
+                      "week or listed in night_exceptions",
+        "night_exceptions": sorted(NIGHT_EXCEPTIONS),
+        "party_rule": "'<theme> party' (or 'parties') is non-live only when the word "
+                      "immediately before 'party' is one of party_themes. This is an "
+                      "allowlist (not any word) on purpose: a bare 'party' match would "
+                      "flag band names like 'Bloc Party', so only these themes count.",
+        "party_themes": list(PARTY_THEMES),
+        "non_music_genres": list(NON_MUSIC_GENRES),
+    }

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -25,6 +25,23 @@ class Settings(BaseSettings):
     APP_ENV: str = "development"
     LOG_LEVEL: str = "INFO"
 
+    # --- Origin enforcement (see app.tokens) ---
+    # The Cloud Run service accepts unauthenticated requests, so its .run.app hostnames
+    # reach the app without passing Cloudflare. These settings let the app itself verify
+    # who a request came from on the two routes that must not be open there.
+    #
+    # Each gate is inert until configured, deliberately: local dev and CI have no
+    # Cloudflare and no Cloud Scheduler in front of them. app.tokens.log_enforcement_state()
+    # logs which gates are live on every boot, so "inert" is never silent.
+
+    # Cloudflare Access gate on /admin/*. Both are required to enforce.
+    CF_ACCESS_TEAM_DOMAIN: str = ""  # e.g. "triangleshows.cloudflareaccess.com"
+    CF_ACCESS_AUD: str = ""  # the Access application's AUD tag
+
+    # Google OIDC gate on POST /api/scrape. Cloud Scheduler already sends the token.
+    SCRAPE_ALLOWED_SERVICE_ACCOUNTS: str = ""  # comma-separated service-account emails
+    SCRAPE_OIDC_AUDIENCE: str = ""  # optional; the audience configured on the scheduler job
+
     model_config = {"env_file": ".env", "env_file_encoding": "utf-8"}
 
 

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -42,6 +42,13 @@ class Settings(BaseSettings):
     SCRAPE_ALLOWED_SERVICE_ACCOUNTS: str = ""  # comma-separated service-account emails
     SCRAPE_OIDC_AUDIENCE: str = ""  # optional; the audience configured on the scheduler job
 
+    # Admin subsite (/admin). Both must be set for the admin to be reachable —
+    # if ADMIN_PASSWORD is blank, the admin login is disabled (fails closed).
+    ADMIN_PASSWORD: str = ""       # shared password exchanged for a session cookie
+    SESSION_SECRET: str = ""       # signs the admin session cookie; MUST be set in
+                                   # production so cookies validate across instances
+                                   # (a random per-process key is used if left blank)
+
     model_config = {"env_file": ".env", "env_file_encoding": "utf-8"}
 
 

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -114,10 +114,30 @@ app = FastAPI(
 )
 
 # CORS
+#
+# allow_credentials is False, and that single flag is what makes the "*" safe. The exact
+# mechanics, measured rather than assumed (see tests/test_cors.py):
+#
+#   Starlette replaces the "*" with the caller's own Origin whenever the request carries a
+#   Cookie header. That happens either way and is not the problem. The problem was pairing
+#   it with allow_credentials=True, which adds Access-Control-Allow-Credentials: true —
+#   the header a browser requires before it will hand a credentialed cross-origin response
+#   back to the page that asked for it. Origin echo plus that header is what let a hostile
+#   page read authenticated responses, leaving the admin cookie's samesite="lax" as the
+#   only control. Without the header the echo is inert: the browser discards the response.
+#
+# Nothing here needs cross-origin credentials, or cross-origin requests of any kind.
+# frontend/js/config.js sets API_BASE to window.location.origin and the admin UI fetches
+# relative paths, so every in-app request is same-origin, where CORS does not apply.
+#
+# Keeping "*" rather than an allowlist is deliberate: the read API is public, so leaving it
+# usable from any page costs nothing once credentials are off. Narrowing allow_origins to
+# the real site origins would stop third parties consuming it from a browser — a product
+# decision, not a security one.
 app.add_middleware(
     CORSMiddleware,
     allow_origins=["*"],
-    allow_credentials=True,
+    allow_credentials=False,
     allow_methods=["*"],
     allow_headers=["*"],
 )

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -25,7 +25,7 @@ from app.config import settings
 from app.database import async_session
 from app.seed import seed_venues
 from app.scheduler import scheduler, configure_scheduler
-from app.api import events, venues, health, feeds
+from app.api import events, venues, health, feeds, admin
 from app import tokens
 
 # --- Logging setup ---
@@ -189,6 +189,9 @@ app.include_router(events.router)
 app.include_router(venues.router)
 app.include_router(health.router)
 app.include_router(feeds.router)
+# Admin subsite — must be registered before the "/" static mount below so its
+# routes take priority over the catch-all StaticFiles handler.
+app.include_router(admin.router)
 
 # --- Origin enforcement on POST /api/scrape ---
 

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -14,9 +14,11 @@ import asyncio
 import logging
 from contextlib import asynccontextmanager
 from pathlib import Path
+from typing import Optional
 
-from fastapi import FastAPI
+from fastapi import Depends, FastAPI, Request
 from fastapi.middleware.cors import CORSMiddleware
+from fastapi.responses import JSONResponse
 from fastapi.staticfiles import StaticFiles
 
 from app.config import settings
@@ -24,6 +26,7 @@ from app.database import async_session
 from app.seed import seed_venues
 from app.scheduler import scheduler, configure_scheduler
 from app.api import events, venues, health, feeds
+from app import tokens
 
 # --- Logging setup ---
 logging.basicConfig(
@@ -68,6 +71,11 @@ async def _startup_scrape():
 async def lifespan(app: FastAPI):
     """Startup and shutdown logic."""
     logger.info("Starting Triangle Shows API...")
+
+    # Report which origin gates are live before serving anything, so a gate that is
+    # configured wrong (and therefore doing nothing) is visible in the boot logs rather
+    # than mistaken for protection.
+    tokens.log_enforcement_state()
 
     # Apply any pending Alembic migrations — creates tables on fresh DBs, updates schema on existing ones
     await asyncio.to_thread(_run_migrations)
@@ -114,6 +122,46 @@ app.add_middleware(
     allow_headers=["*"],
 )
 
+
+# --- Origin enforcement on /admin ---
+
+@app.middleware("http")
+async def enforce_admin_access(request: Request, call_next):
+    """Require a valid Cloudflare Access token on /admin/*, when configured.
+
+    Guarding by path rather than inside the admin router is deliberate. The admin
+    subsite arrives with a separate branch (PR #36); a path check protects those routes
+    from the moment they land, so the admin surface cannot reach production without the
+    origin gate in front of it. Until then this is inert — /admin merely 404s.
+
+    The login page is guarded too, not just the API beneath it. Reaching a password
+    prompt on the origin is the exposure being closed; an unauthenticated caller should
+    not see that the admin subsite exists at all.
+    """
+    if not request.url.path.startswith("/admin"):
+        return await call_next(request)
+
+    if not tokens.cloudflare_access_configured():
+        return await call_next(request)
+
+    try:
+        claims = tokens.verify_cloudflare_access(
+            request.headers.get("cf-access-jwt-assertion")
+        )
+    except tokens.TokenError as exc:
+        # Logged at info, not warning: on a public origin, unauthenticated probes of
+        # /admin are background noise rather than incidents.
+        logger.info(f"[admin] rejected {request.method} {request.url.path}: {exc}")
+        return JSONResponse(
+            {"detail": "This surface is reachable only through Cloudflare Access."},
+            status_code=403,
+        )
+
+    # Downstream handlers can attribute an action to a person rather than to whoever
+    # holds a shared password.
+    request.state.access_email = tokens.access_identity(claims)
+    return await call_next(request)
+
 # --- Route registration ---
 
 # API routes
@@ -122,13 +170,47 @@ app.include_router(venues.router)
 app.include_router(health.router)
 app.include_router(feeds.router)
 
-# Manual scrape trigger (dev only)
+# --- Origin enforcement on POST /api/scrape ---
+
+async def require_scrape_token(request: Request) -> Optional[str]:
+    """Require a Google-issued OIDC token from an allowlisted service account.
+
+    Cloud Scheduler already attaches this token; Cloud Run cannot enforce it, because the
+    service has to accept unauthenticated requests for the public site to work. So the
+    check belongs here.
+
+    Inert until SCRAPE_ALLOWED_SERVICE_ACCOUNTS names at least one account, which keeps
+    local dev and CI working. Returns the calling service account for the audit log.
+    """
+    from fastapi import HTTPException
+
+    if not tokens.scrape_token_configured():
+        return None
+
+    token = tokens.bearer_token(request.headers.get("authorization"))
+    try:
+        claims = tokens.verify_scrape_token(token)
+    except tokens.TokenError as exc:
+        logger.warning(f"[scrape] rejected trigger: {exc}")
+        raise HTTPException(status_code=403, detail="Not authorized to trigger a scrape.")
+
+    return claims.get("email")
+
+
+# Scrape trigger. Called by Cloud Scheduler every 6 hours in production; also usable by
+# hand in local dev, where the gate above is inert.
 @app.post("/api/scrape")
-async def trigger_scrape(scraper_type: str = None):
-    """Manually trigger a scrape (development use)."""
+async def trigger_scrape(
+    scraper_type: str = None,
+    caller: Optional[str] = Depends(require_scrape_token),
+):
+    """Trigger a scrape of every venue, or of one scraper_type."""
     from app.database import async_session
     from app.scrapers.manager import ScrapeManager
     from fastapi import HTTPException
+
+    if caller:
+        logger.info(f"[scrape] triggered by {caller}")
 
     try:
         async with async_session() as session:

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -10,7 +10,7 @@ Requires: app.database (Base), PostgreSQL via asyncpg/SQLAlchemy async.
 
 from datetime import datetime, date, time
 from typing import Optional
-from sqlalchemy import String, Integer, Float, Text, Date, Time, DateTime, ForeignKey, JSON
+from sqlalchemy import String, Integer, Float, Text, Date, Time, DateTime, ForeignKey, JSON, Boolean, UniqueConstraint
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 import enum
 
@@ -83,6 +83,16 @@ class Event(Base):
     source: Mapped[str] = mapped_column(String(50))  # scraper name that produced this event, e.g. "ticketmaster"
     source_url: Mapped[Optional[str]] = mapped_column(String(1000), nullable=True)
     hash: Mapped[str] = mapped_column(String(64), unique=True, index=True)  # SHA-256 of key fields; used by manager.py to deduplicate on upsert
+
+    # --- Live-music classification (see app/classifier.py) ---
+    # Effective flag the calendar and iCal feeds filter on. Materialized (not computed
+    # on read) so filtering is a simple `WHERE is_live_music = true`. Recomputed after
+    # every scrape by ScrapeManager.reclassify_all() — except on rows an admin has
+    # manually overridden (is_manual_override=True), which are left untouched.
+    is_live_music: Mapped[bool] = mapped_column(Boolean, default=True, index=True)
+    is_manual_override: Mapped[bool] = mapped_column(Boolean, default=False)  # True once an admin sets the flag by hand
+    classification_reason: Mapped[Optional[str]] = mapped_column(String(200), nullable=True)  # human-readable why, e.g. "recurring: 6 dates", "keyword: trivia", "manual"
+
     created_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow)
     updated_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow, onupdate=datetime.utcnow)
 
@@ -106,3 +116,34 @@ class ScrapeLog(Base):
     duration_seconds: Mapped[Optional[float]] = mapped_column(Float, nullable=True)
 
     venue: Mapped["Venue"] = relationship(back_populates="scrape_logs")
+
+
+class SeriesOverride(Base):
+    """An admin decision that applies to a whole recurring series, not one event.
+
+    A recurring series (weekly karaoke, a standing jazz jam, a monthly comedy
+    showcase, ...) produces many Event rows over time, and new ones appear on each
+    scrape. A per-event override can't cover future instances, so a series-level
+    rule is keyed by (venue_id, normalized_name) — the same key the recurrence
+    detector groups on (see app.classifier.normalize_series_name). During
+    ScrapeManager.reclassify_all(), a matching rule forces is_live_music for every
+    event in the series, including instances scraped later.
+
+    Precedence, most specific first: a per-event Event.is_manual_override wins over
+    a SeriesOverride, which in turn wins over automatic classification.
+    """
+    __tablename__ = "series_overrides"
+
+    id: Mapped[int] = mapped_column(primary_key=True)
+    venue_id: Mapped[int] = mapped_column(ForeignKey("venues.id"), index=True)
+    normalized_name: Mapped[str] = mapped_column(String(200))  # matches app.classifier.normalize_series_name(event.name)
+    display_name: Mapped[Optional[str]] = mapped_column(String(500), nullable=True)  # a readable example name for the admin UI
+    is_live_music: Mapped[bool] = mapped_column(Boolean)  # the value forced onto every event in the series
+    note: Mapped[Optional[str]] = mapped_column(String(500), nullable=True)  # optional admin note explaining the decision
+    created_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow)
+    updated_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow, onupdate=datetime.utcnow)
+
+    # One rule per (venue, series name); the admin endpoint upserts on this key.
+    __table_args__ = (
+        UniqueConstraint("venue_id", "normalized_name", name="uq_series_override_key"),
+    )

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -92,6 +92,11 @@ class Event(Base):
     is_live_music: Mapped[bool] = mapped_column(Boolean, default=True, index=True)
     is_manual_override: Mapped[bool] = mapped_column(Boolean, default=False)  # True once an admin sets the flag by hand
     classification_reason: Mapped[Optional[str]] = mapped_column(String(200), nullable=True)  # human-readable why, e.g. "recurring: 6 dates", "keyword: trivia", "manual"
+    # Set when an admin confirms the current classification is correct; the admin list
+    # hides approved events by default. Records agreement with a *verdict*, not the
+    # event: reclassify_all() clears this whenever it changes is_live_music, so a
+    # re-classified event returns to the review queue rather than staying hidden.
+    approved_at: Mapped[Optional[datetime]] = mapped_column(DateTime, nullable=True, index=True)
 
     created_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow)
     updated_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow, onupdate=datetime.utcnow)

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -56,6 +56,14 @@ class Venue(Base):
 
     events: Mapped[list["Event"]] = relationship(back_populates="venue", cascade="all, delete-orphan")
     scrape_logs: Mapped[list["ScrapeLog"]] = relationship(back_populates="venue", cascade="all, delete-orphan")
+    # Retiring a venue must not be blocked by its series rules. seed_venues() deletes
+    # venues listed in REMOVED_SLUGS on every startup via session.delete(), which cascades
+    # only through relationships SQLAlchemy knows about — so without this, the first
+    # retirement of a venue holding a series override raises ForeignKeyViolation inside the
+    # lifespan handler and the container never becomes healthy.
+    series_overrides: Mapped[list["SeriesOverride"]] = relationship(
+        back_populates="venue", cascade="all, delete-orphan"
+    )
 
 
 class Event(Base):
@@ -140,13 +148,20 @@ class SeriesOverride(Base):
     __tablename__ = "series_overrides"
 
     id: Mapped[int] = mapped_column(primary_key=True)
-    venue_id: Mapped[int] = mapped_column(ForeignKey("venues.id"), index=True)
+    # ondelete="CASCADE" as well as the ORM relationship on Venue: the relationship covers
+    # session.delete(), the database constraint covers everything else (a manual DELETE, a
+    # future bulk query that bypasses the ORM's cascade).
+    venue_id: Mapped[int] = mapped_column(
+        ForeignKey("venues.id", ondelete="CASCADE"), index=True
+    )
     normalized_name: Mapped[str] = mapped_column(String(200))  # matches app.classifier.normalize_series_name(event.name)
     display_name: Mapped[Optional[str]] = mapped_column(String(500), nullable=True)  # a readable example name for the admin UI
     is_live_music: Mapped[bool] = mapped_column(Boolean)  # the value forced onto every event in the series
     note: Mapped[Optional[str]] = mapped_column(String(500), nullable=True)  # optional admin note explaining the decision
     created_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow)
     updated_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow, onupdate=datetime.utcnow)
+
+    venue: Mapped["Venue"] = relationship(back_populates="series_overrides")
 
     # One rule per (venue, series name); the admin endpoint upserts on this key.
     __table_args__ = (

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -55,6 +55,7 @@ class EventResponse(BaseModel):
     age_restriction: Optional[str] = None
     description: Optional[str] = None
     source: str
+    is_live_music: bool = True  # False => karaoke/trivia/theme night/comedy/etc. (see app/classifier.py)
 
     # Denormalized venue fields — joined in the query so clients don't need
     # a separate /api/venues request to display venue info alongside events

--- a/backend/app/scrapers/base.py
+++ b/backend/app/scrapers/base.py
@@ -8,11 +8,49 @@ method, and uses ScrapedEvent.hash for deduplication before upserting to Postgre
 Requires: No env vars or external services — pure Python stdlib only.
 """
 import hashlib
+import html
 import re
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
 from datetime import date, time, datetime
 from typing import Optional
+from urllib.parse import unquote
+
+
+# --- Title normalization ---
+
+# A percent-escape: '%' followed by exactly two hex digits, e.g. '%26' for '&'.
+_PCT_ESCAPE = re.compile(r"%[0-9A-Fa-f]{2}")
+
+
+def clean_title(text: Optional[str]) -> Optional[str]:
+    """Decode escape sequences a source left in a human-readable title.
+
+    Venue sites hand us the same title in different encodings depending on which page
+    it came from — Shadowbox's listing page yields 'A &#038; B' while its detail page
+    yields 'A %26 B' for the same show. Because the dedup hash is built from the title,
+    two encodings of one title produce two database rows. Normalizing here means every
+    scraper hashes the same string, and users stop seeing raw escape codes.
+
+    Percent-decoding the whole string (rather than each escape separately) is what makes
+    multi-byte UTF-8 sequences like '%E2%80%99' come back as one character. The tradeoff
+    is that a literal '%' followed by two hex digits would be mangled; that does not
+    happen in practice in event titles, and leaving '%26' on screen is the worse failure.
+    """
+    if not text:
+        return text
+
+    # WordPress feeds sometimes double-escape ('&amp;#038;'), so unescape until stable.
+    for _ in range(3):
+        decoded = html.unescape(text)
+        if decoded == text:
+            break
+        text = decoded
+
+    if _PCT_ESCAPE.search(text):
+        text = unquote(text)
+
+    return re.sub(r"\s+", " ", text).strip()
 
 
 # --- ScrapedEvent Dataclass ---
@@ -40,6 +78,12 @@ class ScrapedEvent:
     age_restriction: Optional[str] = None
     description: Optional[str] = None
     source_url: Optional[str] = None
+
+    def __post_init__(self):
+        """Normalize the human-readable fields before anything hashes or stores them."""
+        self.name = clean_title(self.name)
+        self.artist = clean_title(self.artist)
+        self.support_artists = clean_title(self.support_artists)
 
     @property
     def hash(self) -> str:

--- a/backend/app/scrapers/html_text.py
+++ b/backend/app/scrapers/html_text.py
@@ -1,0 +1,84 @@
+"""
+Turns an HTML description fragment into human-readable plain text.
+
+Role: Shared by scrapers whose source hands back a marked-up description - MEC's
+JSON-LD `description` field and Squarespace's `excerpt`/`body` fields. Kept out of
+scrapers/base.py, which is pure-stdlib by design; this needs BeautifulSoup, but only
+the two scrapers that actually have HTML to clean need to import it.
+Requires: beautifulsoup4, lxml (both already required by every scraper that produces
+HTML in the first place).
+"""
+
+import html
+import re
+from typing import Optional
+
+from bs4 import BeautifulSoup
+
+# \xa0 is U+00A0 NO-BREAK SPACE, what &nbsp; decodes to. Not a plain space, and not
+# matched by \s in every regex flavor, so it needs to be named explicitly.
+_WHITESPACE_RUN = re.compile(r"[ \t\xa0]+")
+
+
+def clean_html_text(
+    raw: Optional[str],
+    *,
+    drop_first_paragraph_if: Optional[str] = None,
+    limit: Optional[int] = None,
+) -> Optional[str]:
+    """Decode entities, strip tags, and return readable multi-paragraph text.
+
+    Every source this has been checked against (MEC's JSON-LD description; Squarespace's
+    excerpt and Post Body content) uses `<p>` as its only block-level element -- `<strong>`,
+    `<a>`, and `<em>` appear only inline. So paragraphs are read from `<p>` tags
+    specifically, joined with a blank line, rather than every block-level tag: selecting
+    `<div>` as well would double-count text, since BeautifulSoup's find_all matches an
+    outer container and the paragraphs nested inside it as separate results. `<br>` is
+    converted to a newline before extraction, since it carries no text of its own.
+    Falls back to reading the whole fragment as one block when there are no `<p>` tags
+    at all, so plain, already-markup-free text is not silently dropped.
+
+    raw can itself be HTML-escaped HTML -- MEC's JSON-LD field stores markup as a string
+    that has ALSO been through an HTML-entity pass, e.g. the literal text
+    '&lt;p&gt;&lt;strong&gt;...' rather than an actual '<p>' tag. `html.unescape` runs
+    first so BeautifulSoup sees real tags either way; it is a no-op on already-plain HTML.
+
+    drop_first_paragraph_if: if the first paragraph case-insensitively equals this string
+    once both are stripped, drop it. Squarespace's Post Body editor always repeats the
+    event's own title as the first paragraph of `body` -- never of `excerpt`, which is a
+    genuinely separate summary field -- so pass the event title from `body`-sourced content
+    and leave it unset for `excerpt`. Real description text is never exactly the event's
+    own title, so this cannot discard a paragraph that happens to be genuine content.
+
+    limit: truncate the CLEANED text to this many characters. Truncating before cleaning
+    can cut mid-tag or mid-entity and leave a stray fragment on the visible card.
+
+    Returns None for empty or unparseable input -- same convention as pulling an optional
+    field straight off a dict -- so callers can pass it directly into the description slot.
+    """
+    if not raw:
+        return None
+
+    text = html.unescape(raw)
+    soup = BeautifulSoup(text, "lxml")
+    for br in soup.find_all("br"):
+        br.replace_with("\n")
+
+    paragraphs = [_WHITESPACE_RUN.sub(" ", p.get_text()).strip() for p in soup.find_all("p")]
+    paragraphs = [p for p in paragraphs if p]
+
+    if not paragraphs:
+        whole = _WHITESPACE_RUN.sub(" ", soup.get_text()).strip()
+        paragraphs = [whole] if whole else []
+
+    if (
+        drop_first_paragraph_if
+        and paragraphs
+        and paragraphs[0].casefold() == drop_first_paragraph_if.strip().casefold()
+    ):
+        paragraphs = paragraphs[1:]
+
+    cleaned = "\n\n".join(paragraphs).strip()
+    if not cleaned:
+        return None
+    return cleaned[:limit] if limit else cleaned

--- a/backend/app/scrapers/manager.py
+++ b/backend/app/scrapers/manager.py
@@ -26,7 +26,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.dialects.postgresql import insert as pg_insert
 
 from app.config import settings
-from app.classifier import classification_updates, ALWAYS_LIVE_VENUE_SLUGS
+from app.classifier import classification_updates, reclassify_floor, ALWAYS_LIVE_VENUE_SLUGS
 from app.models import Venue, Event, ScrapeLog, SeriesOverride
 from app.scrapers.base import BaseScraper, ScrapedEvent
 from app.scrapers.ticketmaster import TicketmasterScraper
@@ -409,18 +409,20 @@ class ScrapeManager:
     # --- Classification ---
 
     async def reclassify_all(self) -> dict:
-        """Recompute is_live_music for all upcoming events.
+        """Recompute is_live_music for upcoming events and the recent past.
 
         Runs after every bulk scrape. Recurrence is a cross-event signal, so this
-        always considers the full set of future events regardless of which venues
+        always considers the full set of events in range regardless of which venues
         were just scraped. Admin decisions are respected: per-event manual overrides
         (is_manual_override=True) are left untouched, and series-level overrides are
         applied to every matching event — including instances scraped later.
-        Returns {events, changed} counts.
+
+        The range reaches RECLASSIFY_PAST_DAYS behind today, not just forward: the
+        calendar can be scrolled back into recent dates, and those events need to
+        respond to live/non-live changes too. Returns {events, changed} counts.
         """
-        today = date.today()
         result = await self.session.execute(
-            select(Event).where(Event.date >= today)
+            select(Event).where(Event.date >= reclassify_floor())
         )
         events = result.scalars().all()
 
@@ -446,21 +448,30 @@ class ScrapeManager:
         )
 
         changed = 0
+        unapproved = 0
         for ev in events:
             if ev.id not in updates:
                 continue
             is_live, reason = updates[ev.id]
             if ev.is_live_music != is_live or ev.classification_reason != reason:
+                # An approval records agreement with a specific verdict. If the verdict
+                # itself moves, that approval is stale — clear it so the event returns
+                # to the review queue instead of staying hidden behind an old decision.
+                # Only a change of is_live_music counts; a reworded reason is not a
+                # different answer and should not resurface work already reviewed.
+                if ev.is_live_music != is_live and ev.approved_at is not None:
+                    ev.approved_at = None
+                    unapproved += 1
                 ev.is_live_music = is_live
                 ev.classification_reason = reason
                 changed += 1
 
         await self.session.commit()
         logger.info(
-            f"Reclassified {len(events)} upcoming events; {changed} changed "
-            f"(manual overrides preserved)"
+            f"Reclassified {len(events)} events in range; {changed} changed, "
+            f"{unapproved} approvals cleared (manual overrides preserved)"
         )
-        return {"events": len(events), "changed": changed}
+        return {"events": len(events), "changed": changed, "unapproved": unapproved}
 
     # --- Bulk scrape entry points ---
 

--- a/backend/app/scrapers/manager.py
+++ b/backend/app/scrapers/manager.py
@@ -1,6 +1,11 @@
 """
-Scrape orchestrator: runs all venue scrapers, deduplicates results by hash, and
-upserts events + scrape logs into the database.
+Scrape orchestrator: runs all venue scrapers, matches each run against the events already
+stored for that venue, and upserts events + scrape logs into the database.
+
+Matching is the interesting part. Rows are identified by the venue's own event ID first
+and only then by a hash of the title, because titles get edited (support acts announced,
+events renamed) and a title-only identity turns every edit into a second listing. Rows the
+source has stopped listing are removed, subject to the safety valves below.
 
 Role: Triggered by POST /api/scrape (called by the scheduler every 6 hours or
 by Cloud Scheduler). Sits between the individual scrapers and the database —
@@ -11,8 +16,10 @@ session, and all scraper modules in app.scrapers/.
 
 # --- Imports ---
 import logging
-from datetime import datetime
-from typing import Optional
+from collections import defaultdict
+from dataclasses import dataclass, field
+from datetime import date, datetime
+from typing import Any, Optional
 
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -24,6 +31,151 @@ from app.scrapers.base import BaseScraper, ScrapedEvent
 from app.scrapers.ticketmaster import TicketmasterScraper
 
 logger = logging.getLogger(__name__)
+
+
+# --- Reconcile safety valves ---
+#
+# Reconciling deletes rows, so it has to stay skeptical of its own input. A scraper that
+# half-succeeds — a selector that stops matching, a paginated feed that returns page one —
+# looks exactly like a venue that cancelled most of its calendar. These two constants
+# decide when a run is too lossy to trust.
+
+# Below this many orphans, reconcile always proceeds: small absolute numbers are normal
+# churn (a cancelled show, a series wrapping up) and never worth second-guessing.
+RECONCILE_ALWAYS_ALLOW = 4
+
+# Above that floor, refuse to delete if orphans exceed this share of the venue's rows in
+# the scraped date window. Losing half a venue's calendar in one run means the scraper
+# broke, not that the venue emptied out.
+RECONCILE_MAX_ORPHAN_FRACTION = 0.5
+
+
+# --- Upsert planning ---
+
+
+@dataclass
+class UpsertPlan:
+    """What a scrape run should do to the rows already stored for a venue.
+
+    Pure data — computed by plan_upsert() without touching the session, so the matching
+    rules can be tested without a database.
+    """
+
+    updates: list[tuple[ScrapedEvent, Any]] = field(default_factory=list)   # (scraped, row to update)
+    inserts: list[ScrapedEvent] = field(default_factory=list)               # no row matched
+    superseded: list[Any] = field(default_factory=list)                     # older rows folded into a match
+    expired: list[Any] = field(default_factory=list)                        # rows the source no longer lists
+    reconcile_skipped: bool = False                                         # True when the safety valve tripped
+
+
+def dedupe_scraped(scraped_events: list[ScrapedEvent]) -> list[ScrapedEvent]:
+    """Collapse repeats within a single scrape run, keeping the first of each.
+
+    Sites list the same event twice (a featured section plus the main listing), and
+    without this the repeats collide on Event.hash inside one INSERT batch.
+    """
+    out: list[ScrapedEvent] = []
+    seen_ext: set[tuple[str, date]] = set()
+    seen_hash: set[str] = set()
+
+    for se in scraped_events:
+        ext_key = (se.external_id, se.date) if se.external_id else None
+        if ext_key is not None and ext_key in seen_ext:
+            continue
+        if se.hash in seen_hash:
+            continue
+        if ext_key is not None:
+            seen_ext.add(ext_key)
+        seen_hash.add(se.hash)
+        out.append(se)
+
+    return out
+
+
+def plan_upsert(existing: list[Any], scraped_events: list[ScrapedEvent], today: date) -> UpsertPlan:
+    """Match a scrape run against the rows already stored for one venue.
+
+    Rows are matched on (external_id, date) first and only then on the title hash. That
+    order is the whole point: the hash is built from the title, so when a venue edits an
+    event — adding a support act, renaming it, prefixing a series — the hash changes and
+    a hash-only match sees a brand-new event. The venue's own ID does not change, so it
+    identifies the show across a rename where the title cannot.
+
+    Rows for the same show that were created by earlier renames are `superseded` and get
+    folded into the survivor. Rows inside the scraped date window that the source stopped
+    listing are `expired`.
+
+    Only attribute access is used on `existing` rows (.id, .date, .hash, .external_id,
+    .updated_at), so tests can pass stand-ins instead of ORM objects.
+    """
+    plan = UpsertPlan()
+    if not scraped_events:
+        return plan
+
+    by_ext: dict[tuple[str, date], list[Any]] = defaultdict(list)
+    by_hash: dict[str, Any] = {}
+    for row in existing:
+        if row.external_id:
+            by_ext[(row.external_id, row.date)].append(row)
+        by_hash[row.hash] = row
+
+    claimed: set[int] = set()
+
+    for se in scraped_events:
+        candidates: list[Any] = []
+        if se.external_id:
+            candidates.extend(by_ext.get((se.external_id, se.date), []))
+        hash_row = by_hash.get(se.hash)
+        if hash_row is not None:
+            candidates.append(hash_row)
+
+        # An external_id match and a hash match are often the same row; and a row already
+        # claimed by an earlier scraped event must not be claimed twice.
+        unique: list[Any] = []
+        picked: set[int] = set()
+        for row in candidates:
+            if row.id in claimed or row.id in picked:
+                continue
+            picked.add(row.id)
+            unique.append(row)
+
+        if not unique:
+            plan.inserts.append(se)
+            continue
+
+        # Prefer the row whose title already matches what the source says now; fall back
+        # to the most recently seen row. Both keys are total, so the choice is stable.
+        unique.sort(
+            key=lambda r: (r.hash == se.hash, r.updated_at or datetime.min),
+            reverse=True,
+        )
+        keep, rest = unique[0], unique[1:]
+        claimed.add(keep.id)
+        plan.updates.append((se, keep))
+        for row in rest:
+            claimed.add(row.id)
+            plan.superseded.append(row)
+
+    # --- Reconcile ---
+    # Only rows inside the window the scraper actually covered are candidates. A scraper
+    # that returns three months of listings says nothing about a show ten months out, and
+    # deleting past events would wipe the archive every run — venues drop them from their
+    # own listings as soon as they happen.
+    horizon = max(se.date for se in scraped_events)
+    in_window = [r for r in existing if today <= r.date <= horizon]
+    orphans = [r for r in in_window if r.id not in claimed]
+
+    if orphans:
+        too_lossy = (
+            len(orphans) > RECONCILE_ALWAYS_ALLOW
+            and len(orphans) > len(in_window) * RECONCILE_MAX_ORPHAN_FRACTION
+        )
+        if too_lossy:
+            plan.reconcile_skipped = True
+        else:
+            plan.expired = orphans
+
+    return plan
 
 
 # --- ScrapeManager ---
@@ -112,26 +264,28 @@ class ScrapeManager:
                 raise ValueError(f"No scraper available for {venue_slug}")
 
             scraped_events = await scraper.scrape()
-            created, updated = await self._upsert_events(venue_id, scraped_events)
+            counts = await self._upsert_events(venue_id, venue_slug, scraped_events)
 
             log.status = "success"
             log.events_found = len(scraped_events)
-            log.events_created = created
-            log.events_updated = updated
+            log.events_created = counts["created"]
+            log.events_updated = counts["updated"]
             log.finished_at = datetime.utcnow()
             log.duration_seconds = (log.finished_at - log.started_at).total_seconds()
             await self.session.commit()
 
+            # merged/expired counts have no ScrapeLog column yet, so they live in the log
+            # line and the API response. Individual removals are logged in _upsert_events.
             logger.info(
                 f"[{venue_slug}] Scrape complete: {len(scraped_events)} found, "
-                f"{created} created, {updated} updated"
+                f"{counts['created']} created, {counts['updated']} updated, "
+                f"{counts['merged']} merged, {counts['expired']} expired"
             )
             return {
                 "venue": venue_slug,
                 "status": "success",
                 "found": len(scraped_events),
-                "created": created,
-                "updated": updated,
+                **counts,
             }
 
         except Exception as e:
@@ -152,79 +306,104 @@ class ScrapeManager:
 
     # --- Upsert helpers ---
 
-    async def _upsert_events(self, venue_id: int, scraped_events: list[ScrapedEvent]) -> tuple[int, int]:
-        """Upsert events using hash-based dedup. Returns (created, updated) counts."""
+    @staticmethod
+    def _apply_scraped(row: Event, se: ScrapedEvent) -> None:
+        """Copy a freshly scraped event onto the row that represents it.
+
+        The title and its hash are written back, because a row matched on external_id may
+        be carrying a title the venue has since edited. Optional fields fall back to the
+        stored value so a source that briefly omits a field does not blank out good data.
+        """
+        row.name = se.name
+        row.artist = se.artist or row.artist
+        row.hash = se.hash
+        row.external_id = se.external_id or row.external_id
+        row.source = se.source
+        row.source_url = se.source_url or row.source_url
+        row.price_min = se.price_min
+        row.price_max = se.price_max
+        row.status = se.status
+        row.image_url = se.image_url or row.image_url
+        row.ticket_url = se.ticket_url or row.ticket_url
+        row.doors_time = se.doors_time or row.doors_time
+        row.show_time = se.show_time or row.show_time
+        row.support_artists = se.support_artists or row.support_artists
+        row.genre = se.genre or row.genre
+        row.subgenre = se.subgenre or row.subgenre
+        row.age_restriction = se.age_restriction or row.age_restriction
+        row.description = se.description or row.description
+        row.updated_at = datetime.utcnow()
+
+    async def _upsert_events(self, venue_id: int, venue_slug: str, scraped_events: list[ScrapedEvent]) -> dict:
+        """Reconcile a scrape run against stored events. Returns per-outcome counts."""
         if not scraped_events:
-            return 0, 0
+            return {"created": 0, "updated": 0, "merged": 0, "expired": 0}
 
-        # Deduplicate scraped events by hash (sites sometimes list the same event
-        # twice — e.g. a featured section + main listing — which would cause a
-        # UniqueViolationError when both end up in the same INSERT flush batch.
-        seen: dict[str, ScrapedEvent] = {}
-        for se in scraped_events:
-            seen.setdefault(se.hash, se)
-        scraped_events = list(seen.values())
+        scraped_events = dedupe_scraped(scraped_events)
 
-        # Fetch all matching existing events in one query instead of one per event.
-        hashes = [se.hash for se in scraped_events]
+        # Load the venue's whole calendar in one query. Matching on external_id and
+        # spotting rows the source dropped both need the full picture, and no venue
+        # holds more than a couple hundred rows.
         result = await self.session.execute(
-            select(Event).where(Event.hash.in_(hashes))
+            select(Event).where(Event.venue_id == venue_id)
         )
-        existing_by_hash = {e.hash: e for e in result.scalars().all()}
+        existing = list(result.scalars().all())
 
-        created = 0
-        updated = 0
+        plan = plan_upsert(existing, scraped_events, datetime.utcnow().date())
 
-        for se in scraped_events:
-            existing = existing_by_hash.get(se.hash)
+        if plan.reconcile_skipped:
+            logger.warning(
+                f"[{venue_slug}] Reconcile skipped: {len(scraped_events)} events scraped would "
+                f"orphan too large a share of the stored calendar. Leaving rows in place — "
+                f"this usually means the scraper is partially broken, not that the venue emptied."
+            )
 
-            if existing:
-                # Update mutable fields — identity fields (name, date, venue) are
-                # baked into the hash so they never change for a given event row.
-                existing.price_min = se.price_min
-                existing.price_max = se.price_max
-                existing.status = se.status
-                # Prefer the freshly scraped value but fall back to whatever we already
-                # have stored so we don't accidentally blank out previously-good data.
-                existing.image_url = se.image_url or existing.image_url
-                existing.ticket_url = se.ticket_url or existing.ticket_url
-                existing.doors_time = se.doors_time or existing.doors_time
-                existing.show_time = se.show_time or existing.show_time
-                existing.support_artists = se.support_artists or existing.support_artists
-                existing.genre = se.genre or existing.genre
-                existing.subgenre = se.subgenre or existing.subgenre
-                existing.age_restriction = se.age_restriction or existing.age_restriction
-                existing.description = se.description or existing.description
-                existing.updated_at = datetime.utcnow()
-                updated += 1
-            else:
-                event = Event(
-                    external_id=se.external_id,
-                    venue_id=venue_id,
-                    name=se.name,
-                    artist=se.artist,
-                    support_artists=se.support_artists,
-                    date=se.date,
-                    doors_time=se.doors_time,
-                    show_time=se.show_time,
-                    ticket_url=se.ticket_url,
-                    price_min=se.price_min,
-                    price_max=se.price_max,
-                    image_url=se.image_url,
-                    genre=se.genre,
-                    subgenre=se.subgenre,
-                    status=se.status,
-                    age_restriction=se.age_restriction,
-                    description=se.description,
-                    source=se.source,
-                    source_url=se.source_url,
-                    hash=se.hash,
-                )
-                self.session.add(event)
-                created += 1
+        # Deletes go first, and get their own flush. Event.hash is globally unique, and a
+        # surviving row is often about to take the hash a superseded row still holds.
+        removals = (
+            [(r, "superseded by another listing for the same show") for r in plan.superseded]
+            + [(r, "no longer listed by the source") for r in plan.expired]
+        )
+        for row, why in removals:
+            logger.info(f"[{venue_slug}] Removing event {row.id} ({row.date} {row.name!r}) — {why}")
+            await self.session.delete(row)
+        if removals:
+            await self.session.flush()
+
+        for se, row in plan.updates:
+            self._apply_scraped(row, se)
+
+        for se in plan.inserts:
+            self.session.add(Event(
+                external_id=se.external_id,
+                venue_id=venue_id,
+                name=se.name,
+                artist=se.artist,
+                support_artists=se.support_artists,
+                date=se.date,
+                doors_time=se.doors_time,
+                show_time=se.show_time,
+                ticket_url=se.ticket_url,
+                price_min=se.price_min,
+                price_max=se.price_max,
+                image_url=se.image_url,
+                genre=se.genre,
+                subgenre=se.subgenre,
+                status=se.status,
+                age_restriction=se.age_restriction,
+                description=se.description,
+                source=se.source,
+                source_url=se.source_url,
+                hash=se.hash,
+            ))
 
         await self.session.flush()
-        return created, updated
+        return {
+            "created": len(plan.inserts),
+            "updated": len(plan.updates),
+            "merged": len(plan.superseded),
+            "expired": len(plan.expired),
+        }
 
     # --- Bulk scrape entry points ---
 

--- a/backend/app/scrapers/manager.py
+++ b/backend/app/scrapers/manager.py
@@ -26,7 +26,8 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.dialects.postgresql import insert as pg_insert
 
 from app.config import settings
-from app.models import Venue, Event, ScrapeLog
+from app.classifier import classification_updates, ALWAYS_LIVE_VENUE_SLUGS
+from app.models import Venue, Event, ScrapeLog, SeriesOverride
 from app.scrapers.base import BaseScraper, ScrapedEvent
 from app.scrapers.ticketmaster import TicketmasterScraper
 
@@ -405,6 +406,62 @@ class ScrapeManager:
             "expired": len(plan.expired),
         }
 
+    # --- Classification ---
+
+    async def reclassify_all(self) -> dict:
+        """Recompute is_live_music for all upcoming events.
+
+        Runs after every bulk scrape. Recurrence is a cross-event signal, so this
+        always considers the full set of future events regardless of which venues
+        were just scraped. Admin decisions are respected: per-event manual overrides
+        (is_manual_override=True) are left untouched, and series-level overrides are
+        applied to every matching event — including instances scraped later.
+        Returns {events, changed} counts.
+        """
+        today = date.today()
+        result = await self.session.execute(
+            select(Event).where(Event.date >= today)
+        )
+        events = result.scalars().all()
+
+        # Load series-level overrides, keyed to match classifier.normalize_series_name.
+        so_result = await self.session.execute(select(SeriesOverride))
+        series_overrides = {
+            (so.venue_id, so.normalized_name): (so.is_live_music, so.note)
+            for so in so_result.scalars().all()
+        }
+
+        # Resolve always-live venues (e.g. DPAC) to their ids for the exemption.
+        venue_rows = await self.session.execute(select(Venue.id, Venue.slug))
+        exempt_venue_ids = {
+            vid for vid, slug in venue_rows.all() if slug in ALWAYS_LIVE_VENUE_SLUGS
+        }
+
+        # classification_updates omits manually-overridden rows (those flags survive),
+        # forces always-live venues, and applies series overrides above auto.
+        updates = classification_updates(
+            events,
+            series_overrides=series_overrides,
+            exempt_venue_ids=exempt_venue_ids,
+        )
+
+        changed = 0
+        for ev in events:
+            if ev.id not in updates:
+                continue
+            is_live, reason = updates[ev.id]
+            if ev.is_live_music != is_live or ev.classification_reason != reason:
+                ev.is_live_music = is_live
+                ev.classification_reason = reason
+                changed += 1
+
+        await self.session.commit()
+        logger.info(
+            f"Reclassified {len(events)} upcoming events; {changed} changed "
+            f"(manual overrides preserved)"
+        )
+        return {"events": len(events), "changed": changed}
+
     # --- Bulk scrape entry points ---
 
     async def scrape_all(self, scraper_types: Optional[list[str]] = None) -> list[dict]:
@@ -422,6 +479,9 @@ class ScrapeManager:
             r = await self.scrape_venue(venue)
             results.append(r)
 
+        # Recompute live-music flags across all upcoming events now that new data is in.
+        await self.reclassify_all()
+
         return results
 
     async def scrape_ticketmaster(self) -> list[dict]:
@@ -438,4 +498,8 @@ class ScrapeManager:
         for venue in venues:
             r = await self.scrape_venue(venue)
             results.append(r)
+
+        # Recompute live-music flags across all upcoming events now that new data is in.
+        await self.reclassify_all()
+
         return results

--- a/backend/app/scrapers/mec.py
+++ b/backend/app/scrapers/mec.py
@@ -17,6 +17,7 @@ import httpx
 from bs4 import BeautifulSoup
 
 from app.scrapers.base import BaseScraper, ScrapedEvent, BROWSER_HEADERS
+from app.scrapers.html_text import clean_html_text
 
 # --- Module-level setup ---
 logger = logging.getLogger(__name__)
@@ -206,10 +207,12 @@ class MECScraper(BaseScraper):
                 image = image.get("url", "")
             image_url = image or None
 
-            # Description
-            description = data.get("description", "") or None
-            if description:
-                description = description[:500]  # Truncate to avoid oversized records
+            # Description — MEC's JSON-LD field stores markup that has itself been through
+            # an HTML-entity pass, e.g. the literal text '&lt;p&gt;&lt;strong&gt;...'
+            # rather than an actual '<p>' tag, so it needs both an entity-decode and a
+            # tag-strip before it is readable (#13). Truncated after cleaning — truncating
+            # the raw markup first risks cutting mid-tag or mid-entity.
+            description = clean_html_text(data.get("description"), limit=500)
 
             # Status — derive from schema eventStatus or price
             event_status = data.get("eventStatus", "")

--- a/backend/app/scrapers/motorco.py
+++ b/backend/app/scrapers/motorco.py
@@ -22,6 +22,31 @@ from app.scrapers.base import BaseScraper, ScrapedEvent, BROWSER_HEADERS
 
 logger = logging.getLogger(__name__)
 
+# Each JS event object looks like:
+#   { title: 'Name', start: '2026-04-03 21:00', url: 'https://...', classNames: '...' }
+#
+# `title` is free text, so it must be matched as a proper JS string literal rather
+# than with a stop-at-the-first-quote pattern. WordPress `esc_js` backslash-escapes
+# any apostrophe inside the single-quoted value, and a naive `(.+?)['"]` terminates
+# at that escaped quote — truncating e.g. "This Tour Won't Save You" to
+# "This Tour Won\". Match the opening quote, then a run of escaped characters
+# (`\\.`) or non-quote characters, up to the matching closing quote. The captured
+# value still holds its backslashes; `_parse_event` collapses them.
+#
+# `start` and `url` values never contain a quote, so the simpler form is sufficient
+# (and clearer) for them.
+_EVENT_PATTERN = re.compile(
+    r'\{[^{}]*?title\s*:\s*(?P<q>[\'"])(?P<title>(?:\\.|(?!(?P=q)).)*)(?P=q)'
+    r'[^{}]*?start\s*:\s*[\'"](?P<start>\d{4}-\d{2}-\d{2}[^\'\"]*)[\'"]'
+    r'[^{}]*?url\s*:\s*[\'"](?P<url>[^\'\"]+)[\'"]',
+    re.S,
+)
+
+# A JS string escape is a backslash followed by any single character (`\'`, `\"`,
+# `\\`, `\/`). `esc_js` only ever emits a backslash as an escape introducer, so
+# collapsing each pair to its second character never eats a literal backslash.
+_JS_ESCAPE_PATTERN = re.compile(r"\\(.)")
+
 
 # --- Scraper class ---
 
@@ -46,23 +71,14 @@ class MotorcoScraper(BaseScraper):
             resp.raise_for_status()
             html = resp.text
 
-        # Each JS event object looks like:
-        #   { title: 'Name', start: '2026-04-03 21:00', url: 'https://...', classNames: '...' }
-        # Extract title, start, and url per event block.
-        pattern = re.compile(
-            r'\{[^{}]*?title\s*:\s*[\'"](.+?)[\'"]'
-            r'[^{}]*?start\s*:\s*[\'"](\d{4}-\d{2}-\d{2}[^\'\"]*)[\'"]'
-            r'[^{}]*?url\s*:\s*[\'"]([^\'\"]+)[\'"]',
-            re.S,
-        )
-
-        # Deduplicate by (title, start) — the regex can produce overlapping matches
-        # when event objects share similar surrounding HTML context.
+        # Deduplicate by (title, start). `finditer` yields non-overlapping matches,
+        # so this guards against the same event genuinely appearing twice in the
+        # page markup rather than against overlapping regex matches.
         seen = set()
-        for m in pattern.finditer(html):
-            raw_title, raw_start, raw_url = m.group(1), m.group(2), m.group(3)
+        for m in _EVENT_PATTERN.finditer(html):
+            raw_title, raw_start, raw_url = m.group("title"), m.group("start"), m.group("url")
 
-            # Skip duplicates (the regex can match overlapping regions)
+            # Skip an event object we have already seen
             key = (raw_title, raw_start)
             if key in seen:
                 continue
@@ -78,7 +94,9 @@ class MotorcoScraper(BaseScraper):
     def _parse_event(self, title: str, start_str: str, url: str, today: date) -> Optional[ScrapedEvent]:
         """Parse raw JS-extracted strings into a ScrapedEvent, or return None on failure."""
         try:
-            # Unescape HTML entities in title
+            # Collapse JS string escapes (esc_js turns an apostrophe into \'),
+            # then unescape HTML entities in title
+            title = _JS_ESCAPE_PATTERN.sub(r"\1", title)
             title = title.replace("&#038;", "&").replace("&amp;", "&").replace("&#8217;", "'")
 
             # Parse datetime — format is "2026-04-03 21:00" or "2026-04-03"

--- a/backend/app/scrapers/squarespace.py
+++ b/backend/app/scrapers/squarespace.py
@@ -49,8 +49,7 @@ class SquarespaceScraper(BaseScraper):
                 logger.warning(f"[Squarespace] Non-JSON response from {url}")
                 return []
 
-            # Squarespace can return events under different keys
-            items = data.get("items", data.get("upcoming", data.get("events", [])))
+            items = self._select_items(data)
 
             for item in items:
                 parsed = self._parse_event(item)
@@ -59,6 +58,20 @@ class SquarespaceScraper(BaseScraper):
 
         logger.info(f"[Squarespace] Found {len(events)} events for {self.venue_slug}")
         return events
+
+    @staticmethod
+    def _select_items(data: dict) -> list:
+        """Pick the event list out of a Squarespace JSON payload.
+
+        Which key holds the events depends on the site's template — Neptune's Parlour
+        uses "items", Boom Club uses "upcoming".
+
+        Chained with `or` rather than nested get() defaults on purpose: a default only
+        applies when the key is ABSENT, so a feed carrying "items": [] would take that
+        empty list and stop, never reaching the "upcoming" key holding its events. The
+        venue would silently report zero events with no error anywhere.
+        """
+        return data.get("items") or data.get("upcoming") or data.get("events") or []
 
     def _extract_description(self, item: dict) -> str:
         """Pull a plain-text description out of a Squarespace event body.

--- a/backend/app/scrapers/squarespace.py
+++ b/backend/app/scrapers/squarespace.py
@@ -60,6 +60,37 @@ class SquarespaceScraper(BaseScraper):
         logger.info(f"[Squarespace] Found {len(events)} events for {self.venue_slug}")
         return events
 
+    def _extract_description(self, item: dict) -> str:
+        """Pull a plain-text description out of a Squarespace event body.
+
+        Squarespace nests the post body in a `div.sqs-html-content` block whose first
+        child repeats the event title, so the walk starts at the second child and takes
+        the text of each remaining one — the raw HTML must not reach the database (#17).
+
+        Returns '' when there is nothing to read. A venue that leaves an event body
+        empty gets layout scaffolding with no `sqs-html-content` block at all, and an
+        empty description is never a reason to discard the event (#35).
+        """
+        raw = item.get("excerpt") or item.get("body") or ""
+        if not raw:
+            return ''
+
+        try:
+            body = BeautifulSoup(raw, "lxml").select_one("div.sqs-html-content")
+            if body is None:
+                return ''
+            # select_one rather than select()[0]: an absent block returns None instead of
+            # raising IndexError, which is what used to take the whole event down.
+            return ''.join(child.text + "\r\n" for child in list(body.contents)[1:])
+        except Exception as e:
+            # Description is optional metadata. Losing it must never lose the event, so
+            # this stays outside the caller's try block for the required fields.
+            logger.warning(
+                f"[Squarespace] {self.venue_slug}: could not read description for "
+                f"{item.get('title', '?')!r}: {e}"
+            )
+            return ''
+
     def _parse_event(self, item: dict) -> Optional[ScrapedEvent]:
         """Parse a single Squarespace event dict into a ScrapedEvent, returning None on failure."""
         try:
@@ -90,13 +121,7 @@ class SquarespaceScraper(BaseScraper):
             # End date (usually same day)
             end_ts = item.get("endDate")
 
-            # Extract body/description — fall back to raw body if no excerpt
-            soup = BeautifulSoup(item.get("excerpt", "") or item.get("body", ""), "lxml")
-            description = ''
-            html_content = soup.select("div.sqs-html-content")
-            # start at 1 bc [0] is just the title again
-            for index in range(1, len(html_content[0].contents)):
-                description += html_content[0].contents[index].text + "\r\n"
+            description = self._extract_description(item)
             # Image
             image_url = None
             if item.get("assetUrl"):
@@ -147,5 +172,10 @@ class SquarespaceScraper(BaseScraper):
                 source_url=source_url,
             )
         except Exception as e:
-            logger.warning(f"[Squarespace] Failed to parse event: {e}")
+            # Name the venue and the event: the previous message identified neither,
+            # which is why four silently dropped Boom Club events went unnoticed.
+            logger.warning(
+                f"[Squarespace] {self.venue_slug}: failed to parse "
+                f"{item.get('title', '?')!r}: {e}"
+            )
             return None

--- a/backend/app/scrapers/squarespace.py
+++ b/backend/app/scrapers/squarespace.py
@@ -15,6 +15,7 @@ from bs4 import BeautifulSoup
 import httpx
 
 from app.scrapers.base import BaseScraper, ScrapedEvent, BROWSER_HEADERS
+from app.scrapers.html_text import clean_html_text
 
 # --- Module-level setup ---
 
@@ -73,28 +74,32 @@ class SquarespaceScraper(BaseScraper):
         """
         return data.get("items") or data.get("upcoming") or data.get("events") or []
 
-    def _extract_description(self, item: dict) -> str:
-        """Pull a plain-text description out of a Squarespace event body.
+    def _extract_description(self, item: dict, title: str) -> Optional[str]:
+        """Pull a human-readable description out of a Squarespace event.
 
-        Squarespace nests the post body in a `div.sqs-html-content` block whose first
-        child repeats the event title, so the walk starts at the second child and takes
-        the text of each remaining one — the raw HTML must not reach the database (#17).
+        Two shapes of source content, told apart by which field they came from:
 
-        Returns '' when there is nothing to read. A venue that leaves an event body
-        empty gets layout scaffolding with no `sqs-html-content` block at all, and an
-        empty description is never a reason to discard the event (#35).
+        - `excerpt`, when present, is a genuinely separate summary field: bare `<p>`
+          tags with real content, never a repeat of the title (confirmed against
+          Boom Club, which fills in excerpts but leaves `body` looking like an empty
+          Post Body block). Its paragraphs are kept as-is.
+        - `body` is the Post Body WYSIWYG editor's output, wrapped in Squarespace's
+          layout markup, and its first paragraph always repeats the event's own
+          title (confirmed against Neptune's Parlour) — dropped via
+          `drop_first_paragraph_if` rather than a positional skip, so it only ever
+          removes an actual title repeat and never a paragraph of real content that
+          happens to come first (#13, #17).
+
+        An event whose body is empty layout scaffolding with no readable text
+        returns None — that is never a reason to discard the event itself (#35).
         """
-        raw = item.get("excerpt") or item.get("body") or ""
-        if not raw:
-            return ''
-
         try:
-            body = BeautifulSoup(raw, "lxml").select_one("div.sqs-html-content")
-            if body is None:
-                return ''
-            # select_one rather than select()[0]: an absent block returns None instead of
-            # raising IndexError, which is what used to take the whole event down.
-            return ''.join(child.text + "\r\n" for child in list(body.contents)[1:])
+            excerpt = item.get("excerpt")
+            if excerpt:
+                # A real excerpt is never dropped for matching the title — only
+                # body's known title-repeat paragraph is.
+                return clean_html_text(excerpt)
+            return clean_html_text(item.get("body") or "", drop_first_paragraph_if=title)
         except Exception as e:
             # Description is optional metadata. Losing it must never lose the event, so
             # this stays outside the caller's try block for the required fields.
@@ -102,7 +107,7 @@ class SquarespaceScraper(BaseScraper):
                 f"[Squarespace] {self.venue_slug}: could not read description for "
                 f"{item.get('title', '?')!r}: {e}"
             )
-            return ''
+            return None
 
     def _parse_event(self, item: dict) -> Optional[ScrapedEvent]:
         """Parse a single Squarespace event dict into a ScrapedEvent, returning None on failure."""
@@ -134,7 +139,7 @@ class SquarespaceScraper(BaseScraper):
             # End date (usually same day)
             end_ts = item.get("endDate")
 
-            description = self._extract_description(item)
+            description = self._extract_description(item, title)
             # Image
             image_url = None
             if item.get("assetUrl"):

--- a/backend/app/tokens.py
+++ b/backend/app/tokens.py
@@ -1,0 +1,268 @@
+"""
+Verification of signed tokens, so the Cloud Run origin can tell who a request came from.
+
+Role: Imported by main.py to guard two routes that must not be open on the origin —
+`/admin/*` (Cloudflare Access) and `POST /api/scrape` (Google OIDC, as sent by Cloud
+Scheduler). Pure verification: no database, no application state.
+
+Why this exists. The Cloud Run service sets no `--ingress` restriction, so its `.run.app`
+hostnames answer the public internet directly, skipping Cloudflare and anything enforced
+there. A Cloudflare Access policy on `triangle-shows.net/admin` therefore protects only
+the Cloudflare path; the origin remains reachable. Redacting the hostname (see
+docs/ARCHITECTURE.md) reduces disclosure but is not a control — the hostname is derived
+from the service name and project number rather than from anything secret.
+
+The fix is for the origin to require proof that a request passed through a trusted issuer.
+Both issuers here sign a short-lived token with a private key and publish the matching
+public keys at a fixed URL, so verification is local arithmetic against keys already
+fetched: no callback to the issuer on the request path, and a forged token is not
+possible without the issuer's private key.
+
+Four checks, and the audience check is the one worth being explicit about: without it a
+token the issuer legitimately minted for a *different* application would verify here.
+Signature, expiry, audience, issuer — all four or the token is rejected.
+
+Requires: `pyjwt[crypto]`. Configuration lives in app.config (CF_ACCESS_*, SCRAPE_*);
+each gate is inert until configured, which is what keeps local dev and CI working.
+"""
+
+# --- Imports ---
+import logging
+from typing import Any, Optional, Sequence
+
+import jwt
+from jwt import PyJWKClient
+
+logger = logging.getLogger(__name__)
+
+
+# --- Issuer endpoints ---
+
+GOOGLE_JWKS_URL = "https://www.googleapis.com/oauth2/v3/certs"
+
+# Google has emitted both spellings over the years and both remain valid on ID tokens.
+GOOGLE_ISSUERS = ("https://accounts.google.com", "accounts.google.com")
+
+# Only asymmetric signing is accepted. Allowing an HMAC algorithm here would let a caller
+# who knows the (public) verification key sign their own tokens with it.
+ALLOWED_ALGORITHMS = ("RS256",)
+
+# Tolerance for clock drift between the issuer and this container, in seconds.
+CLOCK_LEEWAY = 60
+
+
+class TokenError(Exception):
+    """A token was absent, malformed, or failed one of the four checks."""
+
+
+# --- Key fetching ---
+
+# One client per JWKS URL, module-scoped. Each client holds the keys it has fetched and
+# refetches only on seeing an unknown key id, so constructing one per request would turn
+# every request into an outbound HTTPS call and defeat the point of caching.
+_jwks_clients: dict[str, PyJWKClient] = {}
+
+
+def _jwks_client(url: str) -> PyJWKClient:
+    client = _jwks_clients.get(url)
+    if client is None:
+        client = PyJWKClient(url, cache_jwk_set=True, lifespan=3600)
+        _jwks_clients[url] = client
+    return client
+
+
+# --- Core verification ---
+
+def verify_token(
+    token: Optional[str],
+    *,
+    jwks_url: str,
+    issuers: Sequence[str],
+    audience: Optional[str],
+) -> dict[str, Any]:
+    """Verify a signed token and return its claims, or raise TokenError.
+
+    `audience` may be None to skip only the audience check — see the callers for when
+    that is a defensible trade and when it is not. Every other check always runs.
+
+    Raises TokenError for every failure mode, so a caller can turn any of them into one
+    response without distinguishing between them. Deliberate: telling an unauthenticated
+    caller *why* their token was rejected is free reconnaissance.
+    """
+    if not token:
+        raise TokenError("no token presented")
+
+    try:
+        signing_key = _jwks_client(jwks_url).get_signing_key_from_jwt(token)
+        claims = jwt.decode(
+            token,
+            signing_key.key,
+            algorithms=list(ALLOWED_ALGORITHMS),
+            audience=audience,
+            leeway=CLOCK_LEEWAY,
+            options={
+                "require": ["exp"],
+                "verify_exp": True,
+                "verify_aud": audience is not None,
+            },
+        )
+    except jwt.PyJWTError as exc:
+        raise TokenError(f"{type(exc).__name__}: {exc}") from exc
+    except Exception as exc:
+        # Key fetching failures (network, malformed JWKS) land here. Treated the same as a
+        # bad token: fail closed. An issuer we cannot reach is not an issuer we can trust.
+        raise TokenError(f"key retrieval failed: {type(exc).__name__}: {exc}") from exc
+
+    # Issuer is checked here rather than passed to jwt.decode() because Google accepts two
+    # spellings and decode() takes a single value.
+    issuer = claims.get("iss")
+    if issuer not in issuers:
+        raise TokenError(f"unexpected issuer: {issuer!r}")
+
+    return claims
+
+
+# --- Cloudflare Access (guards /admin/*) ---
+
+def cloudflare_access_configured() -> bool:
+    """True when both settings needed to enforce the Access gate are present."""
+    from app.config import settings
+
+    return bool(settings.CF_ACCESS_TEAM_DOMAIN and settings.CF_ACCESS_AUD)
+
+
+def verify_cloudflare_access(token: Optional[str]) -> dict[str, Any]:
+    """Verify a Cloudflare Access token and return its claims.
+
+    Cloudflare mints this after the visitor signs in against the configured identity
+    provider, and attaches it to every request it forwards as `Cf-Access-Jwt-Assertion`.
+    A request arriving at the origin directly carries no such header.
+
+    The audience is the Access application's AUD tag and is required: a Cloudflare team
+    can host several applications, and without this check a token issued for any of them
+    would open the admin surface.
+    """
+    from app.config import settings
+
+    team_domain = settings.CF_ACCESS_TEAM_DOMAIN.strip().rstrip("/")
+    # Accept the team domain with or without a scheme, since the dashboard shows it bare.
+    if "://" in team_domain:
+        team_domain = team_domain.split("://", 1)[1]
+
+    return verify_token(
+        token,
+        jwks_url=f"https://{team_domain}/cdn-cgi/access/certs",
+        issuers=(f"https://{team_domain}",),
+        audience=settings.CF_ACCESS_AUD.strip(),
+    )
+
+
+def access_identity(claims: dict[str, Any]) -> str:
+    """The signed-in person's email, for logging and attribution.
+
+    Access always sets `email` for an interactive login; `sub` is the fallback for a
+    service token, which has no human behind it.
+    """
+    return claims.get("email") or claims.get("sub") or "unknown"
+
+
+# --- Google OIDC (guards POST /api/scrape) ---
+
+def scrape_allowed_service_accounts() -> tuple[str, ...]:
+    """Service-account emails permitted to trigger a scrape.
+
+    Comma-separated in the environment so a second caller is a configuration change
+    rather than a code change.
+    """
+    from app.config import settings
+
+    raw = settings.SCRAPE_ALLOWED_SERVICE_ACCOUNTS or ""
+    return tuple(part.strip() for part in raw.split(",") if part.strip())
+
+
+def scrape_token_configured() -> bool:
+    """True when at least one service account is allowlisted, which enables the gate."""
+    return bool(scrape_allowed_service_accounts())
+
+
+def verify_scrape_token(token: Optional[str]) -> dict[str, Any]:
+    """Verify a Google-issued OIDC token from Cloud Scheduler and return its claims.
+
+    Cloud Scheduler is already configured to attach this token, so nothing changes on the
+    scheduler side — the endpoint simply starts reading what has been arriving all along.
+    Cloud Run cannot enforce it for us: the service must accept unauthenticated requests
+    for the public site to work, so the check has to happen in the application.
+
+    The allowlisted service-account email is the substantive control here. Only a caller
+    holding that identity can obtain a Google-signed token bearing it, and an attacker
+    cannot mint one.
+
+    SCRAPE_OIDC_AUDIENCE is honored when set and skipped when not. Skipping it is a real
+    if narrow weakening: it would permit a token this same service account obtained for a
+    *different* audience to be replayed here. With one scheduler job and one service
+    account there is no such second audience, but set it when the value is known.
+    """
+    from app.config import settings
+
+    audience = (settings.SCRAPE_OIDC_AUDIENCE or "").strip() or None
+    claims = verify_token(
+        token,
+        jwks_url=GOOGLE_JWKS_URL,
+        issuers=GOOGLE_ISSUERS,
+        audience=audience,
+    )
+
+    email = claims.get("email")
+    allowed = scrape_allowed_service_accounts()
+    if email not in allowed:
+        raise TokenError(f"service account not allowlisted: {email!r}")
+
+    return claims
+
+
+def bearer_token(header_value: Optional[str]) -> Optional[str]:
+    """Pull the token out of an `Authorization: Bearer <token>` header."""
+    if not header_value:
+        return None
+    scheme, _, value = header_value.partition(" ")
+    if scheme.lower() != "bearer" or not value.strip():
+        return None
+    return value.strip()
+
+
+# --- Startup reporting ---
+
+def log_enforcement_state() -> None:
+    """Say plainly, once per boot, which gates are live.
+
+    A security control that silently does nothing when misconfigured is worse than one
+    that is absent, because it reads as protection. These lines are how you tell which
+    you have.
+    """
+    if cloudflare_access_configured():
+        logger.info("[tokens] /admin: Cloudflare Access enforced at the origin")
+    else:
+        logger.warning(
+            "[tokens] /admin: Cloudflare Access NOT enforced (CF_ACCESS_TEAM_DOMAIN "
+            "and CF_ACCESS_AUD are not both set). The origin hostname reaches /admin "
+            "without passing Cloudflare."
+        )
+
+    if scrape_token_configured():
+        audience_note = "with audience check" if _scrape_audience_set() else "without audience check"
+        logger.info(
+            f"[tokens] POST /api/scrape: Google OIDC enforced for "
+            f"{len(scrape_allowed_service_accounts())} service account(s), {audience_note}"
+        )
+    else:
+        logger.warning(
+            "[tokens] POST /api/scrape: NOT enforced "
+            "(SCRAPE_ALLOWED_SERVICE_ACCOUNTS is empty). Anyone who knows the origin "
+            "hostname can trigger a full scrape."
+        )
+
+
+def _scrape_audience_set() -> bool:
+    from app.config import settings
+
+    return bool((settings.SCRAPE_OIDC_AUDIENCE or "").strip())

--- a/backend/conftest.py
+++ b/backend/conftest.py
@@ -1,0 +1,27 @@
+"""Pytest configuration for the backend suite: make `app` importable.
+
+The tests import the code under test as `app.scrapers.…`, but `app` is a plain
+directory inside `backend/` rather than an installed package, so it is only
+importable when `backend/` is on `sys.path`. Every test module used to arrange that
+for itself with a three-line preamble before its real imports.
+
+That worked, but it made the suite quietly invocation-dependent. `python -m pytest`
+puts the current directory on `sys.path` as a side effect of `-m`, so from `backend/`
+the preamble was redundant and its absence went unnoticed; a bare `pytest tests`
+adds no such entry, so a module that omitted the preamble failed at collection with
+`ModuleNotFoundError: No module named 'app'`. CI uses the `python -m` form, which is
+why it never surfaced there.
+
+pytest imports the conftest.py files covering a test's directory before importing the
+test modules themselves, so putting the insert here runs early enough for the whole
+suite and stays correct however pytest is invoked -- and applies to new test modules
+without them needing to remember anything.
+"""
+
+import sys
+from pathlib import Path
+
+BACKEND_DIR = Path(__file__).resolve().parent
+
+if str(BACKEND_DIR) not in sys.path:
+    sys.path.insert(0, str(BACKEND_DIR))

--- a/backend/requirements-dev.txt
+++ b/backend/requirements-dev.txt
@@ -1,0 +1,3 @@
+# Development / test dependencies (not installed in the production image).
+-r requirements.txt
+pytest==8.3.4

--- a/backend/requirements-dev.txt
+++ b/backend/requirements-dev.txt
@@ -1,3 +1,5 @@
-# Development / test dependencies (not installed in the production image).
+# Test-only dependencies. Kept out of requirements.txt so the Cloud Run image
+# does not ship a test runner. Install with:
+#   pip install -r backend/requirements-dev.txt
 -r requirements.txt
 pytest==8.3.4

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -12,3 +12,7 @@ apscheduler==3.10.4
 tzlocal==5.2
 python-dotenv==1.0.1
 icalendar==6.1.3
+# Verifies the Cloudflare Access and Google OIDC tokens that gate /admin and
+# POST /api/scrape (see app/tokens.py). The [crypto] extra pulls in `cryptography`,
+# which is what supports the RS256 signatures both issuers use.
+pyjwt[crypto]==2.10.1

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -12,6 +12,7 @@ apscheduler==3.10.4
 tzlocal==5.2
 python-dotenv==1.0.1
 icalendar==6.1.3
+itsdangerous==2.2.0
 # Verifies the Cloudflare Access and Google OIDC tokens that gate /admin and
 # POST /api/scrape (see app/tokens.py). The [crypto] extra pulls in `cryptography`,
 # which is what supports the RS256 signatures both issuers use.

--- a/backend/tests/test_admin_login.py
+++ b/backend/tests/test_admin_login.py
@@ -1,0 +1,106 @@
+"""
+Tests for the admin login check — review item #12.
+
+secrets.compare_digest raises TypeError when handed a str containing any non-ASCII
+character, rather than returning False. So a password with an accented character turned a
+wrong-password attempt into a 500. Two problems with that: the endpoint stops failing
+cleanly, and because the response differs from the normal 401 it tells an unauthenticated
+caller something about the configured password.
+
+No database is touched — the login route only compares a string and sets a cookie.
+"""
+
+from fastapi.testclient import TestClient
+
+import pytest
+
+from app.config import settings
+from app.main import app
+
+
+ASCII_PASSWORD = "s3cret-ascii-only"
+ACCENTED_PASSWORD = "contraseña-café"
+
+
+@pytest.fixture
+def client():
+    return TestClient(app)
+
+
+@pytest.fixture(autouse=True)
+def gates_off(monkeypatch):
+    """The origin gate would 403 /admin before the login handler ever ran."""
+    monkeypatch.setattr(settings, "CF_ACCESS_TEAM_DOMAIN", "")
+    monkeypatch.setattr(settings, "CF_ACCESS_AUD", "")
+
+
+def _configure(monkeypatch, password):
+    monkeypatch.setattr(settings, "ADMIN_PASSWORD", password)
+    monkeypatch.setattr(settings, "SESSION_SECRET", "test-signing-key")
+
+
+class TestNonAsciiPasswords:
+    def test_a_wrong_guess_against_an_accented_password_is_a_clean_401(
+        self, client, monkeypatch
+    ):
+        """The regression: this raised TypeError inside compare_digest and returned 500."""
+        _configure(monkeypatch, ACCENTED_PASSWORD)
+
+        response = client.post("/admin/login", json={"password": "wrong"})
+
+        assert response.status_code == 401
+        assert response.json()["ok"] is False
+
+    def test_an_accented_guess_against_an_ascii_password_is_a_clean_401(
+        self, client, monkeypatch
+    ):
+        """The other direction — the non-ASCII operand can arrive from the client."""
+        _configure(monkeypatch, ASCII_PASSWORD)
+
+        response = client.post("/admin/login", json={"password": ACCENTED_PASSWORD})
+
+        assert response.status_code == 401
+
+    def test_the_correct_accented_password_still_authenticates(self, client, monkeypatch):
+        """Encoding both sides must not break the passwords it was meant to support."""
+        _configure(monkeypatch, ACCENTED_PASSWORD)
+
+        response = client.post("/admin/login", json={"password": ACCENTED_PASSWORD})
+
+        assert response.status_code == 200
+        assert response.json()["ok"] is True
+
+    def test_wrong_and_right_are_indistinguishable_apart_from_the_verdict(
+        self, client, monkeypatch
+    ):
+        """The reason a 500 mattered: a differing failure mode is an oracle. Both a wrong
+        ASCII guess and a wrong non-ASCII guess must produce the same 401 shape."""
+        _configure(monkeypatch, ACCENTED_PASSWORD)
+
+        ascii_guess = client.post("/admin/login", json={"password": "wrong"})
+        unicode_guess = client.post("/admin/login", json={"password": "wröng"})
+
+        assert ascii_guess.status_code == unicode_guess.status_code == 401
+        assert ascii_guess.json() == unicode_guess.json()
+
+
+class TestOrdinaryCases:
+    def test_the_correct_ascii_password_authenticates(self, client, monkeypatch):
+        _configure(monkeypatch, ASCII_PASSWORD)
+
+        response = client.post("/admin/login", json={"password": ASCII_PASSWORD})
+
+        assert response.status_code == 200
+
+    def test_an_empty_guess_is_rejected(self, client, monkeypatch):
+        _configure(monkeypatch, ASCII_PASSWORD)
+
+        assert client.post("/admin/login", json={"password": ""}).status_code == 401
+
+    def test_login_is_disabled_when_no_password_is_configured(self, client, monkeypatch):
+        """Fails closed. Notably an empty guess must not match an empty configured
+        password — _admin_enabled() is what prevents compare_digest("", "") succeeding."""
+        _configure(monkeypatch, "")
+
+        assert client.post("/admin/login", json={"password": ""}).status_code == 401
+        assert client.post("/admin/login", json={"password": "anything"}).status_code == 401

--- a/backend/tests/test_classifier.py
+++ b/backend/tests/test_classifier.py
@@ -6,7 +6,7 @@ false-positive guard, recurrence grouping, the manual-override skip that
 protects admin decisions from being overwritten on re-scrape, and series-level
 overrides (including keeping a recurring series as live music).
 
-Run from the backend/ directory:  python -m pytest tests/test_classifier.py
+Run from the backend/ directory:  pytest tests/test_classifier.py
 The classifier is pure stdlib, so no DB or fixtures are needed.
 
 NOT COVERED — known gaps, all requiring a database session:
@@ -31,16 +31,11 @@ session fixture against a throwaway database. The CI workflow already stands up 
 Postgres service container, so that is the natural place to hang it.
 """
 
-import sys
 from dataclasses import dataclass, field
 from datetime import date, timedelta
-from pathlib import Path
 from typing import Optional
 
-# Make `app` importable when running pytest from backend/.
-sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
-
-from app.classifier import (  # noqa: E402
+from app.classifier import (
     classify_one,
     find_recurring_event_ids,
     classify_batch,

--- a/backend/tests/test_classifier.py
+++ b/backend/tests/test_classifier.py
@@ -1,0 +1,312 @@
+"""
+Unit tests for app.classifier — the live-music detection logic.
+
+Covers the three signals (keyword, themed-night phrase, genre), the "night"
+false-positive guard, recurrence grouping, the manual-override skip that
+protects admin decisions from being overwritten on re-scrape, and series-level
+overrides (including keeping a recurring series as live music).
+
+Run from the backend/ directory:  python -m pytest tests/test_classifier.py
+The classifier is pure stdlib, so no DB or fixtures are needed.
+"""
+
+import sys
+from dataclasses import dataclass, field
+from datetime import date, timedelta
+from pathlib import Path
+from typing import Optional
+
+# Make `app` importable when running pytest from backend/.
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from app.classifier import (  # noqa: E402
+    classify_one,
+    find_recurring_event_ids,
+    classify_batch,
+    classification_updates,
+    normalize_series_name,
+    criteria_summary,
+)
+
+
+@dataclass
+class FakeEvent:
+    """Lightweight stand-in for an ORM Event with just the attributes the
+    classifier reads."""
+    id: int
+    venue_id: int
+    name: str
+    date: date
+    genre: Optional[str] = None
+    subgenre: Optional[str] = None
+    is_manual_override: bool = False
+
+
+D0 = date(2026, 8, 1)
+
+
+def _weekly(n: int, start: date = D0) -> list[date]:
+    return [start + timedelta(days=7 * i) for i in range(n)]
+
+
+# --- classify_one: keywords ---
+
+def test_keyword_karaoke_flagged():
+    is_live, reason = classify_one("Tuesday Karaoke")
+    assert is_live is False
+    assert reason == "keyword: karaoke"
+
+
+def test_keyword_trivia_flagged():
+    is_live, reason = classify_one("Pub Trivia")
+    assert is_live is False
+    assert "trivia" in reason
+
+
+def test_keyword_comedy_flagged():
+    is_live, _ = classify_one("Stand-Up Comedy Showcase")
+    assert is_live is False
+
+
+def test_keyword_matches_are_word_bounded():
+    # "class" must not match inside "classic"
+    is_live, reason = classify_one("Classic Rock Tribute")
+    assert is_live is True
+    assert reason is None
+
+
+def test_plain_band_name_is_live():
+    is_live, reason = classify_one("The Mountain Goats")
+    assert is_live is True
+    assert reason is None
+
+
+# --- classify_one: the "night" guard ---
+
+def test_themed_night_flagged():
+    is_live, reason = classify_one("Emo Night")
+    assert is_live is False
+    assert reason == "keyword: emo night"
+
+
+def test_decade_night_flagged():
+    is_live, _ = classify_one("80s Night Dance Party")
+    assert is_live is False
+
+
+def test_bare_night_not_flagged():
+    # Day-of-week / song-title uses of "night" must stay live music.
+    for title in ("Saturday Night Fever Tribute", "Last Night", "A Hard Day's Night",
+                  "One Night Only"):
+        is_live, reason = classify_one(title)
+        assert is_live is True, f"{title!r} was wrongly flagged ({reason})"
+
+
+def test_broad_night_flags_arbitrary_theme_words():
+    # Broadened "<word> night" — any non-excepted word before "night" is flagged.
+    cases = {
+        "Monday Jazz Night!": "jazz night",                      # word before night = jazz
+        "CLUB XCX : CHARLI XCX + HYPERPOP NIGHT": "hyperpop night",
+        "Funk Night": "funk night",
+        "Reggae Nights": "reggae night",                          # plural
+    }
+    for title, expected in cases.items():
+        is_live, reason = classify_one(title)
+        assert is_live is False, f"{title!r} should be flagged"
+        assert reason == f"keyword: {expected}", f"{title!r} -> {reason}"
+
+
+# --- classify_one: "<theme> party" ---
+
+def test_party_themes_flagged():
+    for title, theme in (("Album Listening Party", "listening"),
+                         ("New Release Party", "release"),
+                         ("Block Party", "block")):
+        is_live, reason = classify_one(title)
+        assert is_live is False, f"{title!r} should be flagged"
+        assert reason == f"keyword: {theme} party"
+
+
+def test_band_named_party_not_flagged():
+    # "Bloc Party" (the band) must stay live — bare "party" is never matched.
+    is_live, reason = classify_one("Bloc Party")
+    assert is_live is True
+    assert reason is None
+
+
+# --- classify_one: genre ---
+
+def test_genre_comedy_flagged():
+    is_live, reason = classify_one("An Evening With Someone", genre="Comedy")
+    assert is_live is False
+    assert reason == "genre: comedy"
+
+
+def test_genre_theatre_flagged_via_substring():
+    is_live, _ = classify_one("The Nutcracker", genre="Children's Theatre")
+    assert is_live is False
+
+
+def test_music_genre_stays_live():
+    is_live, reason = classify_one("Some Band", genre="Rock", subgenre="Indie Rock")
+    assert is_live is True
+    assert reason is None
+
+
+def test_dance_electronic_genre_is_live():
+    # "Dance/Electronic" is real live music — must not be caught as non-music.
+    is_live, _ = classify_one("Big DJ Live Set", genre="Dance/Electronic")
+    assert is_live is True
+
+
+# --- recurrence ---
+
+def test_recurring_series_detected():
+    events = [FakeEvent(i, 1, "The Regulars", d) for i, d in enumerate(_weekly(4))]
+    recurring = find_recurring_event_ids(events)
+    assert set(recurring) == {0, 1, 2, 3}
+    assert all(count == 4 for count in recurring.values())
+
+
+def test_below_threshold_not_recurring():
+    events = [FakeEvent(i, 1, "The Regulars", d) for i, d in enumerate(_weekly(2))]
+    assert find_recurring_event_ids(events) == {}
+
+
+def test_recurrence_is_per_venue():
+    # Same name at two venues, twice each -> neither hits the threshold of 3.
+    events = [
+        FakeEvent(1, 1, "House Band", D0),
+        FakeEvent(2, 1, "House Band", D0 + timedelta(days=7)),
+        FakeEvent(3, 2, "House Band", D0),
+        FakeEvent(4, 2, "House Band", D0 + timedelta(days=7)),
+    ]
+    assert find_recurring_event_ids(events) == {}
+
+
+def test_recurrence_groups_dated_name_variants():
+    # Digit-stripping normalization collapses "... 8/1", "... 8/8", "... 8/15".
+    events = [
+        FakeEvent(1, 1, "Open Turntables 8/1", D0),
+        FakeEvent(2, 1, "Open Turntables 8/8", D0 + timedelta(days=7)),
+        FakeEvent(3, 1, "Open Turntables 8/15", D0 + timedelta(days=14)),
+    ]
+    assert set(find_recurring_event_ids(events)) == {1, 2, 3}
+
+
+# --- classify_batch: signal priority ---
+
+def test_recurrence_overrides_a_keyword_miss():
+    # No keyword in the name, but it recurs weekly -> non-live via recurrence.
+    events = [FakeEvent(i, 1, "The Regulars", d) for i, d in enumerate(_weekly(3))]
+    result = classify_batch(events)
+    for eid in (0, 1, 2):
+        is_live, reason = result[eid]
+        assert is_live is False
+        assert reason == "recurring: 3 dates"
+
+
+def test_batch_keeps_one_off_show_live():
+    events = [FakeEvent(1, 1, "Waxahatchee", D0)]
+    is_live, reason = classify_batch(events)[1]
+    assert is_live is True
+    assert reason is None
+
+
+# --- override durability (the pure function behind reclassify_all) ---
+
+def test_manual_override_is_excluded_from_updates():
+    events = [
+        FakeEvent(1, 1, "Karaoke", D0, is_manual_override=True),   # admin forced a value
+        FakeEvent(2, 1, "Trivia", D0, is_manual_override=False),
+    ]
+    updates = classification_updates(events)
+    assert 1 not in updates          # overridden row is left untouched
+    assert updates[2] == (False, "keyword: trivia")
+
+
+# --- series-level overrides ---
+
+def _series_key(venue_id: int, name: str) -> tuple:
+    return (venue_id, normalize_series_name(name))
+
+
+def test_series_override_keeps_recurring_series_live():
+    # A weekly jazz jam that recurrence would flag non-live, but the admin has
+    # marked the whole series as live music.
+    events = [FakeEvent(i, 1, "Wednesday Night Jazz Jam", d)
+              for i, d in enumerate(_weekly(4))]
+    overrides = {_series_key(1, "Wednesday Night Jazz Jam"): (True, "house jazz band")}
+    updates = classification_updates(events, series_overrides=overrides)
+    for eid in range(4):
+        assert updates[eid] == (True, "series override: live music")
+
+
+def test_series_override_can_force_non_live():
+    # A one-off name recurrence wouldn't catch, but the admin wants it hidden.
+    events = [FakeEvent(1, 2, "Vinyl Social", D0)]
+    overrides = {_series_key(2, "Vinyl Social"): (False, "just records, no band")}
+    updates = classification_updates(events, series_overrides=overrides)
+    assert updates[1] == (False, "series override: non-live")
+
+
+def test_series_override_is_venue_scoped():
+    # Same series name at a different venue is unaffected by the override.
+    events = [
+        FakeEvent(1, 1, "Open Turntables", D0),  # overridden venue
+        FakeEvent(2, 2, "Open Turntables", D0),  # different venue
+    ]
+    overrides = {_series_key(1, "Open Turntables"): (True, None)}
+    updates = classification_updates(events, series_overrides=overrides)
+    assert updates[1] == (True, "series override: live music")
+    # Venue 2 falls through to automatic classification (a single date -> live).
+    assert updates[2] == (True, None)
+
+
+def test_per_event_override_beats_series_override():
+    # The specific instance is manually overridden, so it is left untouched even
+    # though a series override also matches it.
+    events = [FakeEvent(1, 1, "Karaoke", D0, is_manual_override=True)]
+    overrides = {_series_key(1, "Karaoke"): (True, None)}
+    updates = classification_updates(events, series_overrides=overrides)
+    assert 1 not in updates  # reclassify leaves the hand-set value in place
+
+
+def test_series_key_matches_dated_name_variants():
+    # The admin keys off one instance; other dated instances of the series match.
+    assert (normalize_series_name("Trivia Night 8/1")
+            == normalize_series_name("Trivia Night 8/8"))
+
+
+# --- always-live venue exemption (e.g. DPAC) ---
+
+def test_exempt_venue_forced_live_over_auto_and_series():
+    # Venue 9 is exempt. Even a recurring, keyword-y name at that venue stays live;
+    # a series override on it is also ignored (venue is out of the filter pass).
+    events = [FakeEvent(i, 9, "Karaoke Night", d) for i, d in enumerate(_weekly(4))]
+    overrides = {_series_key(9, "Karaoke Night"): (False, None)}
+    updates = classification_updates(
+        events, series_overrides=overrides, exempt_venue_ids={9}
+    )
+    for eid in range(4):
+        assert updates[eid] == (True, "venue: always live music")
+
+
+def test_exempt_venue_still_respects_per_event_override():
+    # A hand-set instance at an exempt venue is still left untouched.
+    events = [FakeEvent(1, 9, "Comedy", D0, is_manual_override=True)]
+    updates = classification_updates(events, exempt_venue_ids={9})
+    assert 1 not in updates
+
+
+# --- criteria surface ---
+
+def test_criteria_summary_shape():
+    summary = criteria_summary()
+    assert summary["recurrence_threshold"] == 3
+    assert "karaoke" in summary["keywords"]
+    assert "listening" in summary["party_themes"]
+    assert "allowlist" in summary["party_rule"]  # explains why "party" isn't matched bare
+    assert "saturday" in summary["night_exceptions"]
+    assert "dpac" in summary["always_live_venues"]
+    assert "comedy" in summary["non_music_genres"]

--- a/backend/tests/test_classifier.py
+++ b/backend/tests/test_classifier.py
@@ -26,6 +26,8 @@ from app.classifier import (  # noqa: E402
     classification_updates,
     normalize_series_name,
     criteria_summary,
+    reclassify_floor,
+    RECLASSIFY_PAST_DAYS,
 )
 
 
@@ -310,3 +312,28 @@ def test_criteria_summary_shape():
     assert "saturday" in summary["night_exceptions"]
     assert "dpac" in summary["always_live_venues"]
     assert "comedy" in summary["non_music_genres"]
+
+
+# --- reclassify_floor ---
+
+def test_reclassify_floor_reaches_into_the_past():
+    """The window must extend behind today, not just forward.
+
+    The calendar can be scrolled back into recent dates, and those events carry
+    is_live_music too — if the floor were today, past events would freeze at whatever
+    they were last set to and stop responding to series rules.
+    """
+    today = date(2026, 8, 27)
+    assert reclassify_floor(today) < today
+    assert reclassify_floor(today) == today - timedelta(days=RECLASSIFY_PAST_DAYS)
+
+
+def test_reclassify_floor_window_is_about_a_month():
+    """Guards the constant itself. Widening it changes the blast radius of every
+    series action and of the admin queue, so a change here should be deliberate."""
+    assert RECLASSIFY_PAST_DAYS == 30
+
+
+def test_reclassify_floor_defaults_to_today():
+    """Called with no argument in production code paths, so the default must work."""
+    assert reclassify_floor() == date.today() - timedelta(days=RECLASSIFY_PAST_DAYS)

--- a/backend/tests/test_classifier.py
+++ b/backend/tests/test_classifier.py
@@ -385,16 +385,60 @@ def test_series_key_matches_dated_name_variants():
 
 # --- always-live venue exemption (e.g. DPAC) ---
 
-def test_exempt_venue_forced_live_over_auto_and_series():
-    # Venue 9 is exempt. Even a recurring, keyword-y name at that venue stays live;
-    # a series override on it is also ignored (venue is out of the filter pass).
+def test_exempt_venue_forced_live_over_automatic_classification():
+    # Venue 9 is exempt, so a recurring, keyword-y name there stays live music instead of
+    # being flagged as a series.
+    events = [FakeEvent(i, 9, "Karaoke Night", d) for i, d in enumerate(_weekly(4))]
+    updates = classification_updates(events, exempt_venue_ids={9})
+    for eid in range(4):
+        assert updates[eid] == (True, "venue: always live music")
+
+
+def test_series_override_beats_the_venue_exemption():
+    """Review item #6. This assertion is the reverse of what it was.
+
+    The exemption used to return before series overrides were consulted, which made an
+    exempt venue's series impossible to mark non-live through the series UI — on every
+    future instance, permanently. DPAC is the only exempt venue and it hosts Broadway and
+    comedy alongside music, so that is precisely the case the series UI exists for. The
+    exemption is now a default that a deliberate series decision can override.
+    """
     events = [FakeEvent(i, 9, "Karaoke Night", d) for i, d in enumerate(_weekly(4))]
     overrides = {_series_key(9, "Karaoke Night"): (False, None)}
+
     updates = classification_updates(
         events, series_overrides=overrides, exempt_venue_ids={9}
     )
+
     for eid in range(4):
-        assert updates[eid] == (True, "venue: always live music")
+        assert updates[eid] == (False, "series override: non-live")
+
+
+def test_a_series_override_can_also_keep_an_exempt_venues_series_live():
+    """The override wins in both directions — it is not a special case for hiding."""
+    events = [FakeEvent(i, 9, "Karaoke Night", d) for i, d in enumerate(_weekly(4))]
+    overrides = {_series_key(9, "Karaoke Night"): (True, None)}
+
+    updates = classification_updates(
+        events, series_overrides=overrides, exempt_venue_ids={9}
+    )
+
+    for eid in range(4):
+        assert updates[eid] == (True, "series override: live music")
+
+
+def test_an_unrelated_series_at_an_exempt_venue_still_gets_the_exemption():
+    """Only the overridden series changes; the rest of the venue keeps its default."""
+    events = [FakeEvent(i, 9, "Karaoke Night", d) for i, d in enumerate(_weekly(4))]
+    events += [FakeEvent(100 + i, 9, "Trivia Night", d) for i, d in enumerate(_weekly(4))]
+    overrides = {_series_key(9, "Karaoke Night"): (False, None)}
+
+    updates = classification_updates(
+        events, series_overrides=overrides, exempt_venue_ids={9}
+    )
+
+    assert updates[0] == (False, "series override: non-live")
+    assert updates[100] == (True, "venue: always live music")
 
 
 def test_exempt_venue_still_respects_per_event_override():

--- a/backend/tests/test_classifier.py
+++ b/backend/tests/test_classifier.py
@@ -49,6 +49,8 @@ from app.classifier import (  # noqa: E402
     criteria_summary,
     reclassify_floor,
     RECLASSIFY_PAST_DAYS,
+    RECURRENCE_THRESHOLD,
+    RUN_GAP_DAYS,
 )
 
 
@@ -70,6 +72,11 @@ D0 = date(2026, 8, 1)
 
 def _weekly(n: int, start: date = D0) -> list[date]:
     return [start + timedelta(days=7 * i) for i in range(n)]
+
+
+def _consecutive(n: int, start: date = D0) -> list[date]:
+    """n back-to-back nights — a residency, not a series."""
+    return [start + timedelta(days=i) for i in range(n)]
 
 
 # --- classify_one: keywords ---
@@ -217,6 +224,86 @@ def test_recurrence_groups_dated_name_variants():
     assert set(find_recurring_event_ids(events)) == {1, 2, 3}
 
 
+# --- recurrence: a run is not a series (review item #1) ---
+
+def test_multi_night_residency_is_not_a_series():
+    """A band booked three consecutive nights is the marquee listing, not karaoke."""
+    events = [FakeEvent(i, 1, "Hiss Golden Messenger", d)
+              for i, d in enumerate(_consecutive(3))]
+    assert find_recurring_event_ids(events) == {}
+
+
+def test_long_residency_is_not_a_series():
+    """DPAC-style eight-night Broadway runs must survive even without the exemption."""
+    events = [FakeEvent(i, 1, "Death Becomes Her", d)
+              for i, d in enumerate(_consecutive(8))]
+    assert find_recurring_event_ids(events) == {}
+
+
+def test_a_gap_within_the_run_window_stays_one_occasion():
+    """Fri and Sun with Saturday off is still one booking."""
+    dates = [D0, D0 + timedelta(days=RUN_GAP_DAYS), D0 + timedelta(days=2 * RUN_GAP_DAYS)]
+    events = [FakeEvent(i, 1, "Weekend Stand", d) for i, d in enumerate(dates)]
+    assert find_recurring_event_ids(events) == {}
+
+
+def test_weekly_series_is_still_detected():
+    """The behavior the feature exists for must be unaffected by the run rule."""
+    events = [FakeEvent(i, 1, "Tuesday Karaoke", d)
+              for i, d in enumerate(_weekly(RECURRENCE_THRESHOLD))]
+    assert len(find_recurring_event_ids(events)) == RECURRENCE_THRESHOLD
+
+
+def test_repeating_two_night_run_is_a_series():
+    """Fri+Sat every week is a series — three occasions, six dates."""
+    dates = []
+    for week in range(3):
+        dates.append(D0 + timedelta(days=7 * week))
+        dates.append(D0 + timedelta(days=7 * week + 1))
+    events = [FakeEvent(i, 1, "Emo Weekend", d) for i, d in enumerate(dates)]
+
+    recurring = find_recurring_event_ids(events)
+
+    assert len(recurring) == 6
+    assert all(count == 6 for count in recurring.values()), "count reports dates, not occasions"
+
+
+def test_monthly_series_is_detected():
+    """Sparse cadences are series too — the run rule must not swallow them."""
+    dates = [D0, D0 + timedelta(days=30), D0 + timedelta(days=60)]
+    events = [FakeEvent(i, 1, "First Friday Market", d) for i, d in enumerate(dates)]
+    assert len(find_recurring_event_ids(events)) == 3
+
+
+# --- recurrence: unnamed events are not a series (review item #3) ---
+
+def test_empty_names_do_not_form_a_series():
+    """A scraper emitting nameless records must not hide them as a phantom series."""
+    events = [FakeEvent(i, 1, "", d) for i, d in enumerate(_weekly(4))]
+    assert find_recurring_event_ids(events) == {}
+
+
+def test_digit_only_names_do_not_form_a_series():
+    """These normalize to '' and are unrelated events, not one series."""
+    events = [
+        FakeEvent(1, 1, "2/14", D0),
+        FakeEvent(2, 1, "$5", D0 + timedelta(days=7)),
+        FakeEvent(3, 1, "7/8 - 9", D0 + timedelta(days=14)),
+    ]
+    assert find_recurring_event_ids(events) == {}
+
+
+def test_unnamed_events_do_not_drag_in_named_ones():
+    """The empty-key group must stay separate from a real series at the same venue."""
+    events = [FakeEvent(i, 1, "", d) for i, d in enumerate(_weekly(3))]
+    events += [FakeEvent(10 + i, 1, "Tuesday Karaoke", d)
+               for i, d in enumerate(_weekly(3, start=D0 + timedelta(days=3)))]
+
+    recurring = find_recurring_event_ids(events)
+
+    assert set(recurring) == {10, 11, 12}
+
+
 # --- classify_batch: signal priority ---
 
 def test_recurrence_overrides_a_keyword_miss():
@@ -327,6 +414,8 @@ def test_exempt_venue_still_respects_per_event_override():
 def test_criteria_summary_shape():
     summary = criteria_summary()
     assert summary["recurrence_threshold"] == 3
+    assert summary["run_gap_days"] == RUN_GAP_DAYS
+    assert "occasion" in summary["recurrence_rule"]
     assert "karaoke" in summary["keywords"]
     assert "listening" in summary["party_themes"]
     assert "allowlist" in summary["party_rule"]  # explains why "party" isn't matched bare

--- a/backend/tests/test_classifier.py
+++ b/backend/tests/test_classifier.py
@@ -8,6 +8,27 @@ overrides (including keeping a recurring series as live music).
 
 Run from the backend/ directory:  python -m pytest tests/test_classifier.py
 The classifier is pure stdlib, so no DB or fixtures are needed.
+
+NOT COVERED — known gaps, all requiring a database session:
+
+  * ScrapeManager.reclassify_all() clearing Event.approved_at when a verdict
+    changes. This is the subtlest contract in the feature: the condition checks
+    `is_live_music` specifically, NOT the broader `changed` flag used on the
+    surrounding lines, because a reworded classification_reason is not a
+    different answer. "Simplifying" it to match its neighbours would silently
+    empty the admin review queue on every scrape — no error, just an
+    inexplicably empty page. Verified by hand against real data (22 approvals
+    cleared on a flip, 22 preserved across a no-op reclassify) but nothing here
+    would catch a regression.
+  * The series-scoped approve/unapprove endpoints, which group by
+    normalize_series_name and must match what the dashboard shows collapsed.
+  * The admin list endpoint's honest-count fields — total, approved_hidden and
+    series_size — each of which exists specifically to stop the UI understating
+    what it is showing or what a series action affects.
+
+Closing these needs pytest-asyncio (not currently in requirements-dev.txt) and a
+session fixture against a throwaway database. The CI workflow already stands up a
+Postgres service container, so that is the natural place to hang it.
 """
 
 import sys

--- a/backend/tests/test_cors.py
+++ b/backend/tests/test_cors.py
@@ -1,0 +1,70 @@
+"""
+Tests for the CORS configuration in main.py — review item #11.
+
+The setting that matters is allow_credentials. `allow_origins=["*"]` alongside
+allow_credentials=True let a hostile page read authenticated responses; with credentials
+off, the same "*" is harmless.
+
+Written against measured behavior rather than assumption, because the mechanism is not the
+obvious one. Starlette substitutes the caller's Origin for the "*" whenever the request
+carries a Cookie header, and it does that regardless of allow_credentials — so the origin
+echo is not the vulnerability and removing it is not the fix. What a browser actually
+requires before exposing a credentialed cross-origin response is the
+Access-Control-Allow-Credentials header, and that is what is now absent.
+
+These assertions therefore pin the header that carries the security property, and
+deliberately do not pin the echo, which is Starlette's business and may change.
+"""
+
+from fastapi.testclient import TestClient
+
+import pytest
+
+from app.main import app
+
+
+HOSTILE = "https://evil.example"
+
+
+@pytest.fixture
+def client():
+    return TestClient(app)
+
+
+class TestCredentialsAreNeverAllowed:
+    """The load-bearing assertion. If this fails, a cross-origin page can read
+    authenticated responses and review item #11 has regressed."""
+
+    def test_no_credentials_header_on_a_plain_cross_origin_request(self, client):
+        response = client.get("/openapi.json", headers={"Origin": HOSTILE})
+        assert response.headers.get("access-control-allow-credentials") is None
+
+    def test_no_credentials_header_when_the_request_carries_a_cookie(self, client):
+        """The case that mattered: a hostile page causing the victim's browser to send its
+        session cookie. The response must not be readable by that page."""
+        response = client.get(
+            "/openapi.json",
+            headers={"Origin": HOSTILE, "Cookie": "ts_admin=stolen-or-ambient"},
+        )
+        assert response.headers.get("access-control-allow-credentials") is None
+
+    def test_no_credentials_header_on_a_preflight(self, client):
+        response = client.options(
+            "/api/events",
+            headers={
+                "Origin": HOSTILE,
+                "Access-Control-Request-Method": "POST",
+                "Access-Control-Request-Headers": "content-type",
+            },
+        )
+        assert response.headers.get("access-control-allow-credentials") is None
+
+
+class TestThePublicApiStaysBrowserConsumable:
+    """The other half of the decision: dropping credentials rather than narrowing origins
+    keeps the public read API usable from any page. If someone later swaps to an origin
+    allowlist, these are the tests that should be updated on purpose rather than deleted."""
+
+    def test_a_cross_origin_read_is_permitted(self, client):
+        response = client.get("/openapi.json", headers={"Origin": HOSTILE})
+        assert response.headers.get("access-control-allow-origin") is not None

--- a/backend/tests/test_dedup.py
+++ b/backend/tests/test_dedup.py
@@ -1,0 +1,323 @@
+"""
+Tests for duplicate prevention: title normalization, run-level dedup, and upsert planning.
+
+These cover the two ways the same show used to end up in the database twice — a venue
+editing an event's title, and one scraper reporting a title in two encodings — plus the
+reconcile pass that removes listings a source has dropped.
+
+Every case here is drawn from a real pair found in the production data.
+"""
+
+from dataclasses import dataclass
+from datetime import date, datetime, timedelta
+from typing import Optional
+
+import pytest
+
+from app.scrapers.base import ScrapedEvent, clean_title
+from app.scrapers.manager import (
+    RECONCILE_ALWAYS_ALLOW,
+    dedupe_scraped,
+    plan_upsert,
+)
+
+
+TODAY = date(2026, 9, 1)
+
+
+# --- Test helpers ---
+
+
+@dataclass
+class Row:
+    """Stand-in for an Event row. plan_upsert only reads these attributes."""
+
+    id: int
+    date: date
+    hash: str
+    external_id: Optional[str] = None
+    updated_at: Optional[datetime] = None
+
+
+def scraped(name: str, on: date = TODAY, external_id: Optional[str] = None) -> ScrapedEvent:
+    return ScrapedEvent(
+        name=name,
+        date=on,
+        venue_slug="the-pinhook",
+        source="venuepilot",
+        external_id=external_id,
+    )
+
+
+def row_for(se: ScrapedEvent, id: int, seen: Optional[datetime] = None) -> Row:
+    """A stored row matching a scraped event exactly — the already-up-to-date case."""
+    return Row(
+        id=id,
+        date=se.date,
+        hash=se.hash,
+        external_id=se.external_id,
+        updated_at=seen or datetime(2026, 8, 27),
+    )
+
+
+# --- clean_title ---
+
+
+class TestCleanTitle:
+    def test_decodes_html_entities(self):
+        assert clean_title("JoVia Armstrong &#038; alana amore colvin") == (
+            "JoVia Armstrong & alana amore colvin"
+        )
+
+    def test_decodes_percent_escapes(self):
+        assert clean_title("JoVia Armstrong %26 alana amore colvin") == (
+            "JoVia Armstrong & alana amore colvin"
+        )
+
+    def test_both_encodings_converge(self):
+        """The Shadowbox bug: one event, two pages, two encodings, two database rows."""
+        entity = clean_title("Ben Copperhead &#038; David Menestres")
+        percent = clean_title("Ben Copperhead %26 David Menestres")
+        assert entity == percent
+
+    def test_decodes_double_escaped_entities(self):
+        assert clean_title("Cool Boy&amp;#039;s Tapes") == "Cool Boy's Tapes"
+
+    def test_decodes_multibyte_percent_escapes(self):
+        """Decoding the whole string, not each escape, is what makes this come out right."""
+        assert clean_title("Cool Boy%E2%80%99s Tapes") == "Cool Boy’s Tapes"
+
+    def test_collapses_whitespace(self):
+        assert clean_title("Alex Cameron /  Josh De Costa") == "Alex Cameron / Josh De Costa"
+
+    def test_leaves_a_bare_percent_alone(self):
+        assert clean_title("Get 50% Off Before Doors") == "Get 50% Off Before Doors"
+
+    def test_passes_through_empty_values(self):
+        assert clean_title(None) is None
+        assert clean_title("") == ""
+
+    def test_applied_on_construction(self):
+        assert scraped("A &#038; B").name == "A & B"
+
+    def test_encodings_hash_identically(self):
+        assert scraped("A &#038; B").hash == scraped("A %26 B").hash
+
+
+# --- dedupe_scraped ---
+
+
+class TestDedupeScraped:
+    def test_collapses_repeated_hash(self):
+        events = [scraped("Acopia"), scraped("Acopia")]
+        assert len(dedupe_scraped(events)) == 1
+
+    def test_collapses_repeated_external_id_on_one_date(self):
+        """Two sections of one page describing the same show with different titles."""
+        events = [scraped("Acopia", external_id="188044"),
+                  scraped("Acopia / Lilly Flower", external_id="188044")]
+        assert [e.name for e in dedupe_scraped(events)] == ["Acopia"]
+
+    def test_keeps_same_external_id_on_different_dates(self):
+        """A recurring series reuses its ID; each night is still its own event."""
+        events = [scraped("Open Mic", TODAY, external_id="900"),
+                  scraped("Open Mic", TODAY + timedelta(days=7), external_id="900")]
+        assert len(dedupe_scraped(events)) == 2
+
+    def test_keeps_distinct_events(self):
+        events = [scraped("Acopia"), scraped("Anna Graves")]
+        assert len(dedupe_scraped(events)) == 2
+
+
+# --- plan_upsert: matching ---
+
+
+class TestMatching:
+    def test_unchanged_event_is_updated_not_reinserted(self):
+        se = scraped("Acopia", external_id="188044")
+        plan = plan_upsert([row_for(se, id=1)], [se], TODAY)
+        assert plan.inserts == []
+        assert [(s.name, r.id) for s, r in plan.updates] == [("Acopia", 1)]
+
+    def test_new_event_is_inserted(self):
+        plan = plan_upsert([], [scraped("Acopia", external_id="188044")], TODAY)
+        assert [se.name for se in plan.inserts] == ["Acopia"]
+        assert plan.updates == []
+
+    def test_support_act_added_to_title_updates_in_place(self):
+        """The Pinhook's most common case, and the one hash-only matching got wrong."""
+        stored = row_for(scraped("Acopia", external_id="188044"), id=1)
+        se = scraped("Acopia / Lilly Flower", external_id="188044")
+
+        plan = plan_upsert([stored], [se], TODAY)
+
+        assert plan.inserts == [], "a retitled event is the same event"
+        assert [r.id for _, r in plan.updates] == [1]
+        assert plan.expired == []
+
+    def test_full_rename_updates_in_place(self):
+        """Stanczyks: 'Duke Music Collective' became 'Private Event' under one ID."""
+        stored = row_for(scraped("Duke Music Collective", external_id="192587"), id=1)
+        se = scraped("Private Event", external_id="192587")
+
+        plan = plan_upsert([stored], [se], TODAY)
+
+        assert [r.id for _, r in plan.updates] == [1]
+        assert plan.inserts == []
+
+    def test_matches_on_hash_when_no_external_id(self):
+        """Scrapers like webflow_cms and mec expose no venue-side ID."""
+        se = scraped("Electro Lust w/ Domocile")
+        stored = Row(id=1, date=se.date, hash=se.hash, updated_at=datetime(2026, 8, 27))
+
+        plan = plan_upsert([stored], [se], TODAY)
+
+        assert [r.id for _, r in plan.updates] == [1]
+
+    def test_same_external_id_different_date_does_not_match(self):
+        """Merging a recurring series onto one row would delete every other night."""
+        stored = row_for(scraped("Open Mic", TODAY, external_id="900"), id=1)
+        se = scraped("Open Mic", TODAY + timedelta(days=7), external_id="900")
+
+        plan = plan_upsert([stored], [se], TODAY)
+
+        assert [s.date for s in plan.inserts] == [TODAY + timedelta(days=7)]
+        assert plan.updates == []
+
+    def test_different_external_ids_stay_separate(self):
+        """Rubies lists two shows one night under two IDs; they are not duplicates."""
+        first = row_for(scraped("Adulting - Shallow Cuts", external_id="161232"), id=1)
+        second = row_for(scraped("Shallow Cuts", external_id="160887"), id=2)
+        events = [scraped("Adulting - Shallow Cuts", external_id="161232"),
+                  scraped("Shallow Cuts", external_id="160887")]
+
+        plan = plan_upsert([first, second], events, TODAY)
+
+        assert len(plan.updates) == 2
+        assert plan.superseded == []
+        assert plan.expired == []
+
+    def test_one_row_is_not_claimed_by_two_scraped_events(self):
+        stored = row_for(scraped("Acopia", external_id="188044"), id=1)
+        events = [scraped("Acopia", external_id="188044"),
+                  scraped("Acopia", external_id="999")]
+
+        plan = plan_upsert([stored], events, TODAY)
+
+        assert len(plan.updates) == 1
+        assert len(plan.inserts) == 1
+
+
+# --- plan_upsert: merging existing duplicates ---
+
+
+class TestMerging:
+    def test_existing_duplicate_pair_is_merged(self):
+        """Self-healing: the pairs already in the database collapse on the next scrape."""
+        old = row_for(scraped("Acopia", external_id="188044"), id=1,
+                      seen=datetime(2026, 8, 18))
+        new = row_for(scraped("Acopia / Lilly Flower", external_id="188044"), id=2,
+                      seen=datetime(2026, 8, 27))
+        se = scraped("Acopia / Lilly Flower", external_id="188044")
+
+        plan = plan_upsert([old, new], [se], TODAY)
+
+        assert [r.id for _, r in plan.updates] == [2], "keep the row the source still matches"
+        assert [r.id for r in plan.superseded] == [1]
+        assert plan.expired == [], "a merged row is not also an orphan"
+
+    def test_survivor_is_chosen_by_title_not_recency(self):
+        """A stale row touched more recently must not win over the one that matches."""
+        matching = row_for(scraped("Acopia / Lilly Flower", external_id="188044"), id=1,
+                           seen=datetime(2026, 8, 18))
+        other = row_for(scraped("Acopia", external_id="188044"), id=2,
+                        seen=datetime(2026, 8, 27))
+        se = scraped("Acopia / Lilly Flower", external_id="188044")
+
+        plan = plan_upsert([matching, other], [se], TODAY)
+
+        assert [r.id for _, r in plan.updates] == [1]
+        assert [r.id for r in plan.superseded] == [2]
+
+    def test_survivor_is_stable_regardless_of_row_order(self):
+        old = row_for(scraped("Acopia", external_id="188044"), id=1,
+                      seen=datetime(2026, 8, 18))
+        new = row_for(scraped("Acopia / Lilly Flower", external_id="188044"), id=2,
+                      seen=datetime(2026, 8, 27))
+        se = scraped("Acopia / Lilly Flower", external_id="188044")
+
+        forward = plan_upsert([old, new], [se], TODAY)
+        reverse = plan_upsert([new, old], [se], TODAY)
+
+        assert [r.id for _, r in forward.updates] == [r.id for _, r in reverse.updates]
+        assert [r.id for r in forward.superseded] == [r.id for r in reverse.superseded]
+
+
+# --- plan_upsert: reconcile ---
+
+
+class TestReconcile:
+    def test_dropped_listing_expires(self):
+        """Lincoln Theatre's cancelled shows sat on the calendar because nothing removed them."""
+        gone = row_for(scraped("Crucial Fiya", external_id="500"), id=1)
+        kept = scraped("Anna Graves", TODAY, external_id="187015")
+
+        plan = plan_upsert([gone, row_for(kept, id=2)], [kept], TODAY)
+
+        assert [r.id for r in plan.expired] == [1]
+        assert plan.reconcile_skipped is False
+
+    def test_past_events_are_never_expired(self):
+        """Venues drop past shows from their listings; the archive must survive that."""
+        archived = Row(id=1, date=TODAY - timedelta(days=30), hash="old", updated_at=None)
+        se = scraped("Anna Graves", TODAY, external_id="187015")
+
+        plan = plan_upsert([archived, row_for(se, id=2)], [se], TODAY)
+
+        assert plan.expired == []
+
+    def test_events_beyond_the_scraped_horizon_are_never_expired(self):
+        """A scraper covering three months says nothing about a show ten months out."""
+        far_future = Row(id=1, date=TODAY + timedelta(days=300), hash="far", updated_at=None)
+        se = scraped("Anna Graves", TODAY + timedelta(days=7), external_id="187015")
+
+        plan = plan_upsert([far_future, row_for(se, id=2)], [se], TODAY)
+
+        assert plan.expired == []
+
+    def test_small_orphan_counts_always_expire(self):
+        """A couple of cancellations is normal churn, even against a short calendar."""
+        se = scraped("Anna Graves", TODAY + timedelta(days=10), external_id="187015")
+        orphans = [
+            Row(id=i, date=TODAY + timedelta(days=i), hash=f"h{i}", updated_at=None)
+            for i in range(1, RECONCILE_ALWAYS_ALLOW + 1)
+        ]
+
+        plan = plan_upsert(orphans + [row_for(se, id=99)], [se], TODAY)
+
+        assert len(plan.expired) == RECONCILE_ALWAYS_ALLOW
+        assert plan.reconcile_skipped is False
+
+    def test_a_half_broken_scraper_deletes_nothing(self):
+        """One event returned against a full calendar means the scraper broke."""
+        se = scraped("Anna Graves", TODAY + timedelta(days=30), external_id="187015")
+        orphans = [
+            Row(id=i, date=TODAY + timedelta(days=i), hash=f"h{i}", updated_at=None)
+            for i in range(1, 21)
+        ]
+
+        plan = plan_upsert(orphans + [row_for(se, id=99)], [se], TODAY)
+
+        assert plan.expired == []
+        assert plan.reconcile_skipped is True
+
+    def test_an_empty_run_changes_nothing(self):
+        """A scraper returning nothing must never be read as 'the venue has no shows'."""
+        stored = [Row(id=i, date=TODAY + timedelta(days=i), hash=f"h{i}") for i in range(1, 6)]
+
+        plan = plan_upsert(stored, [], TODAY)
+
+        assert plan.expired == []
+        assert plan.superseded == []
+        assert plan.inserts == []
+        assert plan.updates == []

--- a/backend/tests/test_events_api.py
+++ b/backend/tests/test_events_api.py
@@ -1,0 +1,172 @@
+"""
+Tests for two review items in app.api.events — #4 (dedup ranking) and #5 (list filtering).
+
+#4 is a pure function, so it is tested directly. #5 builds a SQL WHERE clause and would
+need a database to exercise end to end; what is asserted here is the parameter contract,
+with the gap stated plainly rather than papered over. See the note on TestListFiltering.
+"""
+
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Optional
+
+from fastapi.testclient import TestClient
+
+import pytest
+
+from app.api.events import _completeness, _list_conditions
+from app.main import app
+
+
+@dataclass
+class Row:
+    """Stand-in for an ORM Event with only the attributes _completeness reads."""
+
+    id: int
+    is_live_music: bool = True
+    is_manual_override: bool = False
+    image_url: Optional[str] = None
+    ticket_url: Optional[str] = None
+    price_min: Optional[float] = None
+    updated_at: Optional[datetime] = None
+
+
+def _winner(a: Row, b: Row) -> Row:
+    """Whichever row the display-time dedup would keep, order-independently."""
+    forward = a if _completeness(a) > _completeness(b) else b
+    backward = b if _completeness(b) > _completeness(a) else a
+    assert forward is backward, "ranking depends on comparison order — not a total order"
+    return forward
+
+
+# --- #4: dedup must not discard the visible copy ---
+
+class TestDedupRanking:
+    def test_a_live_row_beats_a_non_live_row_with_richer_metadata(self):
+        """The regression. Ranking on field counts alone let the richer row win, and if
+        that row was classified non-live the show vanished from the default calendar."""
+        live_but_sparse = Row(id=1, is_live_music=True)
+        non_live_but_rich = Row(
+            id=2, is_live_music=False, image_url="x", ticket_url="y", price_min=10.0
+        )
+
+        assert _winner(live_but_sparse, non_live_but_rich).id == 1
+
+    def test_an_admin_override_beats_an_automatic_live_verdict(self):
+        """An admin looked at this row and decided; that outranks anything computed —
+        including a computed verdict that happens to be more permissive."""
+        hand_set_hidden = Row(id=1, is_live_music=False, is_manual_override=True)
+        auto_live = Row(id=2, is_live_music=True, image_url="x", ticket_url="y")
+
+        assert _winner(hand_set_hidden, auto_live).id == 1
+
+    def test_metadata_still_decides_between_two_equal_verdicts(self):
+        """The original behavior survives as a tiebreaker rather than being replaced."""
+        sparse = Row(id=1, is_live_music=True)
+        rich = Row(id=2, is_live_music=True, image_url="x", ticket_url="y", price_min=5.0)
+
+        assert _winner(sparse, rich).id == 2
+
+    def test_recency_breaks_a_tie_on_metadata(self):
+        older = Row(id=1, image_url="x", updated_at=datetime(2026, 1, 1))
+        newer = Row(id=2, image_url="y", updated_at=datetime(2026, 6, 1))
+
+        assert _winner(older, newer).id == 2
+
+    def test_id_breaks_a_total_tie(self):
+        """Without a final total key the winner would depend on row order from the
+        database, which is how the earlier version picked a surviving venue at random."""
+        assert _winner(Row(id=1), Row(id=2)).id == 2
+
+    def test_a_missing_updated_at_does_not_raise(self):
+        """Rows inserted but never re-scraped have updated_at unset."""
+        assert _winner(Row(id=1, updated_at=None), Row(id=2, updated_at=None)).id == 2
+
+    def test_is_manual_override_absent_is_treated_as_false(self):
+        """_completeness reads it with getattr, so a stand-in or a partially loaded row
+        lacking the attribute must rank as not-overridden rather than blow up."""
+
+        class NoOverrideAttr:
+            id = 1
+            is_live_music = True
+            image_url = ticket_url = None
+            price_min = None
+            updated_at = None
+
+        assert _completeness(NoOverrideAttr())[0] is False
+
+
+# --- #5: the list endpoint gains the opt-in the other consumers already have ---
+
+class TestListConditions:
+    """The clauses themselves, via _list_conditions.
+
+    An earlier version of this file only checked the OpenAPI parameter contract below.
+    Mutation-testing showed that was not enough: deleting the line that appends the
+    live-music clause left every assertion passing, because a declared-but-unused query
+    parameter still appears in the schema. That is exactly the bug worth catching, so the
+    clause building was split out of the endpoint to make it reachable without Postgres.
+    """
+
+    @staticmethod
+    def _sql(conditions) -> str:
+        return " ".join(str(c) for c in conditions)
+
+    def test_live_music_is_filtered_by_default(self):
+        assert "is_live_music" in self._sql(_list_conditions())
+
+    def test_opting_in_removes_the_filter(self):
+        assert "is_live_music" not in self._sql(_list_conditions(include_non_music=True))
+
+    def test_the_filter_is_added_alongside_other_filters(self):
+        """Regression shape: an early return or an if/elif could drop it whenever another
+        filter was supplied."""
+        sql = self._sql(_list_conditions(search="band", genre="rock", status="onsale"))
+        assert "is_live_music" in sql
+
+    def test_other_filters_are_unaffected_by_the_opt_in(self):
+        """Opting in drops only the live-music clause, not the caller's own filters."""
+        opted_in = self._sql(_list_conditions(search="band", include_non_music=True))
+        assert "events.name" in opted_in and "events.artist" in opted_in
+        assert "is_live_music" not in opted_in
+
+    def test_a_malformed_date_is_ignored_rather_than_raising(self):
+        """Pre-existing behavior, preserved through the extraction."""
+        conditions = _list_conditions(start="not-a-date", include_non_music=True)
+        assert conditions == []
+
+
+class TestListFiltering:
+    """The parameter contract, as it appears to callers."""
+
+    @pytest.fixture
+    def schema(self):
+        return TestClient(app).get("/openapi.json").json()
+
+    def _params(self, schema, path):
+        return {p["name"]: p for p in schema["paths"][path]["get"]["parameters"]}
+
+    def test_the_list_endpoint_offers_the_opt_in(self, schema):
+        assert "include_non_music" in self._params(schema, "/api/events")
+
+    def test_it_defaults_to_live_music_only(self, schema):
+        """Default off is the point: before this, the list endpoint was the one consumer
+        that served the events the feature exists to hide."""
+        param = self._params(schema, "/api/events")["include_non_music"]
+        assert param["schema"]["default"] is False
+
+    def test_it_matches_the_ical_feed_by_name_and_default(self, schema):
+        """Review item #5 is about consistency across consumers, so the two endpoints
+        agreeing is the property worth pinning — a rename of one would break this."""
+        events = self._params(schema, "/api/events")["include_non_music"]
+        feed = self._params(schema, "/feeds/events.ics")["include_non_music"]
+
+        assert events["schema"]["default"] == feed["schema"]["default"] is False
+
+    def test_the_fullcalendar_endpoint_deliberately_has_no_such_parameter(self, schema):
+        """Left returning everything on purpose: filters.js toggles visibility in the
+        browser without refetching, so filtering server-side would empty the calendar the
+        moment someone switched the toggle on. Asserted so the omission reads as a decision
+        rather than as an oversight."""
+        params = self._params(schema, "/api/events/fullcalendar")
+        assert "include_non_music" not in params

--- a/backend/tests/test_html_text.py
+++ b/backend/tests/test_html_text.py
@@ -1,0 +1,158 @@
+"""
+Tests for clean_html_text, the shared HTML-to-readable-text helper (#13).
+
+Two real bugs motivated this: Shadowbox (MEC) stored a description that was HTML
+markup put through an extra HTML-entity pass, so the literal text '&lt;p&gt;...' was
+what ended up on the page. Boom Club (Squarespace) had its real excerpt content
+silently discarded because the extraction only knew how to read Squarespace's
+Post-Body wrapper, which excerpt content is never wrapped in.
+
+Fixtures below are trimmed from real feeds where noted.
+"""
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from app.scrapers.html_text import clean_html_text  # noqa: E402
+
+
+# --- The core regressions ---
+
+class TestDoubleEncodedHtml:
+    """Shadowbox / MEC: the JSON-LD description field itself has been HTML-escaped."""
+
+    RAW = (
+        "&lt;p&gt;&lt;strong&gt;Presenting the final volume of Summer Nights hip hop "
+        "showcase!&lt;/strong&gt;&lt;/p&gt; &lt;p&gt;Co-presented by "
+        "&lt;strong&gt;&lt;a href=&quot;https://www.superempty.com&quot; "
+        "target=&quot;_blank&quot;&gt;Super Empty&lt;/a&gt;&lt;/strong&gt;.&lt;/p&gt;"
+    )
+
+    def test_no_escape_sequences_survive(self):
+        out = clean_html_text(self.RAW)
+        assert "&lt;" not in out and "&gt;" not in out and "&quot;" not in out
+
+    def test_no_tags_survive(self):
+        out = clean_html_text(self.RAW)
+        assert "<p>" not in out and "<strong>" not in out and "<a " not in out
+
+    def test_the_readable_text_survives(self):
+        out = clean_html_text(self.RAW)
+        assert "Presenting the final volume of Summer Nights hip hop showcase!" in out
+        assert "Co-presented by Super Empty." in out
+
+    def test_paragraphs_are_separated(self):
+        out = clean_html_text(self.RAW)
+        assert "\n\n" in out
+
+
+class TestExcerptContentIsNotDiscarded:
+    """Boom Club: excerpt is real content with no Post-Body wrapper around it."""
+
+    # Trimmed from the live boom-club.org feed.
+    EXCERPT = (
+        '<p style="white-space:pre-wrap;" data-rte-preserve-empty="true">'
+        "Modular virtuoso (and great friend of BOOM) Matthew Cha presents "
+        "<em>Technojazz,</em> a live, semi-improvised suite.</p>"
+    )
+
+    def test_content_with_no_wrapping_div_is_still_read(self):
+        """The regression: this used to return None with no wrapper to find."""
+        out = clean_html_text(self.EXCERPT)
+        assert out is not None
+        assert "Modular virtuoso" in out
+        assert "Technojazz" in out
+
+
+# --- Title-repeat handling ---
+
+class TestDropFirstParagraph:
+    def test_matching_first_paragraph_is_dropped(self):
+        html = "<p>The Regulars</p><p>Doors at 8pm.</p>"
+        out = clean_html_text(html, drop_first_paragraph_if="The Regulars")
+        assert "The Regulars" not in out
+        assert out == "Doors at 8pm."
+
+    def test_match_is_case_insensitive(self):
+        html = "<p>THE REGULARS</p><p>Doors at 8pm.</p>"
+        out = clean_html_text(html, drop_first_paragraph_if="the regulars")
+        assert out == "Doors at 8pm."
+
+    def test_non_matching_first_paragraph_is_kept(self):
+        """Real content that isn't a title repeat must never be discarded."""
+        html = "<p>Doors at 8pm.</p><p>$12 advance</p>"
+        out = clean_html_text(html, drop_first_paragraph_if="The Regulars")
+        assert "Doors at 8pm." in out
+
+    def test_unset_never_drops_anything(self):
+        """Excerpt content is never checked against the title — see squarespace.py."""
+        html = "<p>The Regulars</p><p>Doors at 8pm.</p>"
+        out = clean_html_text(html)
+        assert "The Regulars" in out
+
+    def test_a_solo_matching_paragraph_leaves_nothing(self):
+        out = clean_html_text("<p>The Regulars</p>", drop_first_paragraph_if="The Regulars")
+        assert out is None
+
+
+# --- Structural handling ---
+
+class TestStructure:
+    def test_br_becomes_a_newline(self):
+        out = clean_html_text("<p>Line one<br>Line two</p>")
+        assert out == "Line one\nLine two"
+
+    def test_no_p_tags_falls_back_to_the_whole_fragment(self):
+        """Not every source wraps content in <p> — plain text must not vanish."""
+        assert clean_html_text("Plain text, no markup at all.") == "Plain text, no markup at all."
+
+    def test_inline_tags_do_not_fragment_a_paragraph(self):
+        """<strong>/<a> must not each become their own paragraph."""
+        out = clean_html_text("<p>Come see <strong>the band</strong> tonight.</p>")
+        assert out == "Come see the band tonight."
+
+    def test_nbsp_is_treated_as_whitespace(self):
+        out = clean_html_text("<p>Doors at 8pm.</p>")
+        assert out == "Doors at 8pm."
+
+    def test_empty_paragraphs_are_dropped(self):
+        out = clean_html_text("<p></p><p>Real content.</p><p>   </p>")
+        assert out == "Real content."
+
+
+# --- Truncation ---
+
+class TestLimit:
+    def test_truncates_the_cleaned_text_not_the_markup(self):
+        """Truncating raw HTML first could cut mid-tag; this must cut the clean text."""
+        html = "<p>" + ("x" * 600) + "</p>"
+        out = clean_html_text(html, limit=500)
+        assert len(out) == 500
+        assert "<" not in out
+
+    def test_short_text_is_not_padded_or_altered(self):
+        assert clean_html_text("<p>Short.</p>", limit=500) == "Short."
+
+
+# --- Empty / missing input ---
+
+class TestEmptyInput:
+    def test_none_returns_none(self):
+        assert clean_html_text(None) is None
+
+    def test_empty_string_returns_none(self):
+        assert clean_html_text("") is None
+
+    def test_whitespace_only_html_returns_none(self):
+        assert clean_html_text("<p>   </p>") is None
+
+    def test_layout_scaffolding_with_no_text_returns_none(self):
+        """Boom Club's genuinely empty events (#35) — layout markup, zero text."""
+        html = (
+            '<div class="sqs-layout sqs-grid-12 columns-12 empty" '
+            'data-layout-label="Post Body"><div class="row sqs-row">'
+            '<div class="col sqs-col-12 span-12"></div></div></div>'
+        )
+        assert clean_html_text(html) is None

--- a/backend/tests/test_html_text.py
+++ b/backend/tests/test_html_text.py
@@ -10,12 +10,7 @@ Post-Body wrapper, which excerpt content is never wrapped in.
 Fixtures below are trimmed from real feeds where noted.
 """
 
-import sys
-from pathlib import Path
-
-sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
-
-from app.scrapers.html_text import clean_html_text  # noqa: E402
+from app.scrapers.html_text import clean_html_text
 
 
 # --- The core regressions ---

--- a/backend/tests/test_mec.py
+++ b/backend/tests/test_mec.py
@@ -1,0 +1,84 @@
+"""
+Tests for the MEC scraper's description handling (#13).
+
+Regression: MEC's JSON-LD `description` field stores markup that has itself been
+through an HTML-entity pass — the literal text '&lt;p&gt;&lt;strong&gt;...' rather
+than an actual '<p>' tag. Reading it with a plain `data.get("description")` put that
+literal escape text on the page, e.g. "&lt;p&gt;&lt;strong&gt;Presenting the final
+volume...". Confirmed against real Shadowbox Studio data.
+
+The fixture below is trimmed from a real Shadowbox event.
+"""
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from app.scrapers.mec import MECScraper  # noqa: E402
+
+
+# Trimmed from a real Shadowbox Studio JSON-LD Event block.
+DOUBLE_ENCODED_DESCRIPTION = (
+    "&lt;p&gt;&lt;strong&gt;Presenting the final volume of Summer Nights hip hop "
+    "showcase!&lt;/strong&gt;&lt;/p&gt; &lt;p&gt;Co-presented by "
+    "&lt;strong&gt;&lt;a href=&quot;https://www.superempty.com&quot; "
+    "target=&quot;_blank&quot;&gt;Super Empty&lt;/a&gt;&lt;/strong&gt;.&lt;/p&gt;"
+)
+
+
+def _scraper() -> MECScraper:
+    return MECScraper("shadowbox-studio", {"url": "https://example.org/events/"})
+
+
+def _jsonld(**overrides) -> dict:
+    data = {
+        "@type": "Event",
+        "name": "Summer Nights, Vol. 3",
+        "startDate": "2026-09-10T20:00:00",
+        "description": DOUBLE_ENCODED_DESCRIPTION,
+    }
+    data.update(overrides)
+    return data
+
+
+class TestDescriptionIsReadable:
+    def test_no_escape_sequences_reach_the_event(self):
+        """The regression: this used to be the literal text '&lt;p&gt;...'."""
+        parsed = _scraper()._parse_jsonld_event(_jsonld())
+
+        assert parsed is not None
+        assert "&lt;" not in parsed.description
+        assert "&gt;" not in parsed.description
+
+    def test_no_tags_reach_the_event(self):
+        parsed = _scraper()._parse_jsonld_event(_jsonld())
+        assert "<p>" not in parsed.description
+        assert "<strong>" not in parsed.description
+
+    def test_the_readable_text_is_present(self):
+        parsed = _scraper()._parse_jsonld_event(_jsonld())
+        assert "Presenting the final volume of Summer Nights hip hop showcase!" in (
+            parsed.description
+        )
+        assert "Co-presented by Super Empty." in parsed.description
+
+    def test_missing_description_is_none_not_empty_string(self):
+        data = _jsonld()
+        del data["description"]
+        parsed = _scraper()._parse_jsonld_event(data)
+        assert parsed.description is None
+
+    def test_a_long_description_is_truncated_after_cleaning(self):
+        """Truncating the raw markup first could cut mid-tag; must cut clean text."""
+        html = "&lt;p&gt;" + ("x" * 600) + "&lt;/p&gt;"
+        parsed = _scraper()._parse_jsonld_event(_jsonld(description=html))
+        assert len(parsed.description) == 500
+        assert "&lt;" not in parsed.description
+
+    def test_required_fields_are_unaffected(self):
+        """Description cleaning must not disturb the rest of the parse."""
+        parsed = _scraper()._parse_jsonld_event(_jsonld())
+        assert parsed.name == "Summer Nights, Vol. 3"
+        assert parsed.venue_slug == "shadowbox-studio"
+        assert parsed.source == "mec"

--- a/backend/tests/test_mec.py
+++ b/backend/tests/test_mec.py
@@ -10,12 +10,7 @@ volume...". Confirmed against real Shadowbox Studio data.
 The fixture below is trimmed from a real Shadowbox event.
 """
 
-import sys
-from pathlib import Path
-
-sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
-
-from app.scrapers.mec import MECScraper  # noqa: E402
+from app.scrapers.mec import MECScraper
 
 
 # Trimmed from a real Shadowbox Studio JSON-LD Event block.

--- a/backend/tests/test_migrations.py
+++ b/backend/tests/test_migrations.py
@@ -1,0 +1,151 @@
+"""
+Integration cover for the concurrent-migration race (review item #7).
+
+Migrations run from the FastAPI lifespan handler rather than as a deploy step, so two
+Cloud Run containers booting together both call `upgrade head` against the same
+database. Before the advisory lock in alembic/env.py, the loser of that race failed on
+an object the winner had just created and never became healthy.
+
+These tests need a real database — they create and drop a scratch one — and skip
+cleanly when there isn't a reachable server, so a local `pytest` without Postgres
+still passes. CI stands up a Postgres service container, so they do run there.
+
+Note this is a race, so the concurrent test is not guaranteed to fail if the lock is
+removed — it failed on every one of several attempts, but timing decides. What it does
+guarantee is the other direction: that the lock never makes concurrent upgrades fail.
+"""
+
+import os
+import subprocess
+import sys
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+from urllib.parse import urlsplit, urlunsplit
+
+import pytest
+
+BACKEND = Path(__file__).resolve().parent.parent
+SCRATCH_DB = "alembic_race_test"
+RUNNERS = 3
+
+
+# --- Helpers ---
+
+def _sync_url(url: str) -> str:
+    """Convert to a sync driver URL for psycopg2's own use here.
+
+    DATABASE_URL itself must keep the `+asyncpg` form when handed to a subprocess:
+    alembic/env.py imports app.database, which builds an async engine from it and
+    rejects a sync driver. env.py does its own conversion for alembic internally.
+    """
+    return url.replace("postgresql+asyncpg://", "postgresql://").replace(
+        "ssl=require", "sslmode=require"
+    )
+
+
+def _with_database(url: str, dbname: str) -> str:
+    return urlunsplit(urlsplit(url)._replace(path=f"/{dbname}"))
+
+
+def _alembic(url: str, *args: str) -> subprocess.CompletedProcess:
+    """Run the alembic CLI the way the app and CI do, against `url`."""
+    return subprocess.run(
+        [sys.executable, "-m", "alembic", *args],
+        cwd=BACKEND,
+        env={**os.environ, "DATABASE_URL": url},
+        capture_output=True,
+        text=True,
+        timeout=180,
+    )
+
+
+@pytest.fixture
+def scratch_db():
+    """Yield a URL for an empty throwaway database, dropped afterwards."""
+    url = os.getenv("DATABASE_URL")
+    if not url:
+        pytest.skip("DATABASE_URL is not set")
+
+    try:
+        import psycopg2
+    except ImportError:
+        pytest.skip("psycopg2 is not installed")
+
+    admin_url = _with_database(_sync_url(url), "postgres")
+    try:
+        conn = psycopg2.connect(admin_url, connect_timeout=5)
+    except Exception as exc:  # no server, wrong credentials, not listening
+        pytest.skip(f"no reachable database: {exc}")
+
+    conn.autocommit = True  # CREATE/DROP DATABASE cannot run inside a transaction
+    try:
+        with conn.cursor() as cur:
+            cur.execute(f"DROP DATABASE IF EXISTS {SCRATCH_DB} WITH (FORCE)")
+            cur.execute(f"CREATE DATABASE {SCRATCH_DB}")
+        # Async form on purpose — this is passed through as DATABASE_URL.
+        yield _with_database(url, SCRATCH_DB)
+    finally:
+        with conn.cursor() as cur:
+            # FORCE so a leaked connection from a failed run cannot block cleanup.
+            cur.execute(f"DROP DATABASE IF EXISTS {SCRATCH_DB} WITH (FORCE)")
+        conn.close()
+
+
+def _describe(results) -> str:
+    return "\n\n".join(
+        f"--- runner {i} (exit {r.returncode}) ---\n{r.stdout}\n{r.stderr}"
+        for i, r in enumerate(results)
+    )
+
+
+# --- Tests ---
+
+def test_concurrent_upgrades_all_succeed(scratch_db):
+    """The regression: without the lock, one runner dies on the winner's objects."""
+    with ThreadPoolExecutor(max_workers=RUNNERS) as pool:
+        results = [f.result() for f in
+                   [pool.submit(_alembic, scratch_db, "upgrade", "head")
+                    for _ in range(RUNNERS)]]
+
+    failed = [i for i, r in enumerate(results) if r.returncode != 0]
+    assert not failed, f"runners {failed} failed:\n{_describe(results)}"
+
+
+def test_concurrent_upgrades_leave_the_schema_at_head(scratch_db):
+    """Serializing must still apply the migrations, not just avoid the crash."""
+    with ThreadPoolExecutor(max_workers=RUNNERS) as pool:
+        [f.result() for f in
+         [pool.submit(_alembic, scratch_db, "upgrade", "head") for _ in range(RUNNERS)]]
+
+    current = _alembic(scratch_db, "current")
+    assert current.returncode == 0, current.stderr
+    assert "(head)" in current.stdout, f"not at head:\n{current.stdout}\n{current.stderr}"
+
+
+def test_upgrade_is_idempotent(scratch_db):
+    """A container booting against an already-migrated database must no-op, not fail."""
+    first = _alembic(scratch_db, "upgrade", "head")
+    assert first.returncode == 0, first.stderr
+
+    second = _alembic(scratch_db, "upgrade", "head")
+    assert second.returncode == 0, f"re-running at head failed:\n{second.stderr}"
+
+
+def test_the_lock_is_transaction_scoped(scratch_db):
+    """pg_advisory_xact_lock, not pg_advisory_lock.
+
+    A session-scoped lock would survive a crashed migration and wedge every later
+    boot, and would be invisible across Neon's transaction-mode pooler. Asserting no
+    advisory lock outlives the upgrade is the observable form of that requirement.
+    """
+    import psycopg2
+
+    assert _alembic(scratch_db, "upgrade", "head").returncode == 0
+
+    conn = psycopg2.connect(_sync_url(scratch_db), connect_timeout=5)
+    try:
+        with conn.cursor() as cur:
+            cur.execute("SELECT count(*) FROM pg_locks WHERE locktype = 'advisory'")
+            assert cur.fetchone()[0] == 0, "an advisory lock outlived the migration"
+    finally:
+        conn.close()

--- a/backend/tests/test_motorco.py
+++ b/backend/tests/test_motorco.py
@@ -1,0 +1,94 @@
+"""
+Unit tests for app.scrapers.motorco — the FullCalendar JS extraction.
+
+Covers the title field specifically: WordPress `esc_js` backslash-escapes any
+apostrophe inside the single-quoted `title:` value, and the previous
+stop-at-the-first-quote pattern terminated there, storing a truncated title with
+a trailing backslash. A fetch of the live calendar showed 61 of 625 titles
+carrying such an escape.
+
+Run from the backend/ directory:  python -m pytest tests/test_motorco.py
+The extraction is pure stdlib regex, so no DB, no network and no fixtures are
+needed — the scraper's own HTTP call is not exercised here.
+"""
+
+import sys
+from datetime import date, timedelta
+from pathlib import Path
+
+# Make `app` importable when running pytest from backend/.
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from app.scrapers.motorco import _EVENT_PATTERN, MotorcoScraper  # noqa: E402
+
+
+def _scraper() -> MotorcoScraper:
+    return MotorcoScraper("motorco", {"url": "https://motorcomusic.com/calendar/"})
+
+
+def _event_object(title: str, day: str) -> str:
+    """One JS event object, shaped like the live FullCalendar init array."""
+    return (
+        "{"
+        f"title: '{title}',"
+        f"start: '{day} 20:00',"
+        "url: 'https://motorcomusic.com/event/example/',"
+        "classNames: 'tcec-event-'"
+        "}"
+    )
+
+
+# `\\'` in this Python string is one backslash + one apostrophe in the JS source —
+# exactly what `esc_js` emits for a title containing an apostrophe.
+_ESCAPED = "Wednesday : It\\'s Fine"
+_PLAIN = "Hermanos Gutierrez"
+
+
+def test_escaped_apostrophe_title_is_captured_whole():
+    """The old pattern stopped at the escaped quote, yielding 'Wednesday : It\\'."""
+    m = _EVENT_PATTERN.search(_event_object(_ESCAPED, "2026-09-12"))
+    assert m is not None
+    assert m.group("title") == _ESCAPED
+
+
+def test_plain_title_still_captured():
+    m = _EVENT_PATTERN.search(_event_object(_PLAIN, "2026-09-12"))
+    assert m is not None
+    assert m.group("title") == _PLAIN
+
+
+def test_start_and_url_still_captured():
+    m = _EVENT_PATTERN.search(_event_object(_ESCAPED, "2026-09-12"))
+    assert m is not None
+    assert m.group("start") == "2026-09-12 20:00"
+    assert m.group("url") == "https://motorcomusic.com/event/example/"
+
+
+def test_both_titles_survive_in_a_mixed_array():
+    """Events were never dropped — each escaped title was silently truncated."""
+    html = "events: [%s,%s]," % (
+        _event_object(_ESCAPED, "2026-09-12"),
+        _event_object(_PLAIN, "2026-09-20"),
+    )
+    titles = [m.group("title") for m in _EVENT_PATTERN.finditer(html)]
+    assert titles == [_ESCAPED, _PLAIN]
+
+
+def test_parse_event_collapses_the_escape_to_a_real_apostrophe():
+    future = (date.today() + timedelta(days=45)).strftime("%Y-%m-%d %H:%M")
+    parsed = _scraper()._parse_event(
+        _ESCAPED, future, "https://motorcomusic.com/event/example/", date.today()
+    )
+    assert parsed is not None
+    assert parsed.name == "Wednesday : It's Fine"
+    assert parsed.artist == "Wednesday : It's Fine"
+    assert "\\" not in parsed.name
+
+
+def test_parse_event_leaves_a_plain_title_alone():
+    future = (date.today() + timedelta(days=45)).strftime("%Y-%m-%d %H:%M")
+    parsed = _scraper()._parse_event(
+        _PLAIN, future, "https://motorcomusic.com/event/example/", date.today()
+    )
+    assert parsed is not None
+    assert parsed.name == _PLAIN

--- a/backend/tests/test_motorco.py
+++ b/backend/tests/test_motorco.py
@@ -7,19 +7,14 @@ stop-at-the-first-quote pattern terminated there, storing a truncated title with
 a trailing backslash. A fetch of the live calendar showed 61 of 625 titles
 carrying such an escape.
 
-Run from the backend/ directory:  python -m pytest tests/test_motorco.py
+Run from the backend/ directory:  pytest tests/test_motorco.py
 The extraction is pure stdlib regex, so no DB, no network and no fixtures are
 needed — the scraper's own HTTP call is not exercised here.
 """
 
-import sys
 from datetime import date, timedelta
-from pathlib import Path
 
-# Make `app` importable when running pytest from backend/.
-sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
-
-from app.scrapers.motorco import _EVENT_PATTERN, MotorcoScraper  # noqa: E402
+from app.scrapers.motorco import _EVENT_PATTERN, MotorcoScraper
 
 
 def _scraper() -> MotorcoScraper:

--- a/backend/tests/test_origin_gates.py
+++ b/backend/tests/test_origin_gates.py
@@ -51,13 +51,17 @@ class TestGatesInertWhenUnconfigured:
     without breaking local dev, CI, or the running site.
     """
 
+    # Asserted as "not 403" rather than as a specific status on purpose. What matters is
+    # that the middleware passed the request through; what it then meets is not this
+    # test's business. Pinning an exact code here once meant pinning 404 — the code you
+    # get when /admin does not exist — which broke as soon as PR #36 added the admin
+    # subsite and /admin started answering 303 and 200.
+
     def test_admin_is_not_403ed_when_unconfigured(self, client, gates_off):
-        # /admin does not exist on main — the admin subsite arrives with PR #36. A 404
-        # proves the middleware passed the request through rather than rejecting it.
-        assert client.get("/admin").status_code == 404
+        assert client.get("/admin", follow_redirects=False).status_code != 403
 
     def test_admin_login_is_not_403ed_when_unconfigured(self, client, gates_off):
-        assert client.get("/admin/login").status_code == 404
+        assert client.get("/admin/login", follow_redirects=False).status_code != 403
 
 
 # --- Configured: /admin gate ---

--- a/backend/tests/test_origin_gates.py
+++ b/backend/tests/test_origin_gates.py
@@ -1,0 +1,121 @@
+"""
+Tests that the origin gates are actually wired into the app, not merely implemented.
+
+test_tokens.py covers whether a token verifies. This file covers the separate question
+of whether an unverified request is stopped — which is a property of main.py's middleware
+and dependency, and would break silently if either were unregistered or misordered.
+
+Requests go through TestClient without its context manager on purpose: that skips the
+lifespan handler, so no migrations run and no database is needed. Only routes that answer
+before touching the session are exercised here.
+"""
+
+from fastapi.testclient import TestClient
+
+import pytest
+
+from app.config import settings
+from app.main import app
+
+
+TEAM = "triangleshows.cloudflareaccess.com"
+SCHEDULER_SA = "triangle-shows-scrape@triangle-shows.iam.gserviceaccount.com"
+
+
+@pytest.fixture
+def client():
+    return TestClient(app)
+
+
+@pytest.fixture
+def gates_off(monkeypatch):
+    monkeypatch.setattr(settings, "CF_ACCESS_TEAM_DOMAIN", "")
+    monkeypatch.setattr(settings, "CF_ACCESS_AUD", "")
+    monkeypatch.setattr(settings, "SCRAPE_ALLOWED_SERVICE_ACCOUNTS", "")
+
+
+@pytest.fixture
+def gates_on(monkeypatch):
+    monkeypatch.setattr(settings, "CF_ACCESS_TEAM_DOMAIN", TEAM)
+    monkeypatch.setattr(settings, "CF_ACCESS_AUD", "aud123")
+    monkeypatch.setattr(settings, "SCRAPE_ALLOWED_SERVICE_ACCOUNTS", SCHEDULER_SA)
+    monkeypatch.setattr(settings, "SCRAPE_OIDC_AUDIENCE", "")
+
+
+# --- Unconfigured: both gates inert ---
+
+class TestGatesInertWhenUnconfigured:
+    """Deploying this code must change nothing until the settings are populated.
+
+    That is what lets it ship ahead of the Cloudflare and Cloud Scheduler configuration
+    without breaking local dev, CI, or the running site.
+    """
+
+    def test_admin_is_not_403ed_when_unconfigured(self, client, gates_off):
+        # /admin does not exist on main — the admin subsite arrives with PR #36. A 404
+        # proves the middleware passed the request through rather than rejecting it.
+        assert client.get("/admin").status_code == 404
+
+    def test_admin_login_is_not_403ed_when_unconfigured(self, client, gates_off):
+        assert client.get("/admin/login").status_code == 404
+
+
+# --- Configured: /admin gate ---
+
+class TestAdminGate:
+    def test_no_token_is_rejected(self, client, gates_on):
+        assert client.get("/admin").status_code == 403
+
+    def test_the_login_page_is_gated_too(self, client, gates_on):
+        """Reaching a password prompt on the origin is the exposure being closed, so the
+        gate covers /admin/login rather than only the API beneath it."""
+        assert client.get("/admin/login").status_code == 403
+
+    def test_a_nested_admin_path_is_rejected(self, client, gates_on):
+        assert client.get("/admin/api/events").status_code == 403
+
+    def test_a_garbage_token_is_rejected(self, client, gates_on):
+        response = client.get("/admin", headers={"Cf-Access-Jwt-Assertion": "not-a-token"})
+        assert response.status_code == 403
+
+    def test_the_rejection_does_not_explain_itself(self, client, gates_on):
+        """Why a token failed is reconnaissance; the response says only that the surface
+        is Cloudflare-only."""
+        body = client.get("/admin", headers={"Cf-Access-Jwt-Assertion": "x.y.z"}).json()
+        assert "Cloudflare Access" in body["detail"]
+        for leak in ("signature", "expired", "audience", "issuer", "algorithm"):
+            assert leak not in body["detail"].lower()
+
+
+class TestPublicRoutesAreUnaffected:
+    def test_a_normal_route_is_not_gated(self, client, gates_on):
+        """The /admin gate must key on the path prefix only, and let everything else by.
+
+        /openapi.json rather than /api/health: health queries the database for its counts,
+        so it cannot answer in a test that deliberately skips lifespan and runs without
+        Postgres. This route proves the same thing about the middleware.
+        """
+        assert client.get("/openapi.json").status_code == 200
+
+    def test_a_path_merely_containing_admin_is_not_gated(self, client, gates_on):
+        """Guarding on startswith('/admin') and not on a substring match."""
+        assert client.get("/api/venues/not-admin-really").status_code != 403
+
+
+# --- Configured: scrape gate ---
+
+class TestScrapeGate:
+    def test_no_token_is_rejected(self, client, gates_on):
+        assert client.post("/api/scrape").status_code == 403
+
+    def test_a_bearer_token_that_is_not_a_token_is_rejected(self, client, gates_on):
+        response = client.post("/api/scrape", headers={"Authorization": "Bearer garbage"})
+        assert response.status_code == 403
+
+    def test_a_non_bearer_scheme_is_rejected(self, client, gates_on):
+        response = client.post("/api/scrape", headers={"Authorization": "Basic dXNlcjpwdw=="})
+        assert response.status_code == 403
+
+    def test_the_rejection_does_not_explain_itself(self, client, gates_on):
+        body = client.post("/api/scrape").json()
+        assert body["detail"] == "Not authorized to trigger a scrape."

--- a/backend/tests/test_series_override_cascade.py
+++ b/backend/tests/test_series_override_cascade.py
@@ -1,0 +1,77 @@
+"""
+Tests that retiring a venue cannot be blocked by its series rules — review item #9.
+
+seed_venues() deletes venues named in REMOVED_SLUGS on every startup, via
+session.delete(). That cascades only through relationships SQLAlchemy knows about. Venue
+had them for events and scrape_logs but not for series_overrides, and the foreign key had
+no ON DELETE, so the first retirement of a venue holding a series override would raise
+ForeignKeyViolation inside the lifespan handler — and the container would never become
+healthy. REMOVED_SLUGS is [""] today, which is why nothing has broken yet.
+
+The fix has two halves and this file checks both, because either alone leaves a hole:
+
+  * an ORM relationship with delete-orphan, which covers session.delete()
+  * ON DELETE CASCADE on the constraint, which covers anything bypassing the ORM
+
+Asserted against mapper metadata and the migration source rather than a live database.
+The model being right while the migration is wrong is the realistic drift — the model
+governs nothing at runtime, since the table is created by the migration — so the migration
+is checked too. Neither check needs Postgres.
+"""
+
+import pathlib
+import re
+
+from app.models import SeriesOverride, Venue
+
+
+MIGRATION = (
+    pathlib.Path(__file__).resolve().parent.parent
+    / "alembic" / "versions" / "0004_add_series_overrides.py"
+)
+
+
+class TestOrmCascade:
+    """Covers session.delete(venue), which is how seed_venues() retires a venue."""
+
+    def test_venue_has_a_series_overrides_relationship(self):
+        assert "series_overrides" in Venue.__mapper__.relationships
+
+    def test_it_cascades_deletes_like_events_and_scrape_logs(self):
+        rel = Venue.__mapper__.relationships["series_overrides"]
+        assert rel.cascade.delete
+        assert rel.cascade.delete_orphan
+
+    def test_it_matches_the_cascade_on_the_other_two_collections(self):
+        """Consistency is the point — a venue's dependents should not have three different
+        deletion behaviors depending on which was added when."""
+        cascades = {
+            name: (Venue.__mapper__.relationships[name].cascade.delete,
+                   Venue.__mapper__.relationships[name].cascade.delete_orphan)
+            for name in ("events", "scrape_logs", "series_overrides")
+        }
+        assert len(set(cascades.values())) == 1, cascades
+
+    def test_the_reverse_relationship_is_wired(self):
+        """back_populates on Venue requires the matching attribute here, or SQLAlchemy
+        raises at mapper configuration time."""
+        assert "venue" in SeriesOverride.__mapper__.relationships
+
+
+class TestDatabaseConstraint:
+    """Covers deletions that never pass through the ORM's cascade."""
+
+    def test_the_model_declares_on_delete_cascade(self):
+        fks = list(SeriesOverride.__table__.c.venue_id.foreign_keys)
+        assert len(fks) == 1
+        assert fks[0].ondelete == "CASCADE"
+
+    def test_the_migration_declares_it_too(self):
+        """The migration, not the model, is what creates the constraint in the database.
+        A model-only fix would look correct here and change nothing in production."""
+        source = MIGRATION.read_text(encoding="utf-8")
+        fk = re.search(
+            r"ForeignKeyConstraint\(\s*\['venue_id'\][^)]*\)", source, re.DOTALL
+        )
+        assert fk is not None, "venue_id foreign key not found in 0004"
+        assert "ondelete='CASCADE'" in fk.group(0) or 'ondelete="CASCADE"' in fk.group(0)

--- a/backend/tests/test_squarespace.py
+++ b/backend/tests/test_squarespace.py
@@ -53,6 +53,35 @@ def _item(**overrides) -> dict:
     return item
 
 
+# --- _select_items ---
+
+class TestSelectItems:
+    def test_reads_the_items_key(self):
+        assert SquarespaceScraper._select_items({"items": [1, 2]}) == [1, 2]
+
+    def test_reads_the_upcoming_key(self):
+        """Boom Club's template has no 'items' key at all."""
+        assert SquarespaceScraper._select_items({"upcoming": [1]}) == [1]
+
+    def test_reads_the_events_key(self):
+        assert SquarespaceScraper._select_items({"events": [1]}) == [1]
+
+    def test_an_empty_items_key_does_not_mask_upcoming(self):
+        """The reason for `or` over a get() default — a default only fires when the
+        key is absent, so "items": [] used to win and hide the real events."""
+        data = {"items": [], "upcoming": [{"title": "MICROMACHINES"}]}
+        assert SquarespaceScraper._select_items(data) == [{"title": "MICROMACHINES"}]
+
+    def test_items_wins_when_both_are_populated(self):
+        assert SquarespaceScraper._select_items({"items": [1], "upcoming": [2]}) == [1]
+
+    def test_no_known_key_yields_an_empty_list(self):
+        assert SquarespaceScraper._select_items({"past": [1]}) == []
+
+    def test_all_keys_empty_yields_an_empty_list(self):
+        assert SquarespaceScraper._select_items({"items": [], "upcoming": []}) == []
+
+
 # --- _extract_description ---
 
 class TestExtractDescription:

--- a/backend/tests/test_squarespace.py
+++ b/backend/tests/test_squarespace.py
@@ -1,0 +1,128 @@
+"""
+Tests for the Squarespace scraper's description handling.
+
+Regression cover for #35: an event whose body has no `div.sqs-html-content` block
+raised IndexError, which the broad except in _parse_event swallowed — dropping the
+whole event. Every Boom Club listing has an empty body, so the venue sat at zero
+events in the database while its scrape logs reported success.
+
+The markup fixtures below are trimmed copies of what the two live feeds return.
+"""
+
+import sys
+from datetime import date
+from pathlib import Path
+
+# Make `app` importable when running pytest from backend/.
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from app.scrapers.squarespace import SquarespaceScraper  # noqa: E402
+
+
+# --- Fixtures drawn from the live feeds ---
+
+# Boom Club: the venue never filled in a body, so Squarespace emits layout
+# scaffolding marked `empty` with no sqs-html-content block anywhere.
+EMPTY_BODY = (
+    '<div class="sqs-layout sqs-grid-12 columns-12 empty" data-layout-label="Post Body"'
+    ' data-type="item" id="item-6a626f7c24c2d308343e7804">'
+    '<div class="row sqs-row"><div class="col sqs-col-12 span-12"></div></div></div>'
+)
+
+# Neptune's Parlour: a populated body. First child repeats the title, so it is skipped.
+POPULATED_BODY = (
+    '<div class="sqs-layout"><div class="row sqs-row"><div class="col">'
+    '<div class="sqs-block html-block"><div class="sqs-block-content">'
+    '<div class="sqs-html-content">'
+    "<h2>The Regulars</h2>"
+    "<p>Doors at 8pm.</p>"
+    "<p>$12 advance</p>"
+    "</div></div></div></div></div></div>"
+)
+
+START_MS = 1788000000000  # milliseconds, as Squarespace sends them
+
+
+def _scraper() -> SquarespaceScraper:
+    return SquarespaceScraper("boom-club", {"url": "https://example.org/events?format=json"})
+
+
+def _item(**overrides) -> dict:
+    item = {"title": "MICROMACHINES", "startDate": START_MS, "body": EMPTY_BODY}
+    item.update(overrides)
+    return item
+
+
+# --- _extract_description ---
+
+class TestExtractDescription:
+    def test_empty_body_yields_empty_string(self):
+        assert _scraper()._extract_description(_item()) == ''
+
+    def test_missing_body_and_excerpt_yields_empty_string(self):
+        assert _scraper()._extract_description({"title": "X"}) == ''
+
+    def test_populated_body_is_read_as_plain_text(self):
+        out = _scraper()._extract_description(_item(body=POPULATED_BODY))
+        assert "Doors at 8pm." in out
+        assert "$12 advance" in out
+
+    def test_leading_title_child_is_skipped(self):
+        """The first child of sqs-html-content repeats the title (#17)."""
+        out = _scraper()._extract_description(_item(body=POPULATED_BODY))
+        assert "The Regulars" not in out
+
+    def test_html_is_stripped(self):
+        """#17 — raw markup must not reach the database."""
+        out = _scraper()._extract_description(_item(body=POPULATED_BODY))
+        assert "<p>" not in out and "div" not in out
+
+    def test_excerpt_is_preferred_over_body(self):
+        item = _item(excerpt=POPULATED_BODY, body=EMPTY_BODY)
+        assert "Doors at 8pm." in _scraper()._extract_description(item)
+
+
+# --- _parse_event: the actual #35 regression ---
+
+class TestParseEventSurvivesEmptyDescription:
+    def test_event_with_empty_body_is_still_returned(self):
+        """The regression: this used to return None and the event vanished."""
+        parsed = _scraper()._parse_event(_item())
+
+        assert parsed is not None, "an empty description must not discard the event"
+        assert parsed.name == "MICROMACHINES"
+        assert parsed.description == ''
+
+    def test_event_with_empty_body_keeps_its_required_fields(self):
+        parsed = _scraper()._parse_event(_item())
+
+        assert isinstance(parsed.date, date)
+        assert parsed.venue_slug == "boom-club"
+        assert parsed.source == "squarespace"
+
+    def test_event_with_a_description_still_parses(self):
+        parsed = _scraper()._parse_event(_item(body=POPULATED_BODY))
+
+        assert parsed is not None
+        assert "Doors at 8pm." in parsed.description
+
+    def test_price_is_still_read_from_a_populated_description(self):
+        """Description feeds price parsing, so the two must stay wired together."""
+        parsed = _scraper()._parse_event(_item(body=POPULATED_BODY))
+        assert parsed.price_min == 12.0
+
+    def test_missing_title_is_still_rejected(self):
+        """Required fields must keep failing closed — only description got lenient."""
+        assert _scraper()._parse_event(_item(title="")) is None
+
+    def test_missing_start_date_is_still_rejected(self):
+        item = _item()
+        del item["startDate"]
+        assert _scraper()._parse_event(item) is None
+
+    def test_excluded_titles_are_still_skipped(self):
+        scraper = SquarespaceScraper("boom-club", {
+            "url": "https://example.org/events?format=json",
+            "exclude_titles": ["micromachines"],
+        })
+        assert scraper._parse_event(_item()) is None

--- a/backend/tests/test_squarespace.py
+++ b/backend/tests/test_squarespace.py
@@ -15,14 +15,9 @@ Two regressions covered here:
 The markup fixtures below are trimmed copies of what the two live feeds return.
 """
 
-import sys
 from datetime import date
-from pathlib import Path
 
-# Make `app` importable when running pytest from backend/.
-sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
-
-from app.scrapers.squarespace import SquarespaceScraper  # noqa: E402
+from app.scrapers.squarespace import SquarespaceScraper
 
 
 # --- Fixtures drawn from the live feeds ---

--- a/backend/tests/test_squarespace.py
+++ b/backend/tests/test_squarespace.py
@@ -1,10 +1,16 @@
 """
 Tests for the Squarespace scraper's description handling.
 
-Regression cover for #35: an event whose body has no `div.sqs-html-content` block
-raised IndexError, which the broad except in _parse_event swallowed — dropping the
-whole event. Every Boom Club listing has an empty body, so the venue sat at zero
-events in the database while its scrape logs reported success.
+Two regressions covered here:
+
+- #35: an event whose body has no `div.sqs-html-content` block raised IndexError,
+  which the broad except in _parse_event swallowed — dropping the whole event.
+  Every Boom Club listing has an empty body, so the venue sat at zero events in the
+  database while its scrape logs reported success.
+- #13: `excerpt` content (Boom Club fills this in with real summaries) was read with
+  the same "look for a Post-Body wrapper, skip its first child" logic that only
+  applies to `body`. Excerpt has no such wrapper and never repeats the title, so real
+  description text was silently discarded — not shown as raw HTML, but lost outright.
 
 The markup fixtures below are trimmed copies of what the two live feeds return.
 """
@@ -29,15 +35,24 @@ EMPTY_BODY = (
     '<div class="row sqs-row"><div class="col sqs-col-12 span-12"></div></div></div>'
 )
 
-# Neptune's Parlour: a populated body. First child repeats the title, so it is skipped.
+# Neptune's Parlour: the Post Body editor's first <p> always repeats the event's own
+# title verbatim (confirmed against the live feed) — real content follows after it.
 POPULATED_BODY = (
     '<div class="sqs-layout"><div class="row sqs-row"><div class="col">'
     '<div class="sqs-block html-block"><div class="sqs-block-content">'
     '<div class="sqs-html-content">'
-    "<h2>The Regulars</h2>"
+    '<p class="" style="white-space:pre-wrap;">The Regulars</p>'
     "<p>Doors at 8pm.</p>"
     "<p>$12 advance</p>"
     "</div></div></div></div></div></div>"
+)
+
+# Boom Club: `excerpt` is a genuinely separate summary field — bare <p> tags, no
+# Post-Body wrapper, and never a repeat of the title (confirmed against the live feed,
+# where `body` for these same events looks like an unrelated, mostly-empty layout).
+EXCERPT_CONTENT = (
+    '<p style="white-space:pre-wrap;" data-rte-preserve-empty="true">'
+    "Modular virtuoso Matthew Cha presents a live, semi-improvised suite.</p>"
 )
 
 START_MS = 1788000000000  # milliseconds, as Squarespace sends them
@@ -85,30 +100,47 @@ class TestSelectItems:
 # --- _extract_description ---
 
 class TestExtractDescription:
-    def test_empty_body_yields_empty_string(self):
-        assert _scraper()._extract_description(_item()) == ''
+    def test_empty_body_yields_none(self):
+        assert _scraper()._extract_description(_item(), "MICROMACHINES") is None
 
-    def test_missing_body_and_excerpt_yields_empty_string(self):
-        assert _scraper()._extract_description({"title": "X"}) == ''
+    def test_missing_body_and_excerpt_yields_none(self):
+        assert _scraper()._extract_description({"title": "X"}, "X") is None
 
     def test_populated_body_is_read_as_plain_text(self):
-        out = _scraper()._extract_description(_item(body=POPULATED_BODY))
+        out = _scraper()._extract_description(_item(body=POPULATED_BODY), "The Regulars")
         assert "Doors at 8pm." in out
         assert "$12 advance" in out
 
-    def test_leading_title_child_is_skipped(self):
-        """The first child of sqs-html-content repeats the title (#17)."""
-        out = _scraper()._extract_description(_item(body=POPULATED_BODY))
+    def test_leading_title_paragraph_is_dropped_from_body(self):
+        """body's Post-Body editor repeats the title as its first paragraph (#17)."""
+        out = _scraper()._extract_description(_item(body=POPULATED_BODY), "The Regulars")
         assert "The Regulars" not in out
 
     def test_html_is_stripped(self):
         """#17 — raw markup must not reach the database."""
-        out = _scraper()._extract_description(_item(body=POPULATED_BODY))
+        out = _scraper()._extract_description(_item(body=POPULATED_BODY), "The Regulars")
         assert "<p>" not in out and "div" not in out
 
     def test_excerpt_is_preferred_over_body(self):
-        item = _item(excerpt=POPULATED_BODY, body=EMPTY_BODY)
-        assert "Doors at 8pm." in _scraper()._extract_description(item)
+        item = _item(excerpt=EXCERPT_CONTENT, body=POPULATED_BODY)
+        out = _scraper()._extract_description(item, "The Regulars")
+        assert "Matthew Cha" in out
+
+    def test_excerpt_with_no_wrapper_is_still_read(self):
+        """The #13 regression: excerpt has no Post-Body div to find, and previously
+        that meant it was read as having nothing in it."""
+        item = _item(excerpt=EXCERPT_CONTENT)
+        out = _scraper()._extract_description(item, "Matthew Cha \"Technojazz\" Release")
+        assert out is not None
+        assert "Modular virtuoso Matthew Cha" in out
+
+    def test_excerpt_is_never_checked_against_the_title(self):
+        """Only body's known title-repeat paragraph is dropped. Excerpt is a genuinely
+        separate field and must survive even a coincidental title match."""
+        item = _item(excerpt="<p>The Regulars</p><p>A special guest tonight.</p>")
+        out = _scraper()._extract_description(item, "The Regulars")
+        assert "The Regulars" in out
+        assert "A special guest tonight." in out
 
 
 # --- _parse_event: the actual #35 regression ---
@@ -120,7 +152,7 @@ class TestParseEventSurvivesEmptyDescription:
 
         assert parsed is not None, "an empty description must not discard the event"
         assert parsed.name == "MICROMACHINES"
-        assert parsed.description == ''
+        assert parsed.description is None
 
     def test_event_with_empty_body_keeps_its_required_fields(self):
         parsed = _scraper()._parse_event(_item())
@@ -155,3 +187,18 @@ class TestParseEventSurvivesEmptyDescription:
             "exclude_titles": ["micromachines"],
         })
         assert scraper._parse_event(_item()) is None
+
+    def test_excerpt_content_survives_end_to_end(self):
+        """The #13 regression, through the full parse path rather than just the
+        extraction helper: Boom Club's real excerpts must reach the stored event."""
+        item = _item(
+            title='Matthew Cha "Technojazz" Release',
+            excerpt=EXCERPT_CONTENT,
+            body=EMPTY_BODY,
+        )
+        parsed = _scraper()._parse_event(item)
+
+        assert parsed is not None
+        assert parsed.description is not None
+        assert "Modular virtuoso Matthew Cha" in parsed.description
+        assert "<p>" not in parsed.description

--- a/backend/tests/test_tokens.py
+++ b/backend/tests/test_tokens.py
@@ -1,0 +1,412 @@
+"""
+Tests for app.tokens — the signed-token gates on /admin/* and POST /api/scrape.
+
+These verify the checks that actually stop a forged request, so each one is written to
+fail if the corresponding check is removed:
+
+  * signature   — a token signed by a different key must not verify
+  * expiry      — an expired token must not verify
+  * audience    — a token minted for another application must not verify
+  * issuer      — a token from an unexpected issuer must not verify
+  * algorithm   — an HMAC-signed token must not verify, even signed with the public key
+
+The last one is the subtle one. RS256 verification uses a *public* key, which anyone can
+fetch. If HS256 were also accepted, a caller could sign their own token using that public
+key as the shared secret and it would verify. Restricting algorithms to RS256 is what
+prevents it, and the test below is the only thing that would catch a regression there.
+
+A real RSA keypair is generated once per module and the JWKS lookup is redirected at it,
+so nothing here touches the network. Key generation costs well under a second.
+"""
+
+import base64
+import hashlib
+import hmac
+import json
+import time
+from typing import Optional
+
+import jwt
+import pytest
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric import rsa
+
+from app import tokens
+
+
+# --- Keys and signing helpers ---
+
+@pytest.fixture(scope="module")
+def keypair():
+    """One RSA keypair for the whole module: generation is the slow part."""
+    private = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    return private, private.public_key()
+
+
+@pytest.fixture(scope="module")
+def other_keypair():
+    """A second, unrelated keypair — stands in for an attacker's own key."""
+    private = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    return private, private.public_key()
+
+
+def _pem_private(key) -> bytes:
+    return key.private_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PrivateFormat.PKCS8,
+        encryption_algorithm=serialization.NoEncryption(),
+    )
+
+
+@pytest.fixture(autouse=True)
+def redirect_jwks(monkeypatch, keypair):
+    """Point every JWKS lookup at the module's public key, with no network access.
+
+    Mirrors what PyJWKClient returns: an object exposing the verification key as `.key`.
+    """
+    _, public = keypair
+
+    class _StubKey:
+        key = public
+
+    class _StubClient:
+        def get_signing_key_from_jwt(self, token):
+            return _StubKey()
+
+    monkeypatch.setattr(tokens, "_jwks_client", lambda url: _StubClient())
+
+
+def make_token(
+    private_key,
+    *,
+    issuer: str,
+    audience: Optional[str],
+    email: Optional[str] = None,
+    expires_in: int = 600,
+) -> str:
+    now = int(time.time())
+    claims = {"iss": issuer, "iat": now, "exp": now + expires_in}
+    if audience is not None:
+        claims["aud"] = audience
+    if email is not None:
+        claims["email"] = email
+    return jwt.encode(claims, _pem_private(private_key), algorithm="RS256")
+
+
+def _public_pem(public_key) -> bytes:
+    return public_key.public_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PublicFormat.SubjectPublicKeyInfo,
+    )
+
+
+def _b64(raw: bytes) -> str:
+    return base64.urlsafe_b64encode(raw).rstrip(b"=").decode()
+
+
+def make_hmac_token(secret: bytes, claims: dict) -> str:
+    """Build an HS256 token by hand, signed with `secret`.
+
+    Assembled manually rather than through jwt.encode(), which refuses a PEM public key
+    as an HMAC secret. That guard protects the signing side; this test is about the
+    verifying side, and an attacker writing 10 lines of base64 and hmac is not constrained
+    by our library's opinions.
+    """
+    header = {"alg": "HS256", "typ": "JWT"}
+    signing_input = f"{_b64(json.dumps(header).encode())}.{_b64(json.dumps(claims).encode())}"
+    signature = hmac.new(secret, signing_input.encode(), hashlib.sha256).digest()
+    return f"{signing_input}.{_b64(signature)}"
+
+
+# --- Cloudflare Access gate (/admin/*) ---
+
+TEAM = "triangleshows.cloudflareaccess.com"
+CF_ISSUER = f"https://{TEAM}"
+CF_AUD = "abc123def456"
+
+
+@pytest.fixture
+def cf_configured(monkeypatch):
+    from app.config import settings
+
+    monkeypatch.setattr(settings, "CF_ACCESS_TEAM_DOMAIN", TEAM)
+    monkeypatch.setattr(settings, "CF_ACCESS_AUD", CF_AUD)
+    return settings
+
+
+class TestCloudflareAccessGate:
+    def test_valid_token_is_accepted_and_carries_the_email(self, keypair, cf_configured):
+        private, _ = keypair
+        token = make_token(private, issuer=CF_ISSUER, audience=CF_AUD, email="a@example.org")
+
+        claims = tokens.verify_cloudflare_access(token)
+
+        assert tokens.access_identity(claims) == "a@example.org"
+
+    def test_missing_token_is_rejected(self, cf_configured):
+        with pytest.raises(tokens.TokenError):
+            tokens.verify_cloudflare_access(None)
+
+    def test_garbage_token_is_rejected(self, cf_configured):
+        with pytest.raises(tokens.TokenError):
+            tokens.verify_cloudflare_access("not-a-token")
+
+    def test_token_signed_by_another_key_is_rejected(self, other_keypair, cf_configured):
+        """The core forgery case: right claims, wrong signer."""
+        private, _ = other_keypair
+        token = make_token(private, issuer=CF_ISSUER, audience=CF_AUD, email="a@example.org")
+
+        with pytest.raises(tokens.TokenError):
+            tokens.verify_cloudflare_access(token)
+
+    def test_expired_token_is_rejected(self, keypair, cf_configured):
+        private, _ = keypair
+        token = make_token(
+            private, issuer=CF_ISSUER, audience=CF_AUD, email="a@example.org", expires_in=-3600
+        )
+
+        with pytest.raises(tokens.TokenError):
+            tokens.verify_cloudflare_access(token)
+
+    def test_token_for_another_access_application_is_rejected(self, keypair, cf_configured):
+        """A Cloudflare team can host several apps; each token names the one it is for."""
+        private, _ = keypair
+        token = make_token(
+            private, issuer=CF_ISSUER, audience="some-other-app", email="a@example.org"
+        )
+
+        with pytest.raises(tokens.TokenError):
+            tokens.verify_cloudflare_access(token)
+
+    def test_token_with_no_audience_at_all_is_rejected(self, keypair, cf_configured):
+        private, _ = keypair
+        token = make_token(private, issuer=CF_ISSUER, audience=None, email="a@example.org")
+
+        with pytest.raises(tokens.TokenError):
+            tokens.verify_cloudflare_access(token)
+
+    def test_token_from_an_unexpected_issuer_is_rejected(self, keypair, cf_configured):
+        private, _ = keypair
+        token = make_token(
+            private, issuer="https://attacker.cloudflareaccess.com", audience=CF_AUD
+        )
+
+        with pytest.raises(tokens.TokenError):
+            tokens.verify_cloudflare_access(token)
+
+    def test_hmac_signed_token_is_rejected(self, keypair, cf_configured):
+        """Algorithm confusion: a token signed with the *public* key as an HMAC secret.
+
+        This is the attack the ALLOWED_ALGORITHMS allowlist exists to prevent — the
+        verification key is published at the issuer's JWKS URL, so if HS256 were accepted
+        an attacker could sign their own tokens with it.
+
+        Honest note on what this test proves. It asserts the property (such a token does
+        not verify), not the mechanism. Widening ALLOWED_ALGORITHMS to include HS256 does
+        *not* make it fail, because PyJWT's own prepare_key refuses a PEM or key-object
+        operand as an HMAC secret, on decode as well as encode. Confirmed by mutation.
+        So the allowlist here is defense in depth behind a library guarantee rather than
+        the sole control, and no test in this file can pin it while that guarantee holds.
+        Keep the allowlist regardless: it is explicit, and it is what would still hold if
+        the key handling or the library ever changed underneath.
+        """
+        now = int(time.time())
+        _, public = keypair
+        forged = make_hmac_token(
+            _public_pem(public),
+            {"iss": CF_ISSUER, "aud": CF_AUD, "email": "x@example.org", "iat": now, "exp": now + 600},
+        )
+
+        with pytest.raises(tokens.TokenError):
+            tokens.verify_cloudflare_access(forged)
+
+    def test_team_domain_with_a_scheme_is_tolerated(self, keypair, monkeypatch):
+        """The Cloudflare dashboard shows the domain bare; pasting a URL must still work."""
+        from app.config import settings
+
+        monkeypatch.setattr(settings, "CF_ACCESS_TEAM_DOMAIN", f"https://{TEAM}/")
+        monkeypatch.setattr(settings, "CF_ACCESS_AUD", CF_AUD)
+        private, _ = keypair
+        token = make_token(private, issuer=CF_ISSUER, audience=CF_AUD, email="a@example.org")
+
+        assert tokens.verify_cloudflare_access(token)["email"] == "a@example.org"
+
+
+class TestCloudflareAccessConfiguration:
+    def test_not_configured_when_both_unset(self, monkeypatch):
+        from app.config import settings
+
+        monkeypatch.setattr(settings, "CF_ACCESS_TEAM_DOMAIN", "")
+        monkeypatch.setattr(settings, "CF_ACCESS_AUD", "")
+        assert tokens.cloudflare_access_configured() is False
+
+    def test_not_configured_when_only_the_domain_is_set(self, monkeypatch):
+        """Half-configured must read as off, not as on — otherwise the audience check,
+        which is the one that matters, would be silently skipped."""
+        from app.config import settings
+
+        monkeypatch.setattr(settings, "CF_ACCESS_TEAM_DOMAIN", TEAM)
+        monkeypatch.setattr(settings, "CF_ACCESS_AUD", "")
+        assert tokens.cloudflare_access_configured() is False
+
+    def test_configured_when_both_are_set(self, cf_configured):
+        assert tokens.cloudflare_access_configured() is True
+
+
+# --- Google OIDC gate (POST /api/scrape) ---
+
+SCHEDULER_SA = "triangle-shows-scrape@triangle-shows.iam.gserviceaccount.com"
+SCRAPE_AUD = "https://triangle-shows.net/api/scrape"
+
+
+@pytest.fixture
+def scrape_configured(monkeypatch):
+    from app.config import settings
+
+    monkeypatch.setattr(settings, "SCRAPE_ALLOWED_SERVICE_ACCOUNTS", SCHEDULER_SA)
+    monkeypatch.setattr(settings, "SCRAPE_OIDC_AUDIENCE", SCRAPE_AUD)
+    return settings
+
+
+class TestScrapeGate:
+    def test_valid_token_from_the_allowlisted_account_is_accepted(self, keypair, scrape_configured):
+        private, _ = keypair
+        token = make_token(
+            private, issuer="https://accounts.google.com", audience=SCRAPE_AUD, email=SCHEDULER_SA
+        )
+
+        assert tokens.verify_scrape_token(token)["email"] == SCHEDULER_SA
+
+    def test_the_bare_issuer_spelling_is_accepted(self, keypair, scrape_configured):
+        """Google has emitted both 'accounts.google.com' and the https:// form."""
+        private, _ = keypair
+        token = make_token(
+            private, issuer="accounts.google.com", audience=SCRAPE_AUD, email=SCHEDULER_SA
+        )
+
+        assert tokens.verify_scrape_token(token)["email"] == SCHEDULER_SA
+
+    def test_a_different_service_account_is_rejected(self, keypair, scrape_configured):
+        """A validly signed Google token is not enough — it must name an allowlisted
+        account, or any Google customer could trigger a scrape."""
+        private, _ = keypair
+        token = make_token(
+            private,
+            issuer="https://accounts.google.com",
+            audience=SCRAPE_AUD,
+            email="someone-else@other-project.iam.gserviceaccount.com",
+        )
+
+        with pytest.raises(tokens.TokenError):
+            tokens.verify_scrape_token(token)
+
+    def test_a_token_with_no_email_claim_is_rejected(self, keypair, scrape_configured):
+        private, _ = keypair
+        token = make_token(private, issuer="https://accounts.google.com", audience=SCRAPE_AUD)
+
+        with pytest.raises(tokens.TokenError):
+            tokens.verify_scrape_token(token)
+
+    def test_wrong_audience_is_rejected_when_the_audience_is_configured(self, keypair, scrape_configured):
+        private, _ = keypair
+        token = make_token(
+            private,
+            issuer="https://accounts.google.com",
+            audience="https://example.org/something-else",
+            email=SCHEDULER_SA,
+        )
+
+        with pytest.raises(tokens.TokenError):
+            tokens.verify_scrape_token(token)
+
+    def test_audience_is_not_checked_when_left_unconfigured(self, keypair, monkeypatch):
+        """Documented trade in verify_scrape_token: the service-account check still
+        applies, so this stays useful, but set the audience when the value is known."""
+        from app.config import settings
+
+        monkeypatch.setattr(settings, "SCRAPE_ALLOWED_SERVICE_ACCOUNTS", SCHEDULER_SA)
+        monkeypatch.setattr(settings, "SCRAPE_OIDC_AUDIENCE", "")
+        private, _ = keypair
+        token = make_token(
+            private,
+            issuer="https://accounts.google.com",
+            audience="whatever-audience",
+            email=SCHEDULER_SA,
+        )
+
+        assert tokens.verify_scrape_token(token)["email"] == SCHEDULER_SA
+
+    def test_expired_token_is_rejected(self, keypair, scrape_configured):
+        private, _ = keypair
+        token = make_token(
+            private,
+            issuer="https://accounts.google.com",
+            audience=SCRAPE_AUD,
+            email=SCHEDULER_SA,
+            expires_in=-60,
+        )
+
+        with pytest.raises(tokens.TokenError):
+            tokens.verify_scrape_token(token)
+
+    def test_token_signed_by_another_key_is_rejected(self, other_keypair, scrape_configured):
+        private, _ = other_keypair
+        token = make_token(
+            private, issuer="https://accounts.google.com", audience=SCRAPE_AUD, email=SCHEDULER_SA
+        )
+
+        with pytest.raises(tokens.TokenError):
+            tokens.verify_scrape_token(token)
+
+
+class TestScrapeConfiguration:
+    def test_not_configured_when_the_allowlist_is_empty(self, monkeypatch):
+        from app.config import settings
+
+        monkeypatch.setattr(settings, "SCRAPE_ALLOWED_SERVICE_ACCOUNTS", "")
+        assert tokens.scrape_token_configured() is False
+        assert tokens.scrape_allowed_service_accounts() == ()
+
+    def test_multiple_accounts_are_parsed_and_trimmed(self, monkeypatch):
+        """Granting a second caller is a config change, not a code change."""
+        from app.config import settings
+
+        monkeypatch.setattr(
+            settings, "SCRAPE_ALLOWED_SERVICE_ACCOUNTS", f" {SCHEDULER_SA} , other@x.iam.gserviceaccount.com "
+        )
+
+        assert tokens.scrape_allowed_service_accounts() == (
+            SCHEDULER_SA,
+            "other@x.iam.gserviceaccount.com",
+        )
+        assert tokens.scrape_token_configured() is True
+
+    def test_blank_entries_are_ignored(self, monkeypatch):
+        """A trailing comma must not allowlist an empty email, which would then match a
+        token carrying no email claim."""
+        from app.config import settings
+
+        monkeypatch.setattr(settings, "SCRAPE_ALLOWED_SERVICE_ACCOUNTS", f"{SCHEDULER_SA},,")
+        assert tokens.scrape_allowed_service_accounts() == (SCHEDULER_SA,)
+
+
+# --- Authorization header parsing ---
+
+class TestBearerToken:
+    def test_reads_a_bearer_token(self):
+        assert tokens.bearer_token("Bearer abc.def.ghi") == "abc.def.ghi"
+
+    def test_scheme_is_case_insensitive(self):
+        assert tokens.bearer_token("bearer abc.def.ghi") == "abc.def.ghi"
+
+    def test_missing_header_yields_none(self):
+        assert tokens.bearer_token(None) is None
+
+    def test_empty_header_yields_none(self):
+        assert tokens.bearer_token("") is None
+
+    def test_another_scheme_yields_none(self):
+        assert tokens.bearer_token("Basic dXNlcjpwYXNz") is None
+
+    def test_bearer_with_no_value_yields_none(self):
+        assert tokens.bearer_token("Bearer ") is None

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -12,6 +12,12 @@
 #      gcloud secrets create triangle-shows-tm-api-key \
 #        --data-file=- <<< "your_ticketmaster_api_key"
 #
+#      # Admin subsite (/admin) — REQUIRED before enabling the admin secrets in the
+#      # deploy step below, or the deploy will fail on a missing secret:
+#      gcloud secrets create triangle-shows-admin-password \
+#        --data-file=- <<< "a-strong-admin-password"
+#      openssl rand -base64 32 | gcloud secrets create triangle-shows-session-secret --data-file=-
+#
 #   3. Grant the Cloud Build service account permission to deploy to Cloud Run
 #      and access secrets (in IAM Console, or):
 #      PROJECT_NUM=$(gcloud projects describe $PROJECT_ID --format='value(projectNumber)')
@@ -101,6 +107,11 @@ steps:
       - --set-env-vars=APP_ENV=production,ENABLE_SCHEDULER=false,LOG_LEVEL=INFO
       - --update-secrets=DATABASE_URL=triangle-shows-db-url:latest
       - --update-secrets=TICKETMASTER_API_KEY=triangle-shows-tm-api-key:latest
+      # Admin subsite — uncomment BOTH lines only after creating the two secrets
+      # above (see step 2). Without them the /admin login is disabled (fails closed),
+      # so leaving these commented is safe; the rest of the site is unaffected.
+      # - --update-secrets=ADMIN_PASSWORD=triangle-shows-admin-password:latest
+      # - --update-secrets=SESSION_SECRET=triangle-shows-session-secret:latest
 
 images:
   - $_REGION-docker.pkg.dev/$PROJECT_ID/$_REPO/api:$COMMIT_SHA

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -84,6 +84,20 @@ steps:
       - --min-instances=0
       - --max-instances=2
       - --timeout=300
+      # Origin gates (backend/app/tokens.py) are OFF until these env vars are set, and
+      # the boot log says which are live on every start. None of these values is a
+      # secret — a team domain, an application id, and a service-account email — so they
+      # belong here rather than in Secret Manager.
+      #
+      # Turn them on by extending the line below in place. gcloud rejects
+      # --set-env-vars alongside --update-env-vars, so append rather than adding a line:
+      #
+      #   - --set-env-vars=APP_ENV=production,ENABLE_SCHEDULER=false,LOG_LEVEL=INFO,CF_ACCESS_TEAM_DOMAIN=<team>.cloudflareaccess.com,CF_ACCESS_AUD=<aud-tag>,SCRAPE_ALLOWED_SERVICE_ACCOUNTS=<scheduler-sa-email>,SCRAPE_OIDC_AUDIENCE=<audience-on-the-scheduler-job>
+      #
+      # Enable the scrape gate first: its token already arrives, so it can be verified
+      # with nothing else in place. The /admin gate needs a Cloudflare Access application
+      # to exist first, or /admin becomes unreachable — which is safe (it fails closed)
+      # but not useful.
       - --set-env-vars=APP_ENV=production,ENABLE_SCHEDULER=false,LOG_LEVEL=INFO
       - --update-secrets=DATABASE_URL=triangle-shows-db-url:latest
       - --update-secrets=TICKETMASTER_API_KEY=triangle-shows-tm-api-key:latest

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,6 +20,10 @@ services:
       DATABASE_URL: postgresql+asyncpg://postgres:postgres@db:5432/triangle_shows
       ENABLE_SCHEDULER: "false"
       LOG_LEVEL: INFO
+      # Local-only admin credentials (the /admin subsite). Not secrets — production
+      # uses Secret Manager. Log in at http://localhost:8000/admin with this password.
+      ADMIN_PASSWORD: devpassword
+      SESSION_SECRET: local-dev-session-secret
     volumes:
       - ./backend:/app
       - ./frontend:/frontend

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,6 +14,10 @@ services:
     build:
       context: .
       dockerfile: Dockerfile
+      # Dev stage adds requirements-dev.txt (pytest), so the test suite runs in the
+      # container without a manual install after every rebuild. Cloud Build takes the
+      # untargeted default, which is the lean prod stage.
+      target: dev
     ports:
       - "8000:8000"
     environment:

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -54,7 +54,9 @@ does it instead:
 export default {
   async fetch(request) {
     const url = new URL(request.url);
-    url.hostname = 'triangle-shows-bs2va6mvba-ue.a.run.app';
+    // The hashed .run.app hostname — see "Origin hostnames" below for why it is not
+    // written out here, and how to look up the live value.
+    url.hostname = 'triangle-shows-<hash>-ue.a.run.app';
     return fetch(new Request(url.toString(), request));
   }
 }
@@ -73,25 +75,44 @@ contacted.
 
 | Domain | Type | Name | Target | Proxied |
 |---|---|---|---|---|
-| triangle-shows.net | CNAME | `@` | `triangle-shows-bs2va6mvba-ue.a.run.app` | Yes |
-| triangle-shows.net | CNAME | `www` | `triangle-shows-bs2va6mvba-ue.a.run.app` | Yes |
+| triangle-shows.net | CNAME | `@` | the hashed `.run.app` hostname | Yes |
+| triangle-shows.net | CNAME | `www` | the hashed `.run.app` hostname | Yes |
 | triangle-shows.org | A | `@` | `192.0.2.1` (dummy) | Yes |
 
 SSL mode is **Full**, with Always Use HTTPS on. Full works because the `.run.app` origin carries
 a valid Google-managed certificate.
 
-### Two Cloud Run URLs
+### Origin hostnames
 
-The service answers on both of these, and both are in active use:
+The service answers on two `.run.app` hostnames, both in active use:
 
+| Form | Used by |
+|---|---|
+| hashed — `triangle-shows-<hash>-ue.a.run.app` | Cloudflare Worker and the `.net` CNAMEs |
+| project-number — `triangle-shows-<project-number>.us-east1.run.app` | Cloud Scheduler |
+
+Cloud Run issues the project-number form for newer services and keeps the older hashed form
+working. They are the same service. This matters only when changing the hostname: the Worker
+hardcodes the hashed form, so updating one without the other breaks the site.
+
+**Both are deliberately left out of this repo, which is public.** No `--ingress` flag is set on
+the Cloud Run service, so it defaults to `ingress=all` and these hostnames reach the app directly,
+skipping Cloudflare and anything enforced there — including a Cloudflare Access policy on
+`/admin`. The `.net` CNAMEs are proxied, so the origin is not discoverable through public DNS
+either; this document was the only place it was written down.
+
+Treat that as reduced disclosure, not as protection: the origin stays directly reachable until
+ingress is restricted or the app requires a header only the Worker sets. Anything that must not be
+public needs its own authentication regardless of who knows the hostname.
+
+Look up the live values with:
+
+```bash
+gcloud run services describe triangle-shows \
+  --project=triangle-shows --region=us-east1 --format='value(status.url)'
 ```
-https://triangle-shows-bs2va6mvba-ue.a.run.app        ← Cloudflare Worker and CNAMEs
-https://triangle-shows-178508749672.us-east1.run.app  ← Cloud Scheduler
-```
 
-Cloud Run issues the second, project-number form for newer services and keeps the older hashed
-form working. They are the same service. This matters only when changing the hostname: the Worker
-hardcodes the first, so updating one without the other breaks the site.
+Both hostnames are also recorded in `_SESSION-CONTEXT.md`, which is gitignored.
 
 ## Deploy path
 

--- a/frontend/css/styles.css
+++ b/frontend/css/styles.css
@@ -901,6 +901,11 @@ a:hover { color: var(--accent-hover); text-decoration: underline; }
   font-size: 0.8rem;
   color: var(--muted);
   line-height: 1.5;
+  /* Descriptions are plain text with blank lines between paragraphs (see
+     clean_html_text in the backend) — pre-line renders those breaks instead of
+     collapsing every description into one run-on line, while still collapsing
+     ordinary runs of spaces the way normal HTML text does. */
+  white-space: pre-line;
 }
 
 /* Badges */

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -77,6 +77,15 @@
         <p class="subscribe-hint">new shows will appear automatically!</p>
       </div>
 
+      <!-- Live-music filter -->
+      <div class="filter-section">
+        <div class="filter-label">Show</div>
+        <div class="chip-group">
+          <button class="chip" id="chip-non-music" onclick="toggleNonMusic()">include non-live music</button>
+        </div>
+        <p class="subscribe-hint">karaoke, trivia, theme nights &amp; other recurring events are hidden by default</p>
+      </div>
+
       <!-- Friends & Feeds -->
       <div class="filter-section">
         <div class="filter-label">Friends &amp; Feeds</div>

--- a/frontend/js/filters.js
+++ b/frontend/js/filters.js
@@ -3,9 +3,15 @@
 // filter params are sent. Venue, city, and search filters are applied locally.
 
 let venues = [];
+
+// Persisted toggle: hide non-live-music events (karaoke, trivia, theme nights,
+// recurring series) unless the visitor opts in. Default off = filtered.
+const INCLUDE_NON_MUSIC_KEY = "triangle-shows-include-non-music";
+
 let activeFilters = {
   search: "",
   forYou: false,
+  includeNonMusic: localStorage.getItem(INCLUDE_NON_MUSIC_KEY) === "1",
 };
 
 // Cache of all events from the API (plain JS objects). Populated once on initial
@@ -170,16 +176,30 @@ function toggleForYou() {
   applyAllFilters();
 }
 
+// Toggle whether non-live-music events (karaoke/trivia/theme nights/etc.) are shown.
+// Choice is persisted so it sticks across visits. Default (chip inactive) hides them.
+function toggleNonMusic() {
+  activeFilters.includeNonMusic = !activeFilters.includeNonMusic;
+  localStorage.setItem(INCLUDE_NON_MUSIC_KEY, activeFilters.includeNonMusic ? "1" : "0");
+  const chip = document.getElementById("chip-non-music");
+  if (chip) chip.classList.toggle("active", activeFilters.includeNonMusic);
+  applyAllFilters();
+}
+
 // Generate a webcal:// subscription URL from the currently-checked venues
 // and redirect to it, triggering the native Add Subscription dialog.
 function subscribeToVenues() {
   const allCbs  = [...document.querySelectorAll(".venue-checkbox input[type=checkbox]")];
   const checked = allCbs.filter(cb => cb.checked);
-  let path = "/feeds/events.ics";
+  const params = new URLSearchParams();
   if (checked.length > 0 && checked.length < allCbs.length) {
-    path += "?venue=" + checked.map(cb => cb.dataset.venue).join(",");
+    params.set("venue", checked.map(cb => cb.dataset.venue).join(","));
   }
-  window.location.href = `webcal://${window.location.host}${path}`;
+  // Match the feed to what the visitor is viewing: if they've opted into
+  // non-live-music events, include them in the subscription too.
+  if (activeFilters.includeNonMusic) params.set("include_non_music", "1");
+  const qs = params.toString();
+  window.location.href = `webcal://${window.location.host}/feeds/events.ics${qs ? "?" + qs : ""}`;
 }
 
 // Returns true if an event should be visible given the current filter state.
@@ -191,6 +211,11 @@ function _checkEventVisible(ev, venueMap) {
   // the locked city. Non-locked-city venues have no sidebar checkbox, so they
   // wouldn't be in venueMap and would otherwise pass through unchecked.
   if (SITE_CONFIG.city && props.venue_city !== SITE_CONFIG.city) return false;
+
+  // Non-live-music events (karaoke, trivia, theme nights, recurring series) are
+  // hidden unless the visitor opts in via the toggle. Only an explicit `false`
+  // hides — missing/true always shows, so unclassified data is never dropped.
+  if (!activeFilters.includeNonMusic && props.is_live_music === false) return false;
 
   // "For you" mode: show only Spotify-matched events, ignoring venue filters.
   if (activeFilters.forYou) {
@@ -389,6 +414,13 @@ function toggleSidebar() {
   sidebar.classList.toggle("open");
   if (backdrop) backdrop.classList.toggle("active");
 }
+
+// Reflect the persisted non-live-music toggle state on the (static) chip.
+// Scripts load with `defer`, so the DOM is ready when this runs.
+(function initNonMusicChip() {
+  const chip = document.getElementById("chip-non-music");
+  if (chip) chip.classList.toggle("active", activeFilters.includeNonMusic);
+})();
 
 // Initialize
 loadVenues();

--- a/tools/wait_for_deploy.py
+++ b/tools/wait_for_deploy.py
@@ -1,11 +1,17 @@
 #!/usr/bin/env python3
 """
-Polls /api/health until the deployed git SHA matches the local HEAD commit.
+Polls /api/health until the deployed git SHA matches origin/prod's tip commit.
 
-Role: Developer utility — run manually after pushing to confirm a Cloud Run deploy
-has gone live. Not part of the runtime scrape or serving path.
-Requires: git available on PATH; network access to the deployed app's /api/health
-endpoint (which returns a JSON body with a "version" field set to the deployed SHA).
+Role: Developer utility — run manually after promoting main to prod to confirm the
+Cloud Run deploy has gone live. Not part of the runtime scrape or serving path.
+Requires: git available on PATH, run from inside a clone with a reachable 'origin'
+remote; network access to the deployed app's /api/health endpoint (which returns a
+JSON body with a "version" field set to the deployed SHA).
+
+The target is origin/prod's tip, fetched fresh on every run — not local HEAD. A
+promotion PR merges with a real merge commit rather than fast-forwarding, so prod's
+tip is a commit that never existed on main and a local checkout's HEAD (wherever it
+happens to be checked out) has no reliable relationship to what actually shipped.
 
 Usage:
     python tools/wait_for_deploy.py
@@ -13,7 +19,7 @@ Usage:
     python tools/wait_for_deploy.py --interval 15
     python tools/wait_for_deploy.py --timeout 300   # give up sooner
 
-Exits 0 when the deployed SHA matches local HEAD, 1 if the timeout passes first.
+Exits 0 when the deployed SHA matches origin/prod, 1 if the timeout passes first.
 """
 
 # --- Imports ---
@@ -40,16 +46,25 @@ USER_AGENT = "triangle-shows-deploy-watcher/1.0 (+https://github.com/triangle-sh
 
 # --- Helpers ---
 
-def get_local_sha():
-    """Return the full SHA of the local HEAD commit."""
+def get_prod_sha():
+    """Fetch origin/prod and return the full SHA of its current tip.
+
+    Fetches first rather than trusting whatever origin/prod the local repo already
+    has cached — this is meant to be run right after a promotion, so a stale local
+    view of prod would silently wait for the wrong commit.
+    """
     try:
+        subprocess.run(
+            ["git", "fetch", "origin", "prod"],
+            capture_output=True, text=True, check=True
+        )
         result = subprocess.run(
-            ["git", "rev-parse", "HEAD"],
+            ["git", "rev-parse", "origin/prod"],
             capture_output=True, text=True, check=True
         )
         return result.stdout.strip()
     except Exception as e:
-        print(f"ERROR: Could not get local git SHA: {e}", file=sys.stderr)
+        print(f"ERROR: Could not resolve origin/prod: {e}", file=sys.stderr)
         sys.exit(1)
 
 
@@ -84,18 +99,18 @@ def get_deployed_version(url):
 # --- Main ---
 
 def main():
-    parser = argparse.ArgumentParser(description="Poll until deployed version matches local HEAD")
+    parser = argparse.ArgumentParser(description="Poll until deployed version matches origin/prod")
     parser.add_argument("--url", default=BASE_URL, help=f"Base URL (default: {BASE_URL})")
     parser.add_argument("--interval", type=int, default=DEFAULT_INTERVAL, help=f"Poll interval in seconds (default: {DEFAULT_INTERVAL})")
     parser.add_argument("--timeout", type=int, default=DEFAULT_TIMEOUT, help=f"Give up after this many seconds (default: {DEFAULT_TIMEOUT})")
     args = parser.parse_args()
 
-    local_sha = get_local_sha()
-    short = local_sha[:7]  # abbreviated SHA for display
+    target_sha = get_prod_sha()
+    short = target_sha[:7]  # abbreviated SHA for display
 
     # flush on every print: stdout is block-buffered when redirected to a file,
     # so without this a backgrounded run shows no output until it exits.
-    print(f"Waiting for deploy of {short} to {args.url}", flush=True)
+    print(f"Waiting for deploy of {short} (origin/prod) to {args.url}", flush=True)
     print(f"Polling every {args.interval}s, giving up after {args.timeout}s — Ctrl+C to cancel\n", flush=True)
 
     start = datetime.now()
@@ -106,7 +121,7 @@ def main():
         ts = datetime.now().strftime("%H:%M:%S")
 
         # Compare with startswith in both directions to handle full vs. short SHA mismatches
-        if deployed.startswith(local_sha) or local_sha.startswith(deployed):
+        if deployed.startswith(target_sha) or target_sha.startswith(deployed):
             print(f"[{ts}] DEPLOYED  version={deployed[:7]}  ({elapsed:.0f}s)", flush=True)
             return 0
 


### PR DESCRIPTION
**Promotion 1 of 2.** Code only — `cloudbuild.yaml` is deliberately untouched, so both origin gates deploy **inert** and behavior is unchanged apart from the features below. Enabling them is a separate one-line promotion afterward, so that if `/api/scrape` breaks the cause is unambiguous.

Prod is 36 commits behind at `4e05d81`. **47 files, +5315/-182, and three unrun migrations.**

## What's shipping

| PR | Change |
|---|---|
| [#34](https://github.com/triangle-shows/triangle-shows/pull/34) | Motorco titles no longer truncate at an escaped apostrophe (61 of 625 affected) |
| [#48](https://github.com/triangle-shows/triangle-shows/pull/48) | Squarespace events with empty descriptions stop being dropped; MEC/Squarespace descriptions render as readable text |
| [#51](https://github.com/triangle-shows/triangle-shows/pull/51) | Events matched by venue ID before title hash; listings a source drops are reconciled away |
| [#52](https://github.com/triangle-shows/triangle-shows/pull/52) | `conftest.py` for the test suite's `app` import |
| [#53](https://github.com/triangle-shows/triangle-shows/pull/53) | Cloud Run origin hostnames removed from `docs/ARCHITECTURE.md` |
| [#54](https://github.com/triangle-shows/triangle-shows/pull/54) | Token verification for `/admin` (Cloudflare Access) and `POST /api/scrape` (Google OIDC) — **inert until configured** |
| [#55](https://github.com/triangle-shows/triangle-shows/pull/55) | Credentials no longer allowed on cross-origin requests |
| [#57](https://github.com/triangle-shows/triangle-shows/pull/57) | CI runs on every PR, not only those targeting main/prod |
| [#36](https://github.com/triangle-shows/triangle-shows/pull/36) + [#56](https://github.com/triangle-shows/triangle-shows/pull/56) | Live-music filter: classifier, admin subsite, series overrides, review-item fixes |

## Migrations — first run against real data

Prod is at `0002`. These three run in the FastAPI startup handler on first boot:

- **`0003`** — adds `is_live_music`, `is_manual_override`, `classification_reason` to `events`, plus an index
- **`0004`** — creates `series_overrides`
- **`0005`** — adds `events.approved_at`, plus an index

All additive. `0003` adds its `NOT NULL` columns with a `server_default` and drops the default afterward, so existing rows backfill without a table rewrite — catalog-only on modern Postgres, no rewrite on Neon.

**This is the first real exercise of #7's advisory lock.** With `max-instances=2`, two containers can boot together and both run `upgrade head`; `pg_advisory_xact_lock` is what makes the loser wait and then correctly no-op. Reproduced failing before the fix, passing after, with two and three racers — but never yet in production.

## User-visible changes to eyeball

- **The live-music filter goes live.** Events classified non-live disappear from the default calendar, with a toggle to show them. This is the headline change and the one most worth checking against the real calendar.
- **The dedup reconcile can now delete rows.** Bounded to future dates inside the scraped window, and skipped when orphans exceed both 4 and 50% of the venue's rows — but this is its first run against production data.
- **`/api/events` now defaults to live-music only** (`?include_non_music=1` to opt in), matching the iCal feed.
- **`/admin` exists but fails closed** — `ADMIN_PASSWORD` is still commented out, so `_admin_enabled()` returns False. Expected; it becomes usable only after Cloudflare Access is configured and the secrets are created.

## Expected boot log

Both gates should report themselves off. If they don't say this, something is misconfigured:

```
[tokens] /admin: Cloudflare Access NOT enforced (...)
[tokens] POST /api/scrape: NOT enforced (SCRAPE_ALLOWED_SERVICE_ACCOUNTS is empty)
```

## Verifying

`/api/health` reports the deployed SHA and queries the database, so a 200 proves app and Neon both. `tools/wait_for_deploy.py` polls it against `origin/prod`. A container failing migrations never becomes healthy, so a stalled deploy is the signal to look at logs.

## Worth doing first

`CONTRIBUTING.md` recommends rehearsing non-trivial migrations on a Neon branch — copy-on-write, cheap, discard after. With three unrun migrations against a single shared database and no staging copy, that seems worth the ten minutes before merging this.

## Not in this release

- **#8** — admin secrets stay commented out
- **#10** — no rate limiting on `/admin/login`
- Enabling either origin gate

🤖 Generated with [Claude Code](https://claude.com/claude-code)