### PR TITLE
Add dry-run tool for merging duplicate past events

### DIFF
--- a/backend/tests/test_dedupe_past_events.py
+++ b/backend/tests/test_dedupe_past_events.py
@@ -111,30 +111,67 @@ class TestRealDuplicates:
         assert len(groups[0]) == 3
 
 
-class TestEarlyAndLateShowsStaySeparate:
-    """Real pair at venue 10 on 2026-07-07, and the reason the rule changed.
+class TestASessionLabelIsNotDecisiveOnItsOwn:
+    """The clock decides, not the label — and this rule changed twice.
 
-    The first version stripped every bracketed token, which turned '[LATE] Sub Rosa' and
-    'Sub Rosa' into the same string — two performances on one night, one of which would
-    have been deleted. Found by dry-running against production, not by reasoning.
+    v1 stripped every bracketed token, so '[LATE] Sub Rosa' and 'Sub Rosa' normalized
+    identically. v2 treated a differing session label as proof of two performances, which
+    refused to merge them. Both were wrong, and the production rows say why: the pair has
+    identical doors (22:00), start (22:00) and price (18.0), and both rows were inserted
+    by one scrape batch nine microseconds apart. It is one show listed twice.
+
+    A real double bill has two start times, so that is what the rule tests.
     """
 
-    def test_a_late_show_is_not_merged_with_the_early_one(self):
-        rows = [row(3072, "Sub Rosa", venue_id=10, day="2026-07-07"),
-                row(3073, "[LATE] Sub Rosa", venue_id=10, day="2026-07-07")]
+    def test_the_real_sub_rosa_pair_merges(self):
+        rows = [
+            row(3072, "Sub Rosa", venue_id=10, day="2026-07-07",
+                doors_time="22:00:00", show_time="22:00:00", price_min=18.0),
+            row(3073, "[LATE] Sub Rosa", venue_id=10, day="2026-07-07",
+                doors_time="22:00:00", show_time="22:00:00", price_min=18.0),
+        ]
+        groups, _ = tool.find_groups(rows)
+        assert len(groups) == 1 and len(groups[0]) == 2
+
+    def test_the_real_away_with_words_pair_merges(self):
+        rows = [
+            row(2763, "away with words", venue_id=10, day="2026-07-07",
+                doors_time="19:00:00", show_time="19:30:00", price_min=13.0),
+            row(3103, "[Early] away with words", venue_id=10, day="2026-07-07",
+                doors_time="19:00:00", show_time="19:30:00", price_min=13.0),
+        ]
+        groups, _ = tool.find_groups(rows)
+        assert len(groups) == 1 and len(groups[0]) == 2
+
+    def test_a_genuine_double_bill_stays_separate(self):
+        """Different start times, so these really are two performances."""
+        rows = [
+            row(1, "Branford Marsalis (Early)", show_time="19:00:00"),
+            row(2, "Branford Marsalis (Late)", show_time="22:00:00"),
+        ]
         groups, _ = tool.find_groups(rows)
         assert groups == []
 
-    def test_an_early_marker_also_separates(self):
-        rows = [row(2763, "away with words", venue_id=10, day="2026-07-07"),
-                row(3103, "[Early] away with words", venue_id=10, day="2026-07-07")]
+    def test_doors_time_is_used_when_show_time_is_missing(self):
+        rows = [
+            row(1, "Branford Marsalis (Early)", doors_time="18:30:00"),
+            row(2, "Branford Marsalis (Late)", doors_time="21:30:00"),
+        ]
         groups, _ = tool.find_groups(rows)
         assert groups == []
 
-    def test_two_late_shows_still_merge(self):
-        """Compared as sets, so a marker shared by both rows is not a distinction — and a
-        band with 'Late' in its name is not accidentally protected from deduping."""
-        rows = [row(1, "[LATE] Sub Rosa"), row(2, "[LATE] Sub Rosa w/ Guest")]
+    def test_missing_times_fall_back_to_merging(self):
+        """Nothing to compare, and one relabeled listing is likelier than two shows. The
+        dry run is what puts this in front of a person."""
+        rows = [row(1, "Sub Rosa"), row(2, "[LATE] Sub Rosa")]
+        groups, _ = tool.find_groups(rows)
+        assert len(groups) == 1
+
+    def test_matching_labels_never_conflict(self):
+        rows = [
+            row(1, "[LATE] Sub Rosa", show_time="22:00:00"),
+            row(2, "[LATE] Sub Rosa w/ Guest", show_time="23:00:00"),
+        ]
         groups, _ = tool.find_groups(rows)
         assert len(groups) == 1
 
@@ -142,11 +179,6 @@ class TestEarlyAndLateShowsStaySeparate:
         rows = [row(1, "Late Night Drive Home"), row(2, "Late Night Drive Home w/ Support")]
         groups, _ = tool.find_groups(rows)
         assert len(groups) == 1
-
-    def test_set_numbers_separate(self):
-        rows = [row(1, "Branford Marsalis (1st Set)"), row(2, "Branford Marsalis (2nd Set)")]
-        groups, _ = tool.find_groups(rows)
-        assert groups == []
 
 
 class TestStatusMarkersAreStillStripped:

--- a/backend/tests/test_dedupe_past_events.py
+++ b/backend/tests/test_dedupe_past_events.py
@@ -1,0 +1,292 @@
+"""
+Tests for tools/dedupe_past_events.py — the matching and survivor rules.
+
+This tool deletes rows from the production database, and its matching rule is fuzzy by
+necessity, so the rule is worth pinning down. Every fixture below is a real pair or triple
+observed in production between 2026-08-01 and 2026-08-12, plus the near-miss cases the
+containment rule has to *not* match.
+
+Only the pure functions are exercised — clustering and ranking. Nothing here connects to a
+database; the SQL path stays behind --apply and a dry run.
+"""
+
+import importlib.util
+import pathlib
+from datetime import date, datetime
+
+import pytest
+
+
+def _load_tool():
+    path = pathlib.Path(__file__).resolve().parent.parent.parent / "tools" / "dedupe_past_events.py"
+    spec = importlib.util.spec_from_file_location("dedupe_past_events", path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+tool = _load_tool()
+
+
+def row(id, name, venue_id=1, day="2026-08-03", **kw):
+    base = {
+        "id": id,
+        "venue_id": venue_id,
+        "name": name,
+        "date": date.fromisoformat(day),
+        "status": kw.pop("status", "onsale"),
+        "is_live_music": kw.pop("is_live_music", True),
+        "is_manual_override": kw.pop("is_manual_override", False),
+        "updated_at": kw.pop("updated_at", None),
+    }
+    for field in tool.MERGEABLE_FIELDS:
+        base[field] = None
+    base.update(kw)
+    return base
+
+
+# --- normalize ---
+
+class TestNormalize:
+    def test_punctuation_and_case_are_dropped(self):
+        assert tool.normalize("The Briefs w/ Paint Fumes") == "thebriefswpaintfumes"
+
+    def test_a_bracketed_status_marker_is_stripped(self):
+        """The case that rules out prefix matching: the marker sits at the front."""
+        assert tool.normalize("[CANCELLED] The Philharmonik") == "thephilharmonik"
+
+    def test_a_parenthesised_aside_is_kept(self):
+        """Not stripped — only known status markers are. Deliberately conservative after
+        blanket stripping merged an early show with a late one."""
+        assert tool.normalize("Verse Versus Launch Party (subscribe!)") == (
+            "verseversuslaunchpartysubscribe"
+        )
+
+    def test_an_aside_still_merges_through_containment(self):
+        """The real pour-house pair. Keeping the aside costs nothing here, because the
+        shorter name is still contained in the longer one."""
+        rows = [
+            row(3135, "Verse Versus Launch Party (subscribe to their newsletter)"),
+            row(3287, "Verse Versus Launch Party"),
+        ]
+        groups, _ = tool.find_groups(rows)
+        assert len(groups) == 1 and len(groups[0]) == 2
+
+    def test_none_and_empty_are_safe(self):
+        assert tool.normalize(None) == ""
+        assert tool.normalize("") == ""
+
+
+# --- clustering, against real production duplicates ---
+
+class TestRealDuplicates:
+    def test_a_support_act_added_to_the_title(self):
+        rows = [row(2167, "Slow Joy"), row(2946, "Slow Joy with Bike Routes and Growing Pains")]
+        groups, _ = tool.find_groups(rows)
+        assert len(groups) == 1 and len(groups[0]) == 2
+
+    def test_a_cancelled_marker_added_to_the_title(self):
+        rows = [
+            row(2753, "The Philharmonik & Wyatt Waddell"),
+            row(3530, "[CANCELLED] The Philharmonik & Wyatt Waddell"),
+        ]
+        groups, _ = tool.find_groups(rows)
+        assert len(groups) == 1 and len(groups[0]) == 2
+
+    def test_a_subtitle_added_to_the_title(self):
+        rows = [row(708, "Derek Hough"), row(159, "Derek Hough - Symphony of Dance: Encore")]
+        groups, _ = tool.find_groups(rows)
+        assert len(groups) == 1 and len(groups[0]) == 2
+
+    def test_a_three_way_group_collapses_into_one(self):
+        """Real pour-house case. Two overlapping pairs would double-count and pick two
+        survivors, so the clustering has to be transitive."""
+        rows = [
+            row(2924, "The Briefs"),
+            row(2931, "The Briefs w/ The Sleevens, Paint Fumes"),
+            row(2928, "The Briefs w/ Paint Fumes"),
+        ]
+        groups, _ = tool.find_groups(rows)
+        assert len(groups) == 1
+        assert len(groups[0]) == 3
+
+
+class TestEarlyAndLateShowsStaySeparate:
+    """Real pair at venue 10 on 2026-07-07, and the reason the rule changed.
+
+    The first version stripped every bracketed token, which turned '[LATE] Sub Rosa' and
+    'Sub Rosa' into the same string — two performances on one night, one of which would
+    have been deleted. Found by dry-running against production, not by reasoning.
+    """
+
+    def test_a_late_show_is_not_merged_with_the_early_one(self):
+        rows = [row(3072, "Sub Rosa", venue_id=10, day="2026-07-07"),
+                row(3073, "[LATE] Sub Rosa", venue_id=10, day="2026-07-07")]
+        groups, _ = tool.find_groups(rows)
+        assert groups == []
+
+    def test_an_early_marker_also_separates(self):
+        rows = [row(2763, "away with words", venue_id=10, day="2026-07-07"),
+                row(3103, "[Early] away with words", venue_id=10, day="2026-07-07")]
+        groups, _ = tool.find_groups(rows)
+        assert groups == []
+
+    def test_two_late_shows_still_merge(self):
+        """Compared as sets, so a marker shared by both rows is not a distinction — and a
+        band with 'Late' in its name is not accidentally protected from deduping."""
+        rows = [row(1, "[LATE] Sub Rosa"), row(2, "[LATE] Sub Rosa w/ Guest")]
+        groups, _ = tool.find_groups(rows)
+        assert len(groups) == 1
+
+    def test_a_band_name_containing_late_is_unaffected(self):
+        rows = [row(1, "Late Night Drive Home"), row(2, "Late Night Drive Home w/ Support")]
+        groups, _ = tool.find_groups(rows)
+        assert len(groups) == 1
+
+    def test_set_numbers_separate(self):
+        rows = [row(1, "Branford Marsalis (1st Set)"), row(2, "Branford Marsalis (2nd Set)")]
+        groups, _ = tool.find_groups(rows)
+        assert groups == []
+
+
+class TestStatusMarkersAreStillStripped:
+    def test_only_known_status_markers_are_removed(self):
+        assert tool.normalize("[CANCELLED] The Philharmonik") == "thephilharmonik"
+        assert tool.normalize("(SOLD OUT) (18+) Bedroom Division") == "bedroomdivision"
+
+    def test_an_unknown_bracketed_token_is_kept(self):
+        """The conservative direction: an unrecognised marker stays part of the name, so
+        two rows differing only by it are left alone rather than merged."""
+        assert "tour" in tool.normalize("Some Band [Tour Debut]")
+
+
+class TestCancellationWinsTheSurvivorChoice:
+    """A cancelled row is the newer information about the show. If the on-sale row
+    survived, the calendar would keep advertising a show that is not happening."""
+
+    def test_a_cancelled_title_beats_an_on_sale_one(self):
+        cancelled = row(3530, "[CANCELLED] The Philharmonik & Wyatt Waddell")
+        on_sale = row(2753, "The Philharmonik & Wyatt Waddell", image_url="x", ticket_url="y")
+        assert sorted([cancelled, on_sale], key=tool.rank, reverse=True)[0]["id"] == 3530
+
+    def test_a_cancelled_status_column_also_counts(self):
+        cancelled = row(1, "Short", status="cancelled")
+        on_sale = row(2, "Much Longer Title Here", image_url="x")
+        assert sorted([cancelled, on_sale], key=tool.rank, reverse=True)[0]["id"] == 1
+
+    def test_an_admin_override_still_outranks_a_cancellation(self):
+        hand_set = row(1, "Show", is_manual_override=True)
+        cancelled = row(2, "[CANCELLED] Show")
+        assert sorted([hand_set, cancelled], key=tool.rank, reverse=True)[0]["id"] == 1
+
+    def test_is_cancelled_recognises_both_spellings(self):
+        assert tool.is_cancelled(row(1, "[CANCELED] X")) is True
+        assert tool.is_cancelled(row(1, "[CANCELLED] X")) is True
+        assert tool.is_cancelled(row(1, "[POSTPONED] X")) is True
+        assert tool.is_cancelled(row(1, "Ordinary Show")) is False
+
+
+# --- what must NOT be merged ---
+
+class TestNonDuplicates:
+    def test_different_venues_never_group(self):
+        """Two venues booking the same artist on one night is a moved or miscopied show,
+        not a duplicate — the mistake #51 removed from the display-time guard."""
+        rows = [row(1, "Slow Joy", venue_id=1), row(2, "Slow Joy", venue_id=2)]
+        groups, _ = tool.find_groups(rows)
+        assert groups == []
+
+    def test_different_dates_never_group(self):
+        rows = [row(1, "Slow Joy", day="2026-08-03"), row(2, "Slow Joy", day="2026-08-04")]
+        groups, _ = tool.find_groups(rows)
+        assert groups == []
+
+    def test_unrelated_names_at_one_venue_and_date_do_not_group(self):
+        rows = [
+            row(3287, "Verse Versus Launch Party"),
+            row(3338, "(Record Shop) Ariana Grande Listening Party"),
+        ]
+        groups, _ = tool.find_groups(rows)
+        assert groups == []
+
+    def test_a_short_generic_name_is_refused_and_reported(self):
+        """'dj' is contained in half a venue's calendar. Below the length floor the pair is
+        skipped and surfaced, rather than silently merged or silently dropped."""
+        rows = [row(1, "DJ"), row(2, "DJ Shadow and Friends Live")]
+        groups, skipped = tool.find_groups(rows)
+        assert groups == []
+        assert len(skipped) == 1
+
+    def test_the_length_floor_is_adjustable(self):
+        rows = [row(1, "DJ"), row(2, "DJ Shadow and Friends Live")]
+        groups, _ = tool.find_groups(rows, min_length=2)
+        assert len(groups) == 1
+
+
+# --- survivor choice ---
+
+class TestRank:
+    def _survivor(self, rows):
+        return sorted(rows, key=tool.rank, reverse=True)[0]
+
+    def test_an_admin_override_wins(self):
+        hand_set = row(1, "Slow Joy", is_manual_override=True, is_live_music=False)
+        auto = row(2, "Slow Joy with Bike Routes", image_url="x", ticket_url="y")
+        assert self._survivor([hand_set, auto])["id"] == 1
+
+    def test_the_visible_copy_beats_the_hidden_one(self):
+        hidden = row(1, "Slow Joy with Bike Routes", is_live_music=False, image_url="x")
+        visible = row(2, "Slow Joy", is_live_music=True)
+        assert self._survivor([hidden, visible])["id"] == 2
+
+    def test_richer_metadata_wins_between_equal_verdicts(self):
+        sparse = row(1, "Slow Joy")
+        rich = row(2, "Slow Joy", image_url="x", ticket_url="y", price_min=10.0)
+        assert self._survivor([sparse, rich])["id"] == 2
+
+    def test_the_fuller_title_breaks_a_metadata_tie(self):
+        """'The Briefs w/ Paint Fumes' is the more useful listing than 'The Briefs'."""
+        short = row(1, "The Briefs")
+        long = row(2, "The Briefs w/ The Sleevens, Paint Fumes")
+        assert self._survivor([short, long])["id"] == 2
+
+    def test_recency_breaks_a_tie_on_title_length(self):
+        older = row(1, "Slow Joy", updated_at=datetime(2026, 1, 1))
+        newer = row(2, "Slow Joy", updated_at=datetime(2026, 6, 1))
+        assert self._survivor([older, newer])["id"] == 2
+
+    def test_a_missing_updated_at_does_not_raise(self):
+        assert self._survivor([row(1, "Slow Joy"), row(2, "Slow Joy")])["id"] == 2
+
+    def test_the_order_rows_arrive_in_does_not_matter(self):
+        a = row(1, "The Briefs")
+        b = row(2, "The Briefs w/ Paint Fumes")
+        assert self._survivor([a, b])["id"] == self._survivor([b, a])["id"]
+
+
+# --- URL handling ---
+
+class TestUrlRewrite:
+    def test_the_asyncpg_driver_is_stripped(self):
+        assert tool.to_psycopg_url(
+            "postgresql+asyncpg://u:p@host/db"
+        ) == "postgresql://u:p@host/db"
+
+    def test_a_plain_url_is_unchanged(self):
+        assert tool.to_psycopg_url("postgresql://u:p@host/db") == "postgresql://u:p@host/db"
+
+
+# --- fields that must never be rewritten ---
+
+class TestMergeableFields:
+    @pytest.mark.parametrize("field", ["name", "hash", "date", "venue_id", "id"])
+    def test_identity_fields_are_not_mergeable(self, field):
+        """The hash is derived from the name, so rewriting either would leave the surviving
+        row unmatchable by the scraper on a later run."""
+        assert field not in tool.MERGEABLE_FIELDS
+
+    def test_classification_fields_are_not_mergeable(self):
+        """Copying a discarded row's verdict onto the survivor would overwrite the
+        classifier's own answer for the row being kept."""
+        for field in ("is_live_music", "is_manual_override", "classification_reason", "approved_at"):
+            assert field not in tool.MERGEABLE_FIELDS

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -98,7 +98,7 @@ steps:
       # Turn them on by extending the line below in place. gcloud rejects
       # --set-env-vars alongside --update-env-vars, so append rather than adding a line:
       #
-      #   - --set-env-vars=APP_ENV=production,ENABLE_SCHEDULER=false,LOG_LEVEL=INFO,CF_ACCESS_TEAM_DOMAIN=<team>.cloudflareaccess.com,CF_ACCESS_AUD=<aud-tag>,SCRAPE_ALLOWED_SERVICE_ACCOUNTS=<scheduler-sa-email>,SCRAPE_OIDC_AUDIENCE=<audience-on-the-scheduler-job>
+      #   - --set-env-vars=APP_ENV=production,ENABLE_SCHEDULER=false,ENABLE_STARTUP_SCRAPE=false,LOG_LEVEL=INFO,CF_ACCESS_TEAM_DOMAIN=<team>.cloudflareaccess.com,CF_ACCESS_AUD=<aud-tag>,SCRAPE_ALLOWED_SERVICE_ACCOUNTS=<scheduler-sa-email>,SCRAPE_OIDC_AUDIENCE=<audience-on-the-scheduler-job>
       #
       # Enable the scrape gate first: its token already arrives, so it can be verified
       # with nothing else in place. The /admin gate needs a Cloudflare Access application
@@ -116,7 +116,7 @@ steps:
       #
       # The alternative is --no-cpu-throttling, which keeps CPU allocated on idle
       # instances and costs more for work the scheduler already does deterministically.
-      - --set-env-vars=APP_ENV=production,ENABLE_SCHEDULER=false,LOG_LEVEL=INFO,ENABLE_STARTUP_SCRAPE=false
+      - --set-env-vars=APP_ENV=production,ENABLE_SCHEDULER=false,LOG_LEVEL=INFO,ENABLE_STARTUP_SCRAPE=false,SCRAPE_ALLOWED_SERVICE_ACCOUNTS=triangle-shows-scrape@triangle-shows.iam.gserviceaccount.com,SCRAPE_OIDC_AUDIENCE=https://triangle-shows.net/api/scrape
       - --update-secrets=DATABASE_URL=triangle-shows-db-url:latest
       - --update-secrets=TICKETMASTER_API_KEY=triangle-shows-tm-api-key:latest
       # Admin subsite — uncomment BOTH lines only after creating the two secrets

--- a/tools/dedupe_past_events.py
+++ b/tools/dedupe_past_events.py
@@ -1,0 +1,449 @@
+#!/usr/bin/env python3
+"""
+Merges duplicate event rows left behind in past dates. Dry-run unless told otherwise.
+
+Role: One-off cleanup utility. Not part of the runtime scrape or serving path, and not
+something to schedule — the matching rule is deliberately fuzzy, so every run is meant to
+be read by a person before anything is deleted.
+
+Why this is needed. Before PR #51, event identity was a hash of the title, so any title
+edit — a support act announced, a "[CANCELLED]" prefix added, a series name prepended —
+looked like a brand new event and inserted a second row. #51 fixed the cause by matching
+on the venue's own event ID first, and it reconciles away rows a source has stopped
+listing. Neither of those cleans up what already exists in past dates:
+
+  * reconcile is bounded to `today <= date <= horizon` on purpose, because venues drop
+    events from their listings the moment they happen — reconciling the past would delete
+    the archive on every run
+  * merging only happens for events present in the current scrape, and a past event is no
+    longer in any venue's listing, so nothing ever matches it
+  * the display-time guard in api/events.py keys on the normalized name, which is exactly
+    what a title edit changes, so it collapses almost none of these
+
+So they are permanent debris until something like this removes them.
+
+    Usage:
+        # look, change nothing (default: 2026-07-01 .. yesterday)
+        python tools/dedupe_past_events.py
+
+        # a different window
+        python tools/dedupe_past_events.py --start 2026-06-01 --end 2026-06-30
+
+        # actually merge, after reading the dry-run output
+        python tools/dedupe_past_events.py --apply
+
+    Requires DATABASE_URL in the environment, or --database-url. To point at production:
+
+        export DATABASE_URL="$(gcloud secrets versions access latest \
+          --secret=triangle-shows-db-url --project=triangle-shows)"
+
+    Exits 0 when it completes (whether or not anything was found), 1 on a usage or
+    connection error, 2 if --apply hit a database error partway.
+"""
+
+# --- Imports ---
+
+import argparse
+import os
+import re
+import sys
+from collections import defaultdict
+from urllib.parse import parse_qsl, urlencode, urlsplit, urlunsplit
+from datetime import date, datetime, timedelta
+
+try:
+    import psycopg2
+    import psycopg2.extras
+except ImportError:  # pragma: no cover - dependency is in backend/requirements.txt
+    print("psycopg2 is required: pip install -r backend/requirements.txt", file=sys.stderr)
+    raise SystemExit(1)
+
+
+# --- Matching rules ---
+
+# A run is only ever considered inside one (venue, date) pair, so two different bookings
+# would have to be at the same venue on the same night to collide at all.
+#
+# Names are compared after stripping bracketed status markers and reducing to lowercase
+# alphanumerics, then matched by containment rather than equality: the whole point is that
+# one title is an edited version of the other, usually by addition.
+#
+#   'Slow Joy'                         -> slowjoy
+#   'Slow Joy with Bike Routes'        -> slowjoywithbikeroutes          (contains slowjoy)
+#   '[CANCELLED] The Philharmonik'     -> thephilharmonik                (marker stripped)
+#
+# Containment is looser than a prefix test, and it has to be: a "[CANCELLED]" marker sits
+# at the front, so prefix matching would miss precisely the case that motivated this.
+# Only *status* markers are stripped, from an explicit list. Stripping every bracketed
+# token was the first attempt and it was wrong: it turned '[LATE] Sub Rosa' and 'Sub Rosa'
+# into the same string, and those are the early and late shows on one night at a jazz club
+# — two real performances. Deleting one of them would lose a listing, which is a worse
+# error than leaving a duplicate in place.
+_STATUS_MARKER = re.compile(
+    r"[\[\(]\s*(?:"
+    r"cancell?ed|canceled|postponed|rescheduled|moved|new\s*date|"
+    r"sold\s*out|low\s*tix|low\s*tickets|free|"
+    r"\d{1,2}\s*\+|all\s*ages"
+    r")\s*[\]\)]",
+    re.IGNORECASE,
+)
+
+# Session markers do the opposite job: they *distinguish* two events rather than being
+# noise on one. Two rows whose session markers differ are never merged, however similar
+# their titles. Compared as sets, so 'Late Night Drive Home' and 'Late Night Drive Home
+# w/ Support' still match — both carry the same marker.
+_SESSION_MARKER = re.compile(
+    r"\b(?:early|late|matinee|first\s*set|second\s*set|1st\s*set|2nd\s*set)\b",
+    re.IGNORECASE,
+)
+
+# Markers meaning "this show is not happening as listed". A row carrying one of these is
+# the newer information about the show, so it wins the survivor choice — otherwise a
+# cancelled show could keep the row that still says it is on sale.
+_CANCELLED_MARKER = re.compile(
+    r"\b(?:cancell?ed|canceled|postponed|rescheduled)\b", re.IGNORECASE
+)
+
+_NON_ALNUM = re.compile(r"[^a-z0-9]")
+
+# Below this many characters a normalized name is too generic to trust containment on:
+# 'dj' (2) would swallow every DJ night at a venue. Pairs under the floor are reported as
+# skipped rather than silently dropped, so they can be looked at by hand.
+#
+# Six, not eight: 'Slow Joy' normalizes to 'slowjoy', which is 7 characters, and that is a
+# real duplicate in the production data this was written against. A floor of 8 silently
+# excluded it — found by testing the rule against the actual rows rather than by reasoning
+# about it. Six still blocks the short generic names that motivated having a floor.
+MIN_NORMALIZED_LENGTH = 6
+
+# Fields copied from a discarded row onto the survivor when the survivor's value is NULL.
+# `name`, `hash`, `date` and `venue_id` are deliberately absent: the hash is derived from
+# the name, and rewriting either would make the surviving row unmatchable by the scraper
+# on a later run.
+MERGEABLE_FIELDS = (
+    "external_id", "artist", "support_artists", "doors_time", "show_time",
+    "ticket_url", "price_min", "price_max", "image_url", "genre", "subgenre",
+    "age_restriction", "description", "source_url",
+)
+
+BASE_FIELDS = (
+    "id", "venue_id", "name", "date", "status",
+    "is_live_music", "is_manual_override", "updated_at",
+)
+
+
+def normalize(name):
+    """Reduce a title to the form used for comparison."""
+    without_markers = _STATUS_MARKER.sub(" ", name or "")
+    return _NON_ALNUM.sub("", without_markers.lower())
+
+
+def sessions(name):
+    """Session markers in a title, as a set — 'early', 'late', '2nd set' and so on.
+
+    Two rows are only ever merged when these match, so an early show and a late show on
+    one night stay separate.
+    """
+    return frozenset(m.group(0).lower().replace(" ", "") for m in _SESSION_MARKER.finditer(name or ""))
+
+
+def is_cancelled(row):
+    """True when this row says the show is not happening as originally listed."""
+    if _CANCELLED_MARKER.search(row.get("name") or ""):
+        return True
+    status = (row.get("status") or "").lower().replace("_", "").replace("-", "")
+    return status in {"cancelled", "canceled", "postponed"}
+
+
+def rank(row):
+    """Sort key for choosing which row survives — highest wins.
+
+    Mirrors _completeness() in backend/app/api/events.py, with one addition: a longer
+    title breaks a metadata tie, because the longer title is normally the fuller listing
+    ('The Briefs w/ Paint Fumes' over 'The Briefs'). Every component is total and the id
+    settles the last tie, so the choice never depends on row order.
+    """
+    return (
+        bool(row["is_manual_override"]),          # an admin decided about this row
+        is_cancelled(row),                        # a cancellation is the newer truth
+        bool(row["is_live_music"]),               # prefer the visible copy
+        (bool(row["image_url"]) + bool(row["ticket_url"]) + (row["price_min"] is not None)),
+        len(row["name"] or ""),                   # fuller listing
+        row["updated_at"] or datetime.min,        # most recently scraped
+        row["id"],
+    )
+
+
+def find_groups(rows, min_length=MIN_NORMALIZED_LENGTH):
+    """Cluster rows into duplicate groups. Returns (groups, skipped_short).
+
+    Clusters transitively within a (venue, date) bucket, so the three-way Briefs case
+    ('The Briefs' / 'The Briefs w/ Paint Fumes' / 'The Briefs w/ The Sleevens, Paint
+    Fumes') collapses into one group rather than two overlapping pairs.
+    """
+    buckets = defaultdict(list)
+    for row in rows:
+        buckets[(row["venue_id"], row["date"])].append(row)
+
+    groups = []
+    skipped_short = []
+
+    for key in sorted(buckets, key=lambda k: (str(k[1]), k[0])):
+        bucket = buckets[key]
+        if len(bucket) < 2:
+            continue
+
+        # Shortest name first, so the base title anchors its cluster and longer edited
+        # variants join it rather than each starting one of their own.
+        clusters = []
+        for row in sorted(bucket, key=lambda r: len(normalize(r["name"]))):
+            a = normalize(row["name"])
+            target = None
+
+            for cluster in clusters:
+                for other in cluster:
+                    b = normalize(other["name"])
+                    if not a or not b:
+                        continue
+                    if not (a == b or a in b or b in a):
+                        continue
+                    # An early show and a late show are different events.
+                    if sessions(row["name"]) != sessions(other["name"]):
+                        continue
+                    if min(len(a), len(b)) < min_length:
+                        skipped_short.append((row, other))
+                        continue
+                    target = cluster
+                    break
+                if target is not None:
+                    break
+
+            if target is None:
+                clusters.append([row])
+            else:
+                target.append(row)
+
+        groups.extend(c for c in clusters if len(c) > 1)
+
+    return groups, skipped_short
+
+
+# --- Database ---
+
+def to_psycopg_url(url):
+    """Translate the app's asyncpg URL into one psycopg2 accepts.
+
+    Two differences, both of which psycopg2 rejects outright rather than ignoring:
+
+      * the driver suffix, `postgresql+asyncpg://`
+      * the TLS parameter — asyncpg spells it `ssl=require`, psycopg2 `sslmode=require`,
+        and Neon's connection string uses the former. Without this the tool fails with
+        'invalid URI query parameter: "ssl"'.
+
+    An explicit sslmode already in the URL wins, on the assumption it was put there
+    deliberately.
+    """
+    for prefix in ("postgresql+asyncpg://", "postgresql+psycopg2://", "postgres+asyncpg://"):
+        url = url.replace(prefix, "postgresql://")
+
+    parsed = urlsplit(url)
+    if not parsed.query:
+        return url
+
+    params = parse_qsl(parsed.query, keep_blank_values=True)
+    has_sslmode = any(k == "sslmode" for k, _ in params)
+
+    translated = []
+    for key, value in params:
+        if key == "ssl" and not has_sslmode:
+            # asyncpg accepts booleans here; psycopg2 wants a named mode.
+            mode = {"true": "require", "on": "require", "1": "require",
+                    "false": "disable", "off": "disable", "0": "disable"}.get(
+                        value.lower(), value)
+            translated.append(("sslmode", mode))
+        elif key == "ssl":
+            continue  # an explicit sslmode is already present; drop the duplicate
+        else:
+            translated.append((key, value))
+
+    return urlunsplit(parsed._replace(query=urlencode(translated)))
+
+
+def fetch_rows(conn, start, end):
+    columns = ", ".join(BASE_FIELDS + MERGEABLE_FIELDS)
+    with conn.cursor(cursor_factory=psycopg2.extras.RealDictCursor) as cur:
+        cur.execute(
+            f"SELECT {columns} FROM events WHERE date >= %s AND date <= %s ORDER BY date, venue_id, id",
+            (start, end),
+        )
+        return cur.fetchall()
+
+
+def apply_group(conn, survivor, losers):
+    """Copy missing fields onto the survivor, then delete the discarded rows."""
+    fills = {}
+    for field in MERGEABLE_FIELDS:
+        if survivor.get(field) not in (None, ""):
+            continue
+        for loser in losers:
+            value = loser.get(field)
+            if value not in (None, ""):
+                fills[field] = value
+                break
+
+    with conn.cursor() as cur:
+        if fills:
+            assignments = ", ".join(f"{k} = %s" for k in fills)
+            cur.execute(
+                f"UPDATE events SET {assignments}, updated_at = %s WHERE id = %s",
+                (*fills.values(), datetime.utcnow(), survivor["id"]),
+            )
+        cur.execute(
+            "DELETE FROM events WHERE id = ANY(%s)", ([r["id"] for r in losers],)
+        )
+    return fills
+
+
+# --- Reporting ---
+
+def describe(row, marker):
+    bits = [f"{marker} id={row['id']:<6}", f"{(row['name'] or '')[:58]:<58}"]
+    flags = []
+    if row["is_manual_override"]:
+        flags.append("manual-override")
+    if not row["is_live_music"]:
+        flags.append("non-live")
+    if row.get("status") and row["status"] != "onsale":
+        flags.append(str(row["status"]))
+    filled = sum(1 for f in MERGEABLE_FIELDS if row.get(f) not in (None, ""))
+    flags.append(f"{filled}/{len(MERGEABLE_FIELDS)} fields")
+    return "  " + " ".join(bits) + "  [" + ", ".join(flags) + "]"
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Merge duplicate event rows in past dates. Dry-run by default."
+    )
+    parser.add_argument(
+        "--start", default="2026-07-01",
+        help="inclusive start date (YYYY-MM-DD). Default 2026-07-01 — July and August are "
+             "what the calendar's default view still shows.",
+    )
+    parser.add_argument(
+        "--end", default=None,
+        help="inclusive end date (YYYY-MM-DD). Defaults to yesterday: the window has to "
+             "end in the past, because upcoming events are the scraper's to dedupe.",
+    )
+    parser.add_argument("--apply", action="store_true", help="actually merge and delete")
+    parser.add_argument("--database-url", default=os.environ.get("DATABASE_URL"))
+    parser.add_argument(
+        "--min-length", type=int, default=MIN_NORMALIZED_LENGTH,
+        help=f"shortest normalized name to trust containment on (default {MIN_NORMALIZED_LENGTH})",
+    )
+    parser.add_argument(
+        "--allow-future", action="store_true",
+        help="permit a window that reaches today or later (refused by default)",
+    )
+    args = parser.parse_args()
+
+    if not args.database_url:
+        print("No database URL. Set DATABASE_URL or pass --database-url.", file=sys.stderr)
+        return 1
+
+    try:
+        start = date.fromisoformat(args.start)
+        # Yesterday, not today: an event happening today may still be in a venue's listing,
+        # so the scraper can still match and reconcile it.
+        end = date.fromisoformat(args.end) if args.end else date.today() - timedelta(days=1)
+    except ValueError as exc:
+        print(f"Bad date: {exc}", file=sys.stderr)
+        return 1
+    if start > end:
+        print("--start is after --end", file=sys.stderr)
+        return 1
+
+    # Upcoming events are the scraper's business: it matches them on external_id and
+    # reconciles them every run, so touching them here would fight the live system and
+    # could delete a listing that is about to be re-matched.
+    if end >= date.today() and not args.allow_future:
+        print(
+            f"Window ends {end}, which is not in the past. The scraper already dedupes "
+            f"upcoming events on every run — pass --allow-future only if you mean it.",
+            file=sys.stderr,
+        )
+        return 1
+
+    mode = "APPLY (rows will be merged and deleted)" if args.apply else "DRY RUN (nothing will change)"
+    print(f"Window : {start} .. {end}")
+    print(f"Mode   : {mode}")
+    print(f"Rule   : same venue + same date, one normalized name contains the other,")
+    print(f"         shortest normalized name >= {args.min_length} chars")
+    print()
+
+    try:
+        conn = psycopg2.connect(to_psycopg_url(args.database_url))
+    except Exception as exc:
+        print(f"Could not connect: {exc}", file=sys.stderr)
+        return 1
+
+    try:
+        rows = fetch_rows(conn, start, end)
+        print(f"Loaded {len(rows)} events in range.")
+        groups, skipped = find_groups(rows, min_length=args.min_length)
+        print(f"Found {len(groups)} duplicate group(s).")
+        if skipped:
+            print(f"Skipped {len(skipped)} pair(s) whose names were too short to trust.")
+        print()
+
+        total_deleted = 0
+        total_filled = 0
+
+        for n, group in enumerate(sorted(groups, key=lambda g: (str(g[0]['date']), g[0]['venue_id'])), 1):
+            ordered = sorted(group, key=rank, reverse=True)
+            survivor, losers = ordered[0], ordered[1:]
+
+            print(f"[{n}/{len(groups)}] {survivor['date']}  venue_id={survivor['venue_id']}")
+            print(describe(survivor, "KEEP  "))
+            for loser in losers:
+                print(describe(loser, "DELETE"))
+
+            if args.apply:
+                try:
+                    fills = apply_group(conn, survivor, losers)
+                    conn.commit()
+                except Exception as exc:
+                    conn.rollback()
+                    print(f"  ERROR on this group, rolled back, stopping: {exc}", file=sys.stderr)
+                    return 2
+                total_deleted += len(losers)
+                total_filled += len(fills)
+                if fills:
+                    print(f"  filled from discarded rows: {', '.join(sorted(fills))}")
+                print(f"  merged ({total_deleted} row(s) deleted so far)")
+            else:
+                would = [
+                    f for f in MERGEABLE_FIELDS
+                    if survivor.get(f) in (None, "")
+                    and any(l.get(f) not in (None, "") for l in losers)
+                ]
+                if would:
+                    print(f"  would fill from discarded rows: {', '.join(sorted(would))}")
+                total_deleted += len(losers)
+            print()
+
+        print("--- summary ---")
+        print(f"groups            : {len(groups)}")
+        if args.apply:
+            print(f"rows deleted      : {total_deleted}")
+            print(f"fields backfilled : {total_filled}")
+        else:
+            print(f"rows that would be deleted : {total_deleted}")
+            print()
+            print("Nothing was changed. Re-run with --apply once the list above looks right.")
+        return 0
+    finally:
+        conn.close()
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/dedupe_past_events.py
+++ b/tools/dedupe_past_events.py
@@ -139,12 +139,38 @@ def normalize(name):
 
 
 def sessions(name):
-    """Session markers in a title, as a set — 'early', 'late', '2nd set' and so on.
-
-    Two rows are only ever merged when these match, so an early show and a late show on
-    one night stay separate.
-    """
+    """Session markers in a title, as a set — 'early', 'late', '2nd set' and so on."""
     return frozenset(m.group(0).lower().replace(" ", "") for m in _SESSION_MARKER.finditer(name or ""))
+
+
+def start_time(row):
+    """When the show actually starts, preferring show_time over doors."""
+    return row.get("show_time") or row.get("doors_time")
+
+
+def different_performances(a, b):
+    """True when two similarly-named rows look like genuinely separate performances.
+
+    The label alone is not enough to decide, and believing it was a mistake. Kings lists
+    the same show twice, once as 'Sub Rosa' and once as '[LATE] Sub Rosa', with identical
+    doors, start time and price — and both rows were inserted by a single scrape batch
+    nine microseconds apart. Treating the label as decisive refused to merge a pair that
+    is plainly one event.
+
+    So the clock decides. A differing session label matters only when the two rows
+    disagree about when the show starts; a real early-and-late double bill has two start
+    times. When either time is missing there is nothing to compare, and the same act at
+    the same venue on one night is far more often one relabeled listing than two shows —
+    so the rows are treated as mergeable and the dry run puts them in front of a person.
+    """
+    if sessions(a["name"]) == sessions(b["name"]):
+        return False
+
+    ta, tb = start_time(a), start_time(b)
+    if ta is None or tb is None:
+        return False
+
+    return ta != tb
 
 
 def is_cancelled(row):
@@ -207,8 +233,8 @@ def find_groups(rows, min_length=MIN_NORMALIZED_LENGTH):
                         continue
                     if not (a == b or a in b or b in a):
                         continue
-                    # An early show and a late show are different events.
-                    if sessions(row["name"]) != sessions(other["name"]):
+                    # A real early-and-late double bill has two start times.
+                    if different_performances(row, other):
                         continue
                     if min(len(a), len(b)) < min_length:
                         skipped_short.append((row, other))


### PR DESCRIPTION
This pull request adds a comprehensive test suite for the `dedupe_past_events.py` tool and updates the production environment configuration for the scraping service. The tests ensure that the deduplication logic works as intended, covering normalization, clustering, survivor selection, and edge cases. The Cloud Build configuration is also updated to include new environment variables required for secure scraping.

**Testing and Deduplication Logic:**

* Added a new test file `backend/tests/test_dedupe_past_events.py` containing thorough tests for the deduplication tool, covering normalization, clustering, survivor selection, URL handling, and fields that must not be rewritten.

**Production Configuration Updates:**

* Updated the example `--set-env-vars` line in `cloudbuild.yaml` to include `ENABLE_STARTUP_SCRAPE=false` for clarity and consistency.
* Added `SCRAPE_ALLOWED_SERVICE_ACCOUNTS` and `SCRAPE_OIDC_AUDIENCE` environment variables to the production deployment step in `cloudbuild.yaml` to support secure scraping authentication.