### PR TITLE
Accept a Cloudflare Access identity as admin authentication

### DIFF
--- a/backend/app/api/admin.py
+++ b/backend/app/api/admin.py
@@ -10,6 +10,7 @@ admin is disabled (fails closed). Must be registered before the "/" static mount
 main.py so these routes take priority over the catch-all.
 Requires: async PostgreSQL session, app.classifier, app.scrapers.manager, itsdangerous.
 """
+import logging
 import secrets
 from datetime import date, datetime
 from typing import Optional
@@ -28,6 +29,9 @@ from app.models import Event, Venue, SeriesOverride
 from app.classifier import normalize_series_name, criteria_summary, reclassify_floor
 from app.scrapers.manager import ScrapeManager
 from app.admin_ui import LOGIN_HTML, ADMIN_HTML
+from app import tokens
+
+logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/admin", tags=["admin"])
 
@@ -43,9 +47,43 @@ _signing_key = settings.SESSION_SECRET or secrets.token_urlsafe(32)
 _serializer = URLSafeTimedSerializer(_signing_key, salt="ts-admin-session")
 
 
-def _admin_enabled() -> bool:
-    """Admin is reachable only when a password is configured."""
+def _password_login_enabled() -> bool:
+    """Whether the shared-password login is usable at all.
+
+    Kept separate from _admin_enabled() on purpose. This is the check that stops
+    compare_digest comparing a guess against "" — which would accept an empty password —
+    so it must stay pinned to ADMIN_PASSWORD alone and must not widen when some other
+    authentication method becomes available.
+    """
     return bool(settings.ADMIN_PASSWORD)
+
+
+def _admin_enabled() -> bool:
+    """Whether /admin can authenticate anyone at all — by either method.
+
+    Cloudflare Access counts. When the origin gate is enforcing, every request that
+    reaches a handler has already presented a token Cloudflare signed for a person on the
+    Access policy, which is strictly stronger identification than a password shared by
+    everyone. So a password is no longer required for the admin surface to exist.
+    """
+    return _password_login_enabled() or tokens.cloudflare_access_configured()
+
+
+def _access_identity(request: Request) -> Optional[str]:
+    """The Cloudflare-verified person behind this request, if there is one.
+
+    Set by the enforce_admin_access middleware in app.main, which has already checked the
+    token's signature, expiry, audience and issuer. Absent when the gate is not
+    configured — in which case there is no verified identity and the cookie path applies.
+
+    Trusting this is only sound because the gate rejects tokenless requests at the origin.
+    If /admin were reachable without a token, treating its absence as "fall back to the
+    cookie" would be fine, but treating its presence as proof would not be — the header
+    can be set by any client. The middleware never sets this from an unverified header.
+    """
+    if not tokens.cloudflare_access_configured():
+        return None
+    return getattr(request.state, "access_email", None)
 
 
 def _issue_cookie(response) -> None:
@@ -72,11 +110,19 @@ def _is_authenticated(request: Request) -> bool:
         return False
 
 
-async def require_admin(request: Request) -> bool:
-    """Dependency guarding /admin/api/* — raises 401 for the frontend to redirect on."""
-    if not _is_authenticated(request):
-        raise HTTPException(status_code=401, detail="Not authenticated")
-    return True
+async def require_admin(request: Request) -> str:
+    """Dependency guarding /admin/api/* — raises 401 for the frontend to redirect on.
+
+    Returns who is acting: their email when Cloudflare Access identified them, otherwise
+    "admin" for a password session, which carries no identity. Handlers can take it as a
+    parameter to attribute an action to a person.
+    """
+    identity = _access_identity(request)
+    if identity:
+        return identity
+    if _is_authenticated(request):
+        return "admin"
+    raise HTTPException(status_code=401, detail="Not authenticated")
 
 
 # --- Request bodies ---
@@ -98,7 +144,20 @@ class SeriesBody(BaseModel):
 # --- Auth + page routes ---
 
 @router.get("/login", response_class=HTMLResponse)
-async def login_page() -> HTMLResponse:
+async def login_page(request: Request):
+    # Already identified by Cloudflare Access — there is nothing to log in to, so don't
+    # show a password box that would only reject them. A visitor who reached this page at
+    # all has passed the origin gate.
+    if _access_identity(request):
+        return RedirectResponse("/admin", status_code=303)
+    if not _password_login_enabled():
+        # No password configured and no Access identity: nothing can authenticate here.
+        # Say so rather than presenting a form that cannot succeed.
+        return HTMLResponse(
+            "<h1>Admin login is disabled</h1><p>No password is configured, and this "
+            "request did not arrive through Cloudflare Access.</p>",
+            status_code=403,
+        )
     return HTMLResponse(LOGIN_HTML)
 
 
@@ -113,7 +172,12 @@ async def login_submit(body: LoginBody):
     # attempt into a 500 instead of a clean 401 — and, since the message differs, told the
     # caller something about the configured password. UTF-8 on both sides compares the
     # same bytes the client sent.
-    if _admin_enabled() and secrets.compare_digest(
+    #
+    # Gated on _password_login_enabled(), not _admin_enabled(): the latter is now true
+    # whenever Cloudflare Access is configured, and with no ADMIN_PASSWORD set that would
+    # let compare_digest("", "") succeed and hand out a session to anyone posting an empty
+    # password. The two checks exist separately for exactly this reason.
+    if _password_login_enabled() and secrets.compare_digest(
         body.password.encode("utf-8"), settings.ADMIN_PASSWORD.encode("utf-8")
     ):
         response = JSONResponse({"ok": True})
@@ -124,13 +188,31 @@ async def login_submit(body: LoginBody):
 
 @router.get("/logout")
 async def logout() -> RedirectResponse:
-    response = RedirectResponse("/admin/login", status_code=303)
+    """Log out of whichever session is actually in force.
+
+    Deleting the app's cookie does nothing to a Cloudflare Access session, so with the
+    gate enforcing, the old behavior sent you to /admin/login, which recognised your still
+    valid Access identity and bounced you straight back to the dashboard — a logout button
+    that visibly did nothing. Cloudflare's own logout endpoint is what ends that session.
+    """
+    target = "/admin/login"
+    if tokens.cloudflare_access_configured():
+        team_domain = settings.CF_ACCESS_TEAM_DOMAIN.strip().rstrip("/")
+        if "://" in team_domain:
+            team_domain = team_domain.split("://", 1)[1]
+        target = f"https://{team_domain}/cdn-cgi/access/logout"
+
+    response = RedirectResponse(target, status_code=303)
     response.delete_cookie(COOKIE_NAME, path="/admin")
     return response
 
 
 @router.get("", response_class=HTMLResponse)
 async def admin_page(request: Request):
+    identity = _access_identity(request)
+    if identity:
+        logger.info(f"[admin] dashboard opened by {identity}")
+        return HTMLResponse(ADMIN_HTML)
     if not _is_authenticated(request):
         return RedirectResponse("/admin/login", status_code=303)
     return HTMLResponse(ADMIN_HTML)

--- a/backend/tests/test_admin_access_auth.py
+++ b/backend/tests/test_admin_access_auth.py
@@ -1,0 +1,208 @@
+"""
+Tests for treating a Cloudflare Access identity as admin authentication.
+
+Why this exists. A single shared ADMIN_PASSWORD has no per-person identity: you cannot
+tell who approved an event, and removing one collaborator's access means rotating the
+password for everyone holding it. Cloudflare Access already identifies people
+individually; this wires that to the app so the shared secret can stop existing.
+
+Safe only because the origin gate rejects tokenless requests — verified in production,
+where `GET https://<origin>/admin` returns 403. If /admin were reachable without a token,
+the Cf-Access-Jwt-Assertion header could be set by any client and trusting it would be an
+open door. The middleware in app.main never sets request.state.access_email from an
+unverified header, and _access_identity() additionally refuses to read it unless the gate
+is configured.
+
+The most important class here is TestEmptyPasswordIsNeverAccepted. Widening
+_admin_enabled() to include "Access is configured" would, if the password check were
+gated on it, let compare_digest("", "") succeed and hand a session to anyone posting an
+empty password. _password_login_enabled() exists separately for exactly that reason.
+
+Handlers are called directly rather than over HTTP: pytest-asyncio is deliberately absent
+from requirements-dev.txt, and with the gate configured the middleware answers /admin/*
+with 403 before any handler runs, so an HTTP request cannot reach the code under test.
+"""
+
+import asyncio
+
+from fastapi import HTTPException
+from fastapi.testclient import TestClient
+
+import pytest
+
+from app.api import admin
+from app.config import settings
+from app.main import app
+
+
+TEAM = "ty-fi.cloudflareaccess.com"
+AUD = "2672446ca36104364662d122c152746305f880c1d9fb818c0b1ec6cb55c8f0c4"
+PERSON = "collaborator@example.org"
+
+
+def run(coro):
+    """Drive one coroutine to completion."""
+    return asyncio.run(coro)
+
+
+class _FakeState:
+    def __init__(self, email=None):
+        if email is not None:
+            self.access_email = email
+
+
+class _FakeRequest:
+    """Stands in for a Request the middleware has already annotated."""
+
+    def __init__(self, email=None, cookies=None):
+        self.state = _FakeState(email)
+        self.cookies = cookies or {}
+
+
+@pytest.fixture
+def client():
+    return TestClient(app)
+
+
+@pytest.fixture
+def access_on(monkeypatch):
+    monkeypatch.setattr(settings, "CF_ACCESS_TEAM_DOMAIN", TEAM)
+    monkeypatch.setattr(settings, "CF_ACCESS_AUD", AUD)
+
+
+@pytest.fixture
+def access_off(monkeypatch):
+    monkeypatch.setattr(settings, "CF_ACCESS_TEAM_DOMAIN", "")
+    monkeypatch.setattr(settings, "CF_ACCESS_AUD", "")
+
+
+@pytest.fixture
+def no_password(monkeypatch):
+    monkeypatch.setattr(settings, "ADMIN_PASSWORD", "")
+
+
+@pytest.fixture
+def with_password(monkeypatch):
+    monkeypatch.setattr(settings, "ADMIN_PASSWORD", "a-strong-password")
+    monkeypatch.setattr(settings, "SESSION_SECRET", "test-signing-key")
+
+
+# --- the security property that must not regress ---
+
+class TestEmptyPasswordIsNeverAccepted:
+    def test_admin_is_enabled_by_access_alone(self, access_on, no_password):
+        """The widening this change introduces: no password, but admin still works."""
+        assert admin._admin_enabled() is True
+
+    def test_password_login_stays_disabled_without_a_password(self, access_on, no_password):
+        """_password_login_enabled() must not follow _admin_enabled() upward."""
+        assert admin._password_login_enabled() is False
+
+    def test_an_empty_password_is_rejected(self, access_on, no_password):
+        """compare_digest("", "") is True, so gating the password check on
+        _admin_enabled() would hand out a session for an empty post."""
+        assert run(admin.login_submit(admin.LoginBody(password=""))).status_code == 401
+
+    def test_any_password_is_rejected_when_none_is_configured(self, access_on, no_password):
+        assert run(admin.login_submit(admin.LoginBody(password="guess"))).status_code == 401
+
+    def test_no_cookie_is_issued_on_a_rejected_login(self, access_on, no_password):
+        """Belt and braces: even were the status wrong, no session may be handed out."""
+        response = run(admin.login_submit(admin.LoginBody(password="")))
+        assert admin.COOKIE_NAME not in response.headers.get("set-cookie", "")
+
+    def test_the_correct_password_still_works_when_one_is_set(self, access_off, with_password):
+        response = run(admin.login_submit(admin.LoginBody(password="a-strong-password")))
+        assert response.status_code == 200
+
+
+# --- identity resolution ---
+
+class TestAccessIdentity:
+    def test_the_verified_email_is_used(self, access_on):
+        assert admin._access_identity(_FakeRequest(PERSON)) == PERSON
+
+    def test_the_header_is_ignored_when_the_gate_is_not_configured(self, access_off):
+        """Without the gate there is no verified identity, so a value on request.state must
+        not be honored — the fail-safe direction if middleware order ever changes."""
+        assert admin._access_identity(_FakeRequest(PERSON)) is None
+
+    def test_a_missing_identity_is_none(self, access_on):
+        assert admin._access_identity(_FakeRequest()) is None
+
+
+class TestRequireAdmin:
+    def test_an_access_identity_authenticates_without_a_cookie(self, access_on, no_password):
+        assert run(admin.require_admin(_FakeRequest(PERSON))) == PERSON
+
+    def test_no_identity_and_no_cookie_is_a_401(self, access_on, no_password):
+        with pytest.raises(HTTPException) as exc:
+            run(admin.require_admin(_FakeRequest()))
+        assert exc.value.status_code == 401
+
+    def test_a_password_session_still_works(self, access_off, with_password):
+        """The cookie path is unchanged — local dev and docker-compose rely on it."""
+        token = admin._serializer.dumps("admin")
+        result = run(admin.require_admin(_FakeRequest(cookies={admin.COOKIE_NAME: token})))
+        assert result == "admin"
+
+    def test_a_password_session_reports_no_person(self, access_off, with_password):
+        """A shared password identifies nobody, and the return value should say so rather
+        than inventing an email."""
+        token = admin._serializer.dumps("admin")
+        result = run(admin.require_admin(_FakeRequest(cookies={admin.COOKIE_NAME: token})))
+        assert "@" not in result
+
+    def test_a_forged_cookie_is_rejected(self, access_off, with_password):
+        with pytest.raises(HTTPException):
+            run(admin.require_admin(_FakeRequest(cookies={admin.COOKIE_NAME: "nonsense"})))
+
+
+# --- page behavior ---
+
+class TestPages:
+    def test_an_identified_visitor_is_sent_from_login_to_the_dashboard(self, access_on, no_password):
+        """Showing a password box to someone Access already identified would only reject
+        them."""
+        response = run(admin.login_page(_FakeRequest(PERSON)))
+        assert response.status_code == 303
+        assert response.headers["location"] == "/admin"
+
+    def test_the_dashboard_renders_for_an_identified_visitor(self, access_on, no_password):
+        assert run(admin.admin_page(_FakeRequest(PERSON))).status_code == 200
+
+    def test_the_dashboard_redirects_an_unidentified_visitor(self, access_off, with_password):
+        response = run(admin.admin_page(_FakeRequest()))
+        assert response.status_code == 303
+        assert response.headers["location"] == "/admin/login"
+
+    def test_login_says_so_when_nothing_can_authenticate(self, client, access_off, no_password):
+        """No password and no Access: a form that cannot succeed is worse than a message."""
+        response = client.get("/admin/login", follow_redirects=False)
+        assert response.status_code == 403
+        assert "disabled" in response.text.lower()
+
+    def test_the_form_still_renders_when_a_password_is_configured(
+        self, client, access_off, with_password
+    ):
+        response = client.get("/admin/login", follow_redirects=False)
+        assert response.status_code == 200
+        assert "password" in response.text.lower()
+
+
+class TestLogout:
+    def test_it_ends_the_access_session_when_the_gate_is_on(self, access_on, no_password):
+        """Deleting the app cookie does nothing to an Access session — the old target
+        bounced straight back to the dashboard, so the button appeared to do nothing."""
+        response = run(admin.logout())
+        assert response.status_code == 303
+        assert response.headers["location"] == f"https://{TEAM}/cdn-cgi/access/logout"
+
+    def test_it_returns_to_the_login_page_when_the_gate_is_off(self, access_off, with_password):
+        assert run(admin.logout()).headers["location"] == "/admin/login"
+
+    def test_a_team_domain_with_a_scheme_is_tolerated(self, monkeypatch, no_password):
+        monkeypatch.setattr(settings, "CF_ACCESS_TEAM_DOMAIN", f"https://{TEAM}/")
+        monkeypatch.setattr(settings, "CF_ACCESS_AUD", AUD)
+        response = run(admin.logout())
+        assert response.headers["location"] == f"https://{TEAM}/cdn-cgi/access/logout"

--- a/backend/tests/test_origin_gates.py
+++ b/backend/tests/test_origin_gates.py
@@ -51,17 +51,30 @@ class TestGatesInertWhenUnconfigured:
     without breaking local dev, CI, or the running site.
     """
 
-    # Asserted as "not 403" rather than as a specific status on purpose. What matters is
-    # that the middleware passed the request through; what it then meets is not this
-    # test's business. Pinning an exact code here once meant pinning 404 — the code you
-    # get when /admin does not exist — which broke as soon as PR #36 added the admin
-    # subsite and /admin started answering 303 and 200.
+    # What matters is that the *middleware* passed the request through; what the handler
+    # then decides is not this test's business. That distinction has now bitten twice:
+    #
+    #   - pinning an exact status meant pinning 404, which broke when #36 added the admin
+    #     subsite and /admin began answering 303
+    #   - relaxing it to "not 403" broke when /admin/login gained its own, legitimate 403
+    #     for "no password configured and no Access identity"
+    #
+    # So assert on the gate's own rejection body instead, which is unambiguous.
 
-    def test_admin_is_not_403ed_when_unconfigured(self, client, gates_off):
-        assert client.get("/admin", follow_redirects=False).status_code != 403
+    # Distinguished by shape, not by wording: the middleware rejects with JSON, every
+    # /admin handler responds with HTML or a redirect. Matching on the phrase "Cloudflare
+    # Access" was the first attempt and it false-positived, because the handler's own
+    # "login is disabled" page mentions Cloudflare Access too.
+    def _passed_the_gate(self, response):
+        if response.status_code != 403:
+            return True
+        return "application/json" not in response.headers.get("content-type", "")
 
-    def test_admin_login_is_not_403ed_when_unconfigured(self, client, gates_off):
-        assert client.get("/admin/login", follow_redirects=False).status_code != 403
+    def test_admin_is_not_gated_when_unconfigured(self, client, gates_off):
+        assert self._passed_the_gate(client.get("/admin", follow_redirects=False))
+
+    def test_admin_login_is_not_gated_when_unconfigured(self, client, gates_off):
+        assert self._passed_the_gate(client.get("/admin/login", follow_redirects=False))
 
 
 # --- Configured: /admin gate ---


### PR DESCRIPTION
Phase 2 is live and verified, so the shared admin password no longer needs to exist.

A shared `ADMIN_PASSWORD` identifies nobody — you can't tell who approved an event, and removing one collaborator means rotating for everyone. Cloudflare Access already identifies people individually, and it's now enforced at the origin:

```
direct origin /admin  →  403          ← tokenless requests rejected
via Cloudflare        →  302 → ty-fi.cloudflareaccess.com/...
configured AUD == Cloudflare's AUD    ← exact match
```

## The change

`require_admin()` accepts a verified Access identity, and **returns who is acting** — their email, or `"admin"` for a password session, which carries no identity. Handlers can take it as a parameter to attribute an action to a person. That's what the review's objection to a shared credential was about, and what [#63](https://github.com/triangle-shows/triangle-shows/issues/63) will want for duplicate flagging.

## The security detail that matters most

`_admin_enabled()` widens to "password login **or** Access configured". But the password check must **not** follow that widening, so `_password_login_enabled()` is new and deliberately separate:

> `compare_digest("", "")` returns `True`. Gating the password check on the widened predicate would hand a session to anyone posting an **empty password** when no `ADMIN_PASSWORD` is set — which is exactly the configuration this PR makes normal.

Both properties are mutation-checked:

| mutation | result |
|---|---|
| password check gated on `_admin_enabled()` | **2 tests fail** |
| configured-gate check removed from `_access_identity()` | **1 test fails** |

Trusting `request.state.access_email` is sound only because the origin rejects tokenless requests — the header itself can be set by any client. The middleware never sets it from an unverified header, and `_access_identity()` additionally refuses to read it unless the gate is configured, so the fail-safe direction holds if middleware order ever changes.

## Two fixes that fall out of it

**`/admin/login`** redirects an already-identified visitor to the dashboard, instead of showing a password box that would only reject them. With neither method available it says login is disabled rather than presenting a form that cannot succeed.

**`/admin/logout`** points at Cloudflare's logout endpoint when the gate is on. Deleting the app cookie does nothing to an Access session, so the old target sent you to `/admin/login`, which recognised your still-valid identity and bounced you back to the dashboard — **a logout button that visibly did nothing.**

The cookie path is untouched, so local dev and `docker-compose` (`ADMIN_PASSWORD=devpassword`) work exactly as before.

## What this does to Phase 3

**It needs no secrets at all.** With no password login there's no cookie to sign, so `SESSION_SECRET` is unused too — the two `--update-secrets` lines in `cloudbuild.yaml` can stay commented out permanently. Merge this, promote, and `/admin` works for anyone on the Access policy.

Onboarding a collaborator becomes "add their email to the Access policy". Revoking becomes "remove it" — no rotation, nobody else disrupted.

**Break-glass** is unchanged and deliberately a deploy, not a runtime flag: clear `CF_ACCESS_AUD` and redeploy. Note that with no password configured that leaves `/admin` disabled rather than password-protected, which is the safe direction.

## One test I had to fix

`test_origin_gates.py` used "not 403" as a proxy for "the middleware passed the request through". That proxy broke here, because `/admin/login` gained a legitimate 403 of its own. It now distinguishes them by **shape** — the middleware rejects with JSON, handlers respond with HTML or a redirect — rather than by wording, which also false-positived because the disabled-login page mentions Cloudflare Access too. Third time that assertion has needed loosening; keying on structure should end it.

**280 passing.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)