### PR TITLE
Implement Cloudflare Access for admin authentication

### DIFF
--- a/backend/app/api/admin.py
+++ b/backend/app/api/admin.py
@@ -10,6 +10,7 @@ admin is disabled (fails closed). Must be registered before the "/" static mount
 main.py so these routes take priority over the catch-all.
 Requires: async PostgreSQL session, app.classifier, app.scrapers.manager, itsdangerous.
 """
+import logging
 import secrets
 from datetime import date, datetime
 from typing import Optional
@@ -28,6 +29,9 @@ from app.models import Event, Venue, SeriesOverride
 from app.classifier import normalize_series_name, criteria_summary, reclassify_floor
 from app.scrapers.manager import ScrapeManager
 from app.admin_ui import LOGIN_HTML, ADMIN_HTML
+from app import tokens
+
+logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/admin", tags=["admin"])
 
@@ -43,9 +47,43 @@ _signing_key = settings.SESSION_SECRET or secrets.token_urlsafe(32)
 _serializer = URLSafeTimedSerializer(_signing_key, salt="ts-admin-session")
 
 
-def _admin_enabled() -> bool:
-    """Admin is reachable only when a password is configured."""
+def _password_login_enabled() -> bool:
+    """Whether the shared-password login is usable at all.
+
+    Kept separate from _admin_enabled() on purpose. This is the check that stops
+    compare_digest comparing a guess against "" — which would accept an empty password —
+    so it must stay pinned to ADMIN_PASSWORD alone and must not widen when some other
+    authentication method becomes available.
+    """
     return bool(settings.ADMIN_PASSWORD)
+
+
+def _admin_enabled() -> bool:
+    """Whether /admin can authenticate anyone at all — by either method.
+
+    Cloudflare Access counts. When the origin gate is enforcing, every request that
+    reaches a handler has already presented a token Cloudflare signed for a person on the
+    Access policy, which is strictly stronger identification than a password shared by
+    everyone. So a password is no longer required for the admin surface to exist.
+    """
+    return _password_login_enabled() or tokens.cloudflare_access_configured()
+
+
+def _access_identity(request: Request) -> Optional[str]:
+    """The Cloudflare-verified person behind this request, if there is one.
+
+    Set by the enforce_admin_access middleware in app.main, which has already checked the
+    token's signature, expiry, audience and issuer. Absent when the gate is not
+    configured — in which case there is no verified identity and the cookie path applies.
+
+    Trusting this is only sound because the gate rejects tokenless requests at the origin.
+    If /admin were reachable without a token, treating its absence as "fall back to the
+    cookie" would be fine, but treating its presence as proof would not be — the header
+    can be set by any client. The middleware never sets this from an unverified header.
+    """
+    if not tokens.cloudflare_access_configured():
+        return None
+    return getattr(request.state, "access_email", None)
 
 
 def _issue_cookie(response) -> None:
@@ -72,11 +110,19 @@ def _is_authenticated(request: Request) -> bool:
         return False
 
 
-async def require_admin(request: Request) -> bool:
-    """Dependency guarding /admin/api/* — raises 401 for the frontend to redirect on."""
-    if not _is_authenticated(request):
-        raise HTTPException(status_code=401, detail="Not authenticated")
-    return True
+async def require_admin(request: Request) -> str:
+    """Dependency guarding /admin/api/* — raises 401 for the frontend to redirect on.
+
+    Returns who is acting: their email when Cloudflare Access identified them, otherwise
+    "admin" for a password session, which carries no identity. Handlers can take it as a
+    parameter to attribute an action to a person.
+    """
+    identity = _access_identity(request)
+    if identity:
+        return identity
+    if _is_authenticated(request):
+        return "admin"
+    raise HTTPException(status_code=401, detail="Not authenticated")
 
 
 # --- Request bodies ---
@@ -98,7 +144,20 @@ class SeriesBody(BaseModel):
 # --- Auth + page routes ---
 
 @router.get("/login", response_class=HTMLResponse)
-async def login_page() -> HTMLResponse:
+async def login_page(request: Request):
+    # Already identified by Cloudflare Access — there is nothing to log in to, so don't
+    # show a password box that would only reject them. A visitor who reached this page at
+    # all has passed the origin gate.
+    if _access_identity(request):
+        return RedirectResponse("/admin", status_code=303)
+    if not _password_login_enabled():
+        # No password configured and no Access identity: nothing can authenticate here.
+        # Say so rather than presenting a form that cannot succeed.
+        return HTMLResponse(
+            "<h1>Admin login is disabled</h1><p>No password is configured, and this "
+            "request did not arrive through Cloudflare Access.</p>",
+            status_code=403,
+        )
     return HTMLResponse(LOGIN_HTML)
 
 
@@ -113,7 +172,12 @@ async def login_submit(body: LoginBody):
     # attempt into a 500 instead of a clean 401 — and, since the message differs, told the
     # caller something about the configured password. UTF-8 on both sides compares the
     # same bytes the client sent.
-    if _admin_enabled() and secrets.compare_digest(
+    #
+    # Gated on _password_login_enabled(), not _admin_enabled(): the latter is now true
+    # whenever Cloudflare Access is configured, and with no ADMIN_PASSWORD set that would
+    # let compare_digest("", "") succeed and hand out a session to anyone posting an empty
+    # password. The two checks exist separately for exactly this reason.
+    if _password_login_enabled() and secrets.compare_digest(
         body.password.encode("utf-8"), settings.ADMIN_PASSWORD.encode("utf-8")
     ):
         response = JSONResponse({"ok": True})
@@ -124,13 +188,31 @@ async def login_submit(body: LoginBody):
 
 @router.get("/logout")
 async def logout() -> RedirectResponse:
-    response = RedirectResponse("/admin/login", status_code=303)
+    """Log out of whichever session is actually in force.
+
+    Deleting the app's cookie does nothing to a Cloudflare Access session, so with the
+    gate enforcing, the old behavior sent you to /admin/login, which recognised your still
+    valid Access identity and bounced you straight back to the dashboard — a logout button
+    that visibly did nothing. Cloudflare's own logout endpoint is what ends that session.
+    """
+    target = "/admin/login"
+    if tokens.cloudflare_access_configured():
+        team_domain = settings.CF_ACCESS_TEAM_DOMAIN.strip().rstrip("/")
+        if "://" in team_domain:
+            team_domain = team_domain.split("://", 1)[1]
+        target = f"https://{team_domain}/cdn-cgi/access/logout"
+
+    response = RedirectResponse(target, status_code=303)
     response.delete_cookie(COOKIE_NAME, path="/admin")
     return response
 
 
 @router.get("", response_class=HTMLResponse)
 async def admin_page(request: Request):
+    identity = _access_identity(request)
+    if identity:
+        logger.info(f"[admin] dashboard opened by {identity}")
+        return HTMLResponse(ADMIN_HTML)
     if not _is_authenticated(request):
         return RedirectResponse("/admin/login", status_code=303)
     return HTMLResponse(ADMIN_HTML)

--- a/backend/tests/test_admin_access_auth.py
+++ b/backend/tests/test_admin_access_auth.py
@@ -1,0 +1,208 @@
+"""
+Tests for treating a Cloudflare Access identity as admin authentication.
+
+Why this exists. A single shared ADMIN_PASSWORD has no per-person identity: you cannot
+tell who approved an event, and removing one collaborator's access means rotating the
+password for everyone holding it. Cloudflare Access already identifies people
+individually; this wires that to the app so the shared secret can stop existing.
+
+Safe only because the origin gate rejects tokenless requests — verified in production,
+where `GET https://<origin>/admin` returns 403. If /admin were reachable without a token,
+the Cf-Access-Jwt-Assertion header could be set by any client and trusting it would be an
+open door. The middleware in app.main never sets request.state.access_email from an
+unverified header, and _access_identity() additionally refuses to read it unless the gate
+is configured.
+
+The most important class here is TestEmptyPasswordIsNeverAccepted. Widening
+_admin_enabled() to include "Access is configured" would, if the password check were
+gated on it, let compare_digest("", "") succeed and hand a session to anyone posting an
+empty password. _password_login_enabled() exists separately for exactly that reason.
+
+Handlers are called directly rather than over HTTP: pytest-asyncio is deliberately absent
+from requirements-dev.txt, and with the gate configured the middleware answers /admin/*
+with 403 before any handler runs, so an HTTP request cannot reach the code under test.
+"""
+
+import asyncio
+
+from fastapi import HTTPException
+from fastapi.testclient import TestClient
+
+import pytest
+
+from app.api import admin
+from app.config import settings
+from app.main import app
+
+
+TEAM = "ty-fi.cloudflareaccess.com"
+AUD = "2672446ca36104364662d122c152746305f880c1d9fb818c0b1ec6cb55c8f0c4"
+PERSON = "collaborator@example.org"
+
+
+def run(coro):
+    """Drive one coroutine to completion."""
+    return asyncio.run(coro)
+
+
+class _FakeState:
+    def __init__(self, email=None):
+        if email is not None:
+            self.access_email = email
+
+
+class _FakeRequest:
+    """Stands in for a Request the middleware has already annotated."""
+
+    def __init__(self, email=None, cookies=None):
+        self.state = _FakeState(email)
+        self.cookies = cookies or {}
+
+
+@pytest.fixture
+def client():
+    return TestClient(app)
+
+
+@pytest.fixture
+def access_on(monkeypatch):
+    monkeypatch.setattr(settings, "CF_ACCESS_TEAM_DOMAIN", TEAM)
+    monkeypatch.setattr(settings, "CF_ACCESS_AUD", AUD)
+
+
+@pytest.fixture
+def access_off(monkeypatch):
+    monkeypatch.setattr(settings, "CF_ACCESS_TEAM_DOMAIN", "")
+    monkeypatch.setattr(settings, "CF_ACCESS_AUD", "")
+
+
+@pytest.fixture
+def no_password(monkeypatch):
+    monkeypatch.setattr(settings, "ADMIN_PASSWORD", "")
+
+
+@pytest.fixture
+def with_password(monkeypatch):
+    monkeypatch.setattr(settings, "ADMIN_PASSWORD", "a-strong-password")
+    monkeypatch.setattr(settings, "SESSION_SECRET", "test-signing-key")
+
+
+# --- the security property that must not regress ---
+
+class TestEmptyPasswordIsNeverAccepted:
+    def test_admin_is_enabled_by_access_alone(self, access_on, no_password):
+        """The widening this change introduces: no password, but admin still works."""
+        assert admin._admin_enabled() is True
+
+    def test_password_login_stays_disabled_without_a_password(self, access_on, no_password):
+        """_password_login_enabled() must not follow _admin_enabled() upward."""
+        assert admin._password_login_enabled() is False
+
+    def test_an_empty_password_is_rejected(self, access_on, no_password):
+        """compare_digest("", "") is True, so gating the password check on
+        _admin_enabled() would hand out a session for an empty post."""
+        assert run(admin.login_submit(admin.LoginBody(password=""))).status_code == 401
+
+    def test_any_password_is_rejected_when_none_is_configured(self, access_on, no_password):
+        assert run(admin.login_submit(admin.LoginBody(password="guess"))).status_code == 401
+
+    def test_no_cookie_is_issued_on_a_rejected_login(self, access_on, no_password):
+        """Belt and braces: even were the status wrong, no session may be handed out."""
+        response = run(admin.login_submit(admin.LoginBody(password="")))
+        assert admin.COOKIE_NAME not in response.headers.get("set-cookie", "")
+
+    def test_the_correct_password_still_works_when_one_is_set(self, access_off, with_password):
+        response = run(admin.login_submit(admin.LoginBody(password="a-strong-password")))
+        assert response.status_code == 200
+
+
+# --- identity resolution ---
+
+class TestAccessIdentity:
+    def test_the_verified_email_is_used(self, access_on):
+        assert admin._access_identity(_FakeRequest(PERSON)) == PERSON
+
+    def test_the_header_is_ignored_when_the_gate_is_not_configured(self, access_off):
+        """Without the gate there is no verified identity, so a value on request.state must
+        not be honored — the fail-safe direction if middleware order ever changes."""
+        assert admin._access_identity(_FakeRequest(PERSON)) is None
+
+    def test_a_missing_identity_is_none(self, access_on):
+        assert admin._access_identity(_FakeRequest()) is None
+
+
+class TestRequireAdmin:
+    def test_an_access_identity_authenticates_without_a_cookie(self, access_on, no_password):
+        assert run(admin.require_admin(_FakeRequest(PERSON))) == PERSON
+
+    def test_no_identity_and_no_cookie_is_a_401(self, access_on, no_password):
+        with pytest.raises(HTTPException) as exc:
+            run(admin.require_admin(_FakeRequest()))
+        assert exc.value.status_code == 401
+
+    def test_a_password_session_still_works(self, access_off, with_password):
+        """The cookie path is unchanged — local dev and docker-compose rely on it."""
+        token = admin._serializer.dumps("admin")
+        result = run(admin.require_admin(_FakeRequest(cookies={admin.COOKIE_NAME: token})))
+        assert result == "admin"
+
+    def test_a_password_session_reports_no_person(self, access_off, with_password):
+        """A shared password identifies nobody, and the return value should say so rather
+        than inventing an email."""
+        token = admin._serializer.dumps("admin")
+        result = run(admin.require_admin(_FakeRequest(cookies={admin.COOKIE_NAME: token})))
+        assert "@" not in result
+
+    def test_a_forged_cookie_is_rejected(self, access_off, with_password):
+        with pytest.raises(HTTPException):
+            run(admin.require_admin(_FakeRequest(cookies={admin.COOKIE_NAME: "nonsense"})))
+
+
+# --- page behavior ---
+
+class TestPages:
+    def test_an_identified_visitor_is_sent_from_login_to_the_dashboard(self, access_on, no_password):
+        """Showing a password box to someone Access already identified would only reject
+        them."""
+        response = run(admin.login_page(_FakeRequest(PERSON)))
+        assert response.status_code == 303
+        assert response.headers["location"] == "/admin"
+
+    def test_the_dashboard_renders_for_an_identified_visitor(self, access_on, no_password):
+        assert run(admin.admin_page(_FakeRequest(PERSON))).status_code == 200
+
+    def test_the_dashboard_redirects_an_unidentified_visitor(self, access_off, with_password):
+        response = run(admin.admin_page(_FakeRequest()))
+        assert response.status_code == 303
+        assert response.headers["location"] == "/admin/login"
+
+    def test_login_says_so_when_nothing_can_authenticate(self, client, access_off, no_password):
+        """No password and no Access: a form that cannot succeed is worse than a message."""
+        response = client.get("/admin/login", follow_redirects=False)
+        assert response.status_code == 403
+        assert "disabled" in response.text.lower()
+
+    def test_the_form_still_renders_when_a_password_is_configured(
+        self, client, access_off, with_password
+    ):
+        response = client.get("/admin/login", follow_redirects=False)
+        assert response.status_code == 200
+        assert "password" in response.text.lower()
+
+
+class TestLogout:
+    def test_it_ends_the_access_session_when_the_gate_is_on(self, access_on, no_password):
+        """Deleting the app cookie does nothing to an Access session — the old target
+        bounced straight back to the dashboard, so the button appeared to do nothing."""
+        response = run(admin.logout())
+        assert response.status_code == 303
+        assert response.headers["location"] == f"https://{TEAM}/cdn-cgi/access/logout"
+
+    def test_it_returns_to_the_login_page_when_the_gate_is_off(self, access_off, with_password):
+        assert run(admin.logout()).headers["location"] == "/admin/login"
+
+    def test_a_team_domain_with_a_scheme_is_tolerated(self, monkeypatch, no_password):
+        monkeypatch.setattr(settings, "CF_ACCESS_TEAM_DOMAIN", f"https://{TEAM}/")
+        monkeypatch.setattr(settings, "CF_ACCESS_AUD", AUD)
+        response = run(admin.logout())
+        assert response.headers["location"] == f"https://{TEAM}/cdn-cgi/access/logout"

--- a/backend/tests/test_origin_gates.py
+++ b/backend/tests/test_origin_gates.py
@@ -51,17 +51,30 @@ class TestGatesInertWhenUnconfigured:
     without breaking local dev, CI, or the running site.
     """
 
-    # Asserted as "not 403" rather than as a specific status on purpose. What matters is
-    # that the middleware passed the request through; what it then meets is not this
-    # test's business. Pinning an exact code here once meant pinning 404 — the code you
-    # get when /admin does not exist — which broke as soon as PR #36 added the admin
-    # subsite and /admin started answering 303 and 200.
+    # What matters is that the *middleware* passed the request through; what the handler
+    # then decides is not this test's business. That distinction has now bitten twice:
+    #
+    #   - pinning an exact status meant pinning 404, which broke when #36 added the admin
+    #     subsite and /admin began answering 303
+    #   - relaxing it to "not 403" broke when /admin/login gained its own, legitimate 403
+    #     for "no password configured and no Access identity"
+    #
+    # So assert on the gate's own rejection body instead, which is unambiguous.
 
-    def test_admin_is_not_403ed_when_unconfigured(self, client, gates_off):
-        assert client.get("/admin", follow_redirects=False).status_code != 403
+    # Distinguished by shape, not by wording: the middleware rejects with JSON, every
+    # /admin handler responds with HTML or a redirect. Matching on the phrase "Cloudflare
+    # Access" was the first attempt and it false-positived, because the handler's own
+    # "login is disabled" page mentions Cloudflare Access too.
+    def _passed_the_gate(self, response):
+        if response.status_code != 403:
+            return True
+        return "application/json" not in response.headers.get("content-type", "")
 
-    def test_admin_login_is_not_403ed_when_unconfigured(self, client, gates_off):
-        assert client.get("/admin/login", follow_redirects=False).status_code != 403
+    def test_admin_is_not_gated_when_unconfigured(self, client, gates_off):
+        assert self._passed_the_gate(client.get("/admin", follow_redirects=False))
+
+    def test_admin_login_is_not_gated_when_unconfigured(self, client, gates_off):
+        assert self._passed_the_gate(client.get("/admin/login", follow_redirects=False))
 
 
 # --- Configured: /admin gate ---

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,7 +1,7 @@
 # Architecture
 
 How a request reaches the app, and how a commit becomes a deploy. Values here were verified
-against the live infrastructure on 2026-08-26.
+against the live infrastructure on 2026-08-27.
 
 For the branch and release workflow see [CONTRIBUTING.md](../.github/CONTRIBUTING.md).
 For running the app on your own machine see [SELF-HOSTING.md](SELF-HOSTING.md).
@@ -153,21 +153,77 @@ commit is live. That's what [`tools/wait_for_deploy.py`](../tools/wait_for_deplo
 | request timeout | 300s | Scrape requests can be slow |
 | `APP_ENV` | `production` | |
 | `ENABLE_SCHEDULER` | `false` | Scraping is driven externally by Cloud Scheduler, not in-process |
+| `ENABLE_STARTUP_SCRAPE` | `false` | See below — a detached task cannot work under this service's CPU allocation |
 | `LOG_LEVEL` | `INFO` | |
 | `DATABASE_URL` | secret `triangle-shows-db-url` | |
 | `TICKETMASTER_API_KEY` | secret `triangle-shows-tm-api-key` | |
+| `SCRAPE_ALLOWED_SERVICE_ACCOUNTS` | the scheduler's service account | Gates `POST /api/scrape` — see Origin gates |
+| `SCRAPE_OIDC_AUDIENCE` | `https://triangle-shows.net/api/scrape` | The audience configured on the scheduler job |
+| `CF_ACCESS_TEAM_DOMAIN` | the Cloudflare Zero Trust team domain | Gates `/admin/*` |
+| `CF_ACCESS_AUD` | the Access application's AUD tag | An identifier, not a credential — see Origin gates |
 
-The admin subsite (`/admin`) is **disabled**. It requires `ADMIN_PASSWORD` and `SESSION_SECRET`,
-neither of which exists in Secret Manager, and the corresponding lines in `cloudbuild.yaml` are
-commented out. It fails closed, so the rest of the site is unaffected. Create both secrets
-*before* uncommenting, or the deploy fails on a missing secret.
+**No admin secrets exist, and none are needed.** `ADMIN_PASSWORD` and `SESSION_SECRET` are
+absent from Secret Manager and their `cloudbuild.yaml` lines are commented out deliberately:
+`/admin` authenticates from the Cloudflare Access identity instead, so there is no shared
+password to distribute or rotate, and with no password login there is no cookie to sign.
+Access to the admin surface is granted by adding someone to the `triangle-shows` GitHub
+organization and revoked by removing them.
+
+**Why the on-boot scrape is off.** It ran as a detached asyncio task, and this service sets no
+CPU-throttling override, so Cloud Run allocates CPU only while a request is in flight — the
+task was starved as soon as startup finished. On the 2026-08-27 release it deleted rows in
+dribs over five minutes as health checks briefly granted CPU, never reached the reclassify
+pass at the end, and emitted no stdout at all, so the live-music filter shipped classifying
+nothing with no logs to say so. Cloud Scheduler already calls `POST /api/scrape` every six
+hours inside a real request, which is where a scrape belongs.
+
+### Origin gates
+
+The service accepts unauthenticated requests — it has to, for the public site to work — so its
+`.run.app` hostnames reach the app directly, skipping Cloudflare and anything enforced there.
+A Cloudflare Access policy on `triangle-shows.net/admin` therefore protects only the Cloudflare
+path; on its own it leaves the origin open.
+
+`backend/app/tokens.py` closes that by making the application itself require proof that a
+request passed through a trusted issuer. Both issuers sign a short-lived token and publish the
+matching public keys, so verification is local arithmetic against cached keys:
+
+| Route | Issuer | Header |
+|---|---|---|
+| `/admin/*` | Cloudflare Access | `Cf-Access-Jwt-Assertion` |
+| `POST /api/scrape` | Google (Cloud Scheduler's OIDC token) | `Authorization: Bearer …` |
+
+Four checks on each: signature, expiry, audience, issuer. Both gates are inert until their env
+vars are set, and `log_enforcement_state()` states on every boot which are live — a control that
+silently does nothing when misconfigured is worse than an absent one, because it reads as
+protection.
+
+Verified in production: `GET https://<origin>/admin` and `POST https://<origin>/api/scrape` both
+return 403, while a signed-in request through Cloudflare reaches the app normally.
+
+Restricting Cloud Run ingress is *not* an alternative here. `internal-and-cloud-load-balancing`
+admits only Google's load balancer, and Cloudflare is not one — it reaches the origin over the
+public internet like any other client. Making that setting work would mean reintroducing the
+GCP HTTPS Load Balancer deleted during the Cloudflare migration, which is also why IAP is out.
 
 ## Scheduled scraping
 
 Cloud Scheduler job `triangle-shows-scrape` posts to `/api/scrape` on `0 */6 * * *` (UTC), using
-the project-number Cloud Run URL and OIDC authentication. This is why `ENABLE_SCHEDULER` is
-`false` in the container — the schedule lives outside the app, so a scaled-to-zero service still
-gets scraped, and two running instances don't scrape twice.
+the project-number Cloud Run URL and an OIDC token from a dedicated service account,
+`triangle-shows-scrape@…`, rather than the project's default compute identity. This is why
+`ENABLE_SCHEDULER` is `false` in the container — the schedule lives outside the app, so a
+scaled-to-zero service still gets scraped, and two running instances don't scrape twice.
+
+**The application verifies that token** (see Origin gates). Cloud Run cannot do it for us,
+because the service must accept unauthenticated requests for the public site to work, so the
+token arrives and is simply ignored unless the app checks it. The allowlisted service-account
+email is the substantive control; granting a second caller is a matter of adding its email to
+`SCRAPE_ALLOWED_SERVICE_ACCOUNTS`, which is configuration rather than code.
+
+Since this endpoint drives the whole dataset, note that a scrape also runs the reclassify pass
+and the reconcile that deletes listings a source has stopped carrying. Its response reports both
+the per-venue counts and the reclassify result, so a manual trigger says what it did without
+needing the logs.
 
 ## Data
 


### PR DESCRIPTION
This pull request introduces Cloudflare Access as an alternative authentication method for the `/admin` interface, allowing per-user identification and removing the strict requirement for a shared admin password. It carefully separates password-based and Cloudflare-based authentication to avoid security regressions, especially ensuring that an empty password is never accepted. The changes also improve the admin login/logout flow and add comprehensive tests to guarantee correct and secure behavior.

Authentication and Authorization Improvements:
* Added Cloudflare Access as a valid authentication method for `/admin`, allowing users identified by Cloudflare to access admin routes without a shared password. The new `_access_identity()` function checks for a verified Cloudflare identity, and `_admin_enabled()` now returns true if either a password or Cloudflare Access is configured.
* Separated `_password_login_enabled()` from `_admin_enabled()` to ensure that password checks are only performed when a password is actually configured, preventing accidental acceptance of empty passwords. [[1]](diffhunk://#diff-fae045e7735b2ec0ed1eafd802d879738a836eaf94a729fd084503bd5273754fL46-R88) [[2]](diffhunk://#diff-fae045e7735b2ec0ed1eafd802d879738a836eaf94a729fd084503bd5273754fL116-R180)
* Updated `require_admin()` to return the acting user's email (when authenticated via Cloudflare) or "admin" (for password sessions), allowing handlers to attribute actions to individuals.

Admin Page and Session Flow Enhancements:
* Modified the admin login page to redirect Cloudflare-authenticated users directly to the dashboard and to clearly indicate when login is disabled due to lack of authentication methods.
* Improved the logout endpoint to properly end Cloudflare Access sessions by redirecting to Cloudflare's logout URL when Access is configured, instead of just deleting the app's cookie.

Testing and Security Assurance:
* Added a comprehensive new test suite (`test_admin_access_auth.py`) to verify that Cloudflare Access authentication works correctly, that empty passwords are never accepted, and that all authentication and page flows behave as intended.
* Updated origin gate tests to distinguish between middleware and handler rejections, ensuring that admin routes are only gated by the intended mechanism and not by handler logic.