### PR TITLE
Stop detached scrape task and improve observability of results

### DIFF
--- a/backend/app/api/health.py
+++ b/backend/app/api/health.py
@@ -38,9 +38,14 @@ router = APIRouter(prefix="/api/health", tags=["health"])
 
 # --- Endpoint ---
 
-@router.get("", response_model=HealthResponse)
+@router.api_route("", methods=["GET", "HEAD"], response_model=HealthResponse)
 async def health_check(response: Response, session: AsyncSession = Depends(get_session)):
     """Health check with event count and last scrape info.
+
+    HEAD is accepted as well as GET because UptimeRobot sends HEAD, and a GET-only route
+    answers that with 404 — so the uptime monitor was recording a failure on every check
+    against a perfectly healthy service. Starlette discards the body for a HEAD request,
+    so the status code still reflects the staleness logic below.
 
     Reports 503 with status="stale" when the most recent successful scrape is older
     than STALE_AFTER. Freshness is only enforced in production: CI and local runs

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -59,10 +59,14 @@ async def _startup_scrape():
             results = await manager.scrape_all()
             for r in results:
                 logger.info(f"  [startup] {r}")
+            logger.info(f"Startup scrape: reclassify {manager.last_reclassify}")
         logger.info("Startup scrape: complete")
     except Exception as e:
-        # Non-fatal: the API should still serve cached data even if the scrape fails
-        logger.warning(f"Startup scrape failed: {e}")
+        # Non-fatal: the API should still serve cached data even if the scrape fails.
+        # ERROR with a traceback, not a bare WARNING: this handler swallows every failure
+        # in the scrape and reclassify path, so without the traceback the only signal that
+        # anything went wrong was a one-line message with no stack.
+        logger.error(f"Startup scrape failed: {e}", exc_info=True)
 
 
 # --- Lifespan (startup / shutdown) ---
@@ -242,7 +246,11 @@ async def trigger_scrape(
                 results = await manager.scrape_all(scraper_types=[scraper_type])
             else:
                 results = await manager.scrape_all()
-            return {"results": results}
+            # Report the reclassify pass alongside the per-venue results. A caller that
+            # triggers a scrape by hand can then see whether the classifier actually did
+            # anything, instead of having to find a log line — which is how a pass that
+            # classified nothing went unnoticed through a whole release.
+            return {"results": results, "reclassified": manager.last_reclassify}
     except Exception as e:
         logger.error(f"[trigger_scrape] Unhandled error: {e}", exc_info=True)
         raise HTTPException(status_code=500, detail=str(e))

--- a/backend/app/scrapers/manager.py
+++ b/backend/app/scrapers/manager.py
@@ -186,6 +186,11 @@ class ScrapeManager:
 
     def __init__(self, session: AsyncSession):
         self.session = session
+        # Result of the reclassify pass at the end of the last bulk scrape, so a caller
+        # can report what the classifier actually did. Without this, the only record was
+        # a log line — and Cloud Run drops stdout from work that runs outside a request,
+        # which is exactly how a reclassify pass silently doing nothing went unnoticed.
+        self.last_reclassify: Optional[dict] = None
 
     def _get_scraper(self, venue: Venue) -> Optional[BaseScraper]:
         """Instantiate the correct scraper for a venue."""
@@ -491,7 +496,7 @@ class ScrapeManager:
             results.append(r)
 
         # Recompute live-music flags across all upcoming events now that new data is in.
-        await self.reclassify_all()
+        self.last_reclassify = await self.reclassify_all()
 
         return results
 
@@ -511,6 +516,6 @@ class ScrapeManager:
             results.append(r)
 
         # Recompute live-music flags across all upcoming events now that new data is in.
-        await self.reclassify_all()
+        self.last_reclassify = await self.reclassify_all()
 
         return results

--- a/backend/tests/test_scrape_observability.py
+++ b/backend/tests/test_scrape_observability.py
@@ -1,0 +1,83 @@
+"""
+Tests for the observability gaps that let a broken release look healthy.
+
+Background. The 2026-08-27 release shipped the live-music filter classifying nothing, and
+it took manual API probing to notice, because every signal that would have shown it was
+either absent or unreadable:
+
+  * the reclassify pass reported itself only to stdout, and the work ran in a detached
+    asyncio task that Cloud Run starves of CPU once startup finishes, so nothing was
+    flushed — the whole scrape produced zero log lines
+  * _startup_scrape() caught every exception into a one-line WARNING with no traceback
+  * POST /api/scrape returned per-venue counts and said nothing about classification
+
+These assertions cover the parts reachable without a database. The route and manager
+contracts are what a caller depends on; the Cloud Run CPU behavior is not testable here
+and is addressed in cloudbuild.yaml instead.
+"""
+
+from fastapi.routing import APIRoute
+
+import pytest
+
+from app.main import app
+from app.scrapers.manager import ScrapeManager
+
+
+def _route(path: str) -> APIRoute:
+    for r in app.routes:
+        if isinstance(r, APIRoute) and r.path == path:
+            return r
+    raise AssertionError(f"no route for {path}")
+
+
+class TestHealthAcceptsHead:
+    """UptimeRobot sends HEAD. A GET-only route answers 404, so the monitor was recording
+    a failure on every check against a healthy service — verified against production logs.
+    """
+
+    def test_head_is_accepted(self):
+        assert "HEAD" in _route("/api/health").methods
+
+    def test_get_still_works(self):
+        assert "GET" in _route("/api/health").methods
+
+    def test_no_other_method_was_opened_up(self):
+        """Widening to HEAD must not have widened to writes."""
+        assert _route("/api/health").methods <= {"GET", "HEAD"}
+
+
+class TestScrapeReportsReclassification:
+    def test_a_fresh_manager_has_no_reclassify_result(self):
+        """None rather than an empty dict, so "did not run" is distinguishable from
+        "ran and changed nothing" — the exact distinction that was unavailable while
+        diagnosing the release."""
+        assert ScrapeManager(session=None).last_reclassify is None
+
+    def test_the_attribute_exists_before_any_scrape(self):
+        """The endpoint reads it unconditionally; if it were only set inside scrape_all,
+        an early failure would turn a useful response into an AttributeError."""
+        assert hasattr(ScrapeManager(session=None), "last_reclassify")
+
+
+class TestStartupScrapeLogsFailuresLoudly:
+    """The handler swallows every failure in the scrape and reclassify path, so what it
+    logs is the only evidence that anything went wrong."""
+
+    @pytest.fixture
+    def source(self):
+        import inspect
+
+        from app import main
+
+        return inspect.getsource(main._startup_scrape)
+
+    def test_failures_are_logged_at_error(self, source):
+        assert "logger.error" in source
+        assert "logger.warning" not in source
+
+    def test_the_traceback_is_included(self, source):
+        assert "exc_info=True" in source
+
+    def test_the_reclassify_result_is_logged(self, source):
+        assert "last_reclassify" in source

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -104,7 +104,19 @@ steps:
       # with nothing else in place. The /admin gate needs a Cloudflare Access application
       # to exist first, or /admin becomes unreachable — which is safe (it fails closed)
       # but not useful.
-      - --set-env-vars=APP_ENV=production,ENABLE_SCHEDULER=false,LOG_LEVEL=INFO
+      # ENABLE_STARTUP_SCRAPE=false because the on-boot scrape cannot work reliably here.
+      # It runs as a detached asyncio task, and this service has no CPU-throttling
+      # override, so Cloud Run allocates CPU only while a request is in flight. The task
+      # is therefore starved the moment startup finishes: on the 2026-08-27 release it
+      # deleted ~98 rows in dribs over five minutes as health checks briefly granted CPU,
+      # never reached the reclassify pass at the end, and emitted no stdout at all — so
+      # the live-music filter shipped classifying nothing, and there were no logs to say
+      # so. Cloud Scheduler already calls POST /api/scrape every 6 hours, inside a real
+      # request where CPU is allocated, which is where a scrape belongs.
+      #
+      # The alternative is --no-cpu-throttling, which keeps CPU allocated on idle
+      # instances and costs more for work the scheduler already does deterministically.
+      - --set-env-vars=APP_ENV=production,ENABLE_SCHEDULER=false,LOG_LEVEL=INFO,ENABLE_STARTUP_SCRAPE=false
       - --update-secrets=DATABASE_URL=triangle-shows-db-url:latest
       - --update-secrets=TICKETMASTER_API_KEY=triangle-shows-tm-api-key:latest
       # Admin subsite — uncomment BOTH lines only after creating the two secrets


### PR DESCRIPTION
This pull request addresses critical observability gaps that previously allowed a broken release to go unnoticed, especially around the live-music filter's classification step. The changes improve error visibility, ensure important classification results are reported, and update deployment configuration to avoid unreliable startup behavior. Comprehensive tests are also added to prevent regressions in observability.

**Observability and Error Reporting Improvements:**

* The `ScrapeManager` class now stores the result of the last reclassification pass in a new attribute `last_reclassify`, making it possible to report what the classifier actually did, instead of relying solely on log lines that might be lost in detached tasks. [[1]](diffhunk://#diff-070c2fa77803ff5745a59ec74aff3cd5a3272472eb12ff55c1e7475362a66496R189-R193) [[2]](diffhunk://#diff-070c2fa77803ff5745a59ec74aff3cd5a3272472eb12ff55c1e7475362a66496L494-R499) [[3]](diffhunk://#diff-070c2fa77803ff5745a59ec74aff3cd5a3272472eb12ff55c1e7475362a66496L514-R519)
* The `/api/scrape` endpoint now includes the `reclassified` result in its response, so callers can see if the classifier ran and what it did, improving transparency and diagnosability.
* The startup scrape error handler now logs failures at the ERROR level with full tracebacks, instead of a one-line WARNING, making it easier to diagnose issues that occur during startup.

**API and Deployment Adjustments:**

* The `/api/health` endpoint now accepts both GET and HEAD requests, ensuring uptime monitors like UptimeRobot do not record false failures, while still restricting to safe methods.
* The deployment configuration disables the unreliable on-boot scrape by setting `ENABLE_STARTUP_SCRAPE=false`, preventing silent failures due to Cloud Run's CPU throttling and relying on scheduled scrapes instead.

**Testing and Regression Prevention:**

* New tests in `test_scrape_observability.py` verify that critical observability features are present, including HEAD acceptance on `/api/health`, correct reporting of reclassification, and proper error logging with tracebacks for startup scrapes.