### PR TITLE
Add Cloudflare access tokens for raw CF domain

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -116,7 +116,7 @@ steps:
       #
       # The alternative is --no-cpu-throttling, which keeps CPU allocated on idle
       # instances and costs more for work the scheduler already does deterministically.
-      - --set-env-vars=APP_ENV=production,ENABLE_SCHEDULER=false,LOG_LEVEL=INFO,ENABLE_STARTUP_SCRAPE=false,SCRAPE_ALLOWED_SERVICE_ACCOUNTS=triangle-shows-scrape@triangle-shows.iam.gserviceaccount.com,SCRAPE_OIDC_AUDIENCE=https://triangle-shows.net/api/scrape
+      - --set-env-vars=APP_ENV=production,ENABLE_SCHEDULER=false,LOG_LEVEL=INFO,ENABLE_STARTUP_SCRAPE=false,SCRAPE_ALLOWED_SERVICE_ACCOUNTS=triangle-shows-scrape@triangle-shows.iam.gserviceaccount.com,SCRAPE_OIDC_AUDIENCE=https://triangle-shows.net/api/scrape,CF_ACCESS_TEAM_DOMAIN=ty-fi.cloudflareaccess.com,CF_ACCESS_AUD=2672446ca36104364662d122c152746305f880c1d9fb818c0b1ec6cb55c8f0c4
       - --update-secrets=DATABASE_URL=triangle-shows-db-url:latest
       - --update-secrets=TICKETMASTER_API_KEY=triangle-shows-tm-api-key:latest
       # Admin subsite — uncomment BOTH lines only after creating the two secrets


### PR DESCRIPTION
This pull request updates the deployment configuration in `cloudbuild.yaml` by adding two new environment variables related to Cloudflare Access. These variables (`CF_ACCESS_TEAM_DOMAIN` and `CF_ACCESS_AUD`) are now set during deployment to support integration with Cloudflare Access authentication.

**Deployment configuration updates:**

* Added `CF_ACCESS_TEAM_DOMAIN` and `CF_ACCESS_AUD` environment variables to the `--set-env-vars` argument in the deployment step of `cloudbuild.yaml` to enable Cloudflare Access integration.