### PR TITLE
Rework calendar type and tile contrast, add a night-density equalizer

### DIFF
--- a/backend/app/seed.py
+++ b/backend/app/seed.py
@@ -285,7 +285,15 @@ VENUES = [
         "website": "https://carolinatheatre.org/",
         "scraper_type": "carolina_theatre",
         "scraper_config": {"url": "https://carolinatheatre.org/events/"},
-        "color": "#F5D765",  # yellow (Durham)
+        # Was #F5D765, a bright yellow that sat outside the jewel-tone family every other
+        # venue uses and failed contrast in both modes (1.42:1 white-on-tile in dark,
+        # ~1.2:1 as tile text in light). Citrine keeps the warm identity, joins the
+        # palette, and measures 7.11:1 against white -- clearing the normalizer in
+        # frontend/js/design.js on its own rather than being clamped by it.
+        # Hue is 56 deg rather than a browner gold: that puts ~30 deg between it and
+        # Stanczyks' espresso (#5a3a20), the nearest warm tone and also a Durham venue,
+        # so the two do not read alike when they land in the same week.
+        "color": "#5f5a0b",  # citrine (Durham)
     },
 ]
 

--- a/frontend/css/styles.css
+++ b/frontend/css/styles.css
@@ -25,12 +25,6 @@
   --font-data:     'IBM Plex Mono', 'Space Mono', ui-monospace, monospace;
   --font-pixel:    'Silkscreen', 'Space Mono', ui-monospace, monospace;
 
-  /* Ink for text sitting on a venue-colored tile. Mixed from --text rather than fixed, so
-     each palette gets an off-white with its own cast. Deliberately not #fff: pure white on
-     a saturated field blooms at the edges and reads softer than the same measured
-     contrast in an off-white. */
-  --tile-ink:     color-mix(in srgb, white 62%, var(--text));
-  --tile-ink-dim: color-mix(in srgb, white 20%, var(--text));
 
   /* Hearted shows in the equalizer. Deliberately off-palette -- it is the one thing in
      the strip that is not "how busy is that night", so it should not be a shade of the
@@ -770,7 +764,7 @@ a:hover { color: var(--accent-hover); text-decoration: underline; }
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
-  color: var(--tile-ink);
+  color: var(--text);
 }
 /* Venue line.
    Was 10.1px at 78% alpha. Two problems: 10px is under the floor for a mono, and
@@ -782,7 +776,7 @@ a:hover { color: var(--accent-hover); text-decoration: underline; }
   font-weight: 400;
   letter-spacing: 0.015em;
   line-height: 1.3;
-  color: var(--tile-ink-dim);
+  color: color-mix(in srgb, var(--muted) 60%, var(--text));
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -1200,14 +1194,10 @@ html[data-mode="light"] .fc-list-event .ev-heart { color: rgba(0,0,0,0.35); }
 html[data-mode="light"] .fc-list-event .ev-hide  { color: rgba(0,0,0,0.25); }
 html[data-mode="light"] .venue-hide-btn          { color: rgba(0,0,0,0.35); }
 
-/* Light mode: daygrid event chips — light bg + accent text so venue colors aren't washed */
-html[data-mode="light"] .fc .fc-daygrid-event {
-  background-color: var(--surface2) !important;
-}
-html[data-mode="light"] .fc-daygrid-event .ev-title { color: var(--venue-color, var(--accent)); }
-html[data-mode="light"] .fc-daygrid-event .ev-venue { color: var(--muted); }
-html[data-mode="light"] .fc-daygrid-event .ev-heart { color: rgba(0,0,0,0.35); }
-html[data-mode="light"] .fc-daygrid-event .ev-hide  { color: rgba(0,0,0,0.3);  }
+/* Light mode needs nothing special for daygrid events now. The block that used to live
+   here put them on --surface2 and colored the title with the venue color, to rescue the
+   filled tile in light mode. The gutter treatment already does that in both modes, and
+   these rules were (0,3,1) -- high enough to override it. */
 
 /* === Spotify === */
 .spotify-connect-wrap { margin-top: 0.55rem; }
@@ -1338,32 +1328,38 @@ html[data-mode="light"] .fc-daygrid-event .ev-hide  { color: rgba(0,0,0,0.3);  }
    background-color needs !important because FullCalendar writes the venue color to
    the element as an inline style. */
 
-html[data-tiles="gutter"] .fc .fc-daygrid-event {
+.fc .fc-daygrid-event {
   background-color: var(--surface2) !important;
   border: none !important;
 }
-html[data-tiles="gutter"] .fc .fc-daygrid-event .ev {
-  border-left: 3px solid var(--venue-color, var(--accent));
+.fc .fc-daygrid-event .ev,
+.fc .fc-list-event .ev {
+  border-left: 3px solid var(--venue-rule-dark, var(--venue-color, var(--accent)));
   padding-left: 6px;
 }
-html[data-tiles="gutter"] .fc .fc-daygrid-event .ev-title { color: var(--text); }
+html[data-mode="light"] .fc .fc-daygrid-event .ev,
+html[data-mode="light"] .fc .fc-list-event .ev {
+  border-left-color: var(--venue-rule-light, var(--venue-color, var(--accent)));
+}
+.fc .fc-daygrid-event .ev-title { color: var(--text); }
 /* Not plain --muted: measured at 4.07:1 on --surface2, which is under the 4.5 floor for
    11px text. Lifted toward --text until it clears, in every palette and both modes. */
-html[data-tiles="gutter"] .fc .fc-daygrid-event .ev-venue {
+.fc .fc-daygrid-event .ev-venue {
   color: color-mix(in srgb, var(--muted) 60%, var(--text));
 }
-html[data-tiles="gutter"] .fc .fc-daygrid-event:hover {
+.fc .fc-daygrid-event:hover {
   background-color: color-mix(in srgb, var(--venue-color, var(--accent)) 14%, var(--surface2)) !important;
 }
-html[data-tiles="gutter"] .fc .fc-daygrid-event .ev-heart,
-html[data-tiles="gutter"] .fc .fc-daygrid-event .ev-hide {
+.fc .fc-daygrid-event .ev-heart,
+.fc .fc-daygrid-event .ev-hide {
   color: var(--dim);
 }
 
-/* The list view already draws on the surface, so it only needs the same gutter. */
-html[data-tiles="gutter"] .fc .fc-list-event .ev {
-  border-left: 3px solid var(--venue-color, var(--accent));
-  padding-left: 6px;
+/* The list view's own dot is drawn by FullCalendar from the event's border color, which
+   is the unbrightened seed value -- same invisibility problem on a dark surface. */
+.fc .fc-list-event-dot { border-color: var(--venue-rule-dark, var(--venue-color)) !important; }
+html[data-mode="light"] .fc .fc-list-event-dot {
+  border-color: var(--venue-rule-light, var(--venue-color)) !important;
 }
 
 
@@ -1376,24 +1372,45 @@ html[data-tiles="gutter"] .fc .fc-list-event .ev {
    gets closer to that than turning one shadow up would -- a single wide shadow at high
    opacity just goes muddy. */
 html[data-glow="on"] .ascii-title {
-  text-shadow: 0 0 2px  color-mix(in srgb, var(--accent) 85%, transparent),
-               0 0 9px  color-mix(in srgb, var(--accent) 75%, transparent),
-               0 0 22px color-mix(in srgb, var(--accent) 45%, transparent),
-               0 0 42px color-mix(in srgb, var(--accent) 22%, transparent);
+  text-shadow: 0 0 2px  color-mix(in srgb, var(--accent) 68%, transparent),
+               0 0 9px  color-mix(in srgb, var(--accent) 58%, transparent),
+               0 0 22px color-mix(in srgb, var(--accent) 33%, transparent),
+               0 0 42px color-mix(in srgb, var(--accent) 15%, transparent);
 }
 html[data-glow="on"] .site-title,
 html[data-glow="on"] .site-subtitle,
 html[data-glow="on"] .fc .fc-toolbar-title,
 html[data-glow="on"] .filter-label,
 html[data-glow="on"] .ls-text {
-  text-shadow: 0 0 2px  color-mix(in srgb, var(--accent) 60%, transparent),
-               0 0 8px  color-mix(in srgb, var(--accent) 62%, transparent),
-               0 0 18px color-mix(in srgb, var(--accent) 30%, transparent);
+  text-shadow: 0 0 2px  color-mix(in srgb, var(--accent) 46%, transparent),
+               0 0 8px  color-mix(in srgb, var(--accent) 46%, transparent),
+               0 0 18px color-mix(in srgb, var(--accent) 21%, transparent);
 }
 html[data-glow="on"] .cursor,
 html[data-glow="on"] .ls-cursor {
-  box-shadow: 0 0 4px  color-mix(in srgb, var(--accent) 90%, transparent),
-              0 0 12px color-mix(in srgb, var(--accent) 55%, transparent);
+  box-shadow: 0 0 4px  color-mix(in srgb, var(--accent) 70%, transparent),
+              0 0 12px color-mix(in srgb, var(--accent) 40%, transparent);
+}
+
+/* Calendar chrome: weekday headers, day numbers, and the list view's date headers.
+   These glow in currentColor rather than --accent, because unlike the identity text they
+   are not all accent-colored -- day numbers are --muted, today's is --accent, and the
+   list headers are --accent. Phosphor emits the color it is already showing, so
+   currentColor is both more accurate and self-maintaining. Radii stay tight: these sit
+   at 11-12px, and a wide falloff at that size costs legibility. */
+html[data-glow="on"] .fc .fc-col-header-cell-cushion,
+html[data-glow="on"] .fc .fc-daygrid-day-number,
+html[data-glow="on"] .fc .fc-list-day-text,
+html[data-glow="on"] .fc .fc-list-day-side-text {
+  text-shadow: 0 0 4px  color-mix(in srgb, currentColor 40%, transparent),
+               0 0 10px color-mix(in srgb, currentColor 18%, transparent);
+}
+
+/* Today's number is the one number that is meant to catch the eye, so it gets a little
+   more than its neighbours rather than the same amount. */
+html[data-glow="on"] .fc .fc-day-today .fc-daygrid-day-number {
+  text-shadow: 0 0 3px  color-mix(in srgb, var(--accent) 58%, transparent),
+               0 0 11px color-mix(in srgb, var(--accent) 30%, transparent);
 }
 
 /* Footer. Radius is kept tight here on purpose: bloom has to scale with type size, and
@@ -1401,18 +1418,18 @@ html[data-glow="on"] .ls-cursor {
    mush. Same effect, sized for the text it sits on. */
 html[data-glow="on"] .site-credit,
 html[data-glow="on"] .site-credit a {
-  text-shadow: 0 0 3px color-mix(in srgb, var(--accent) 55%, transparent),
-               0 0 9px color-mix(in srgb, var(--accent) 28%, transparent);
+  text-shadow: 0 0 3px color-mix(in srgb, var(--accent) 44%, transparent),
+               0 0 9px color-mix(in srgb, var(--accent) 20%, transparent);
 }
 
 /* Light mode stays much weaker: bloom on a paper-white ground reads as a printing error
    rather than as phosphor, because there is no dark surround for light to spill into. */
 html[data-glow="on"][data-mode="light"] .ascii-title {
-  text-shadow: 0 0 4px color-mix(in srgb, var(--accent) 26%, transparent);
+  text-shadow: 0 0 4px color-mix(in srgb, var(--accent) 20%, transparent);
 }
 html[data-glow="on"][data-mode="light"] .site-credit,
 html[data-glow="on"][data-mode="light"] .site-credit a {
-  text-shadow: 0 0 3px color-mix(in srgb, var(--accent) 18%, transparent);
+  text-shadow: 0 0 3px color-mix(in srgb, var(--accent) 14%, transparent);
 }
 
 
@@ -1530,52 +1547,6 @@ html[data-glow="on"][data-mode="light"] .site-credit a {
   margin-top: 0.35rem;
   min-height: 1.2em;
   letter-spacing: 0.02em;
-}
-
-
-/* ── Design lab (temporary) ──────────────────────────────────────────────────
-   Comparison controls for this branch. Remove alongside the markup in index.html and
-   the lab section of js/design.js once the direction is chosen. */
-
-.lab-section {
-  border-top: 1px dashed var(--border);
-  padding-top: 0.75rem;
-  margin-top: 0.4rem;
-}
-.lab-label::after {
-  content: " ·branch";
-  color: var(--dim);
-  font-style: italic;
-}
-.lab-row {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 0.5rem;
-  margin-bottom: 0.3rem;
-}
-.lab-row-label {
-  font-family: var(--font-data);
-  font-size: var(--fs-2xs);
-  color: var(--muted);
-}
-.lab-group { display: flex; gap: 3px; }
-.lab-btn {
-  font-family: var(--font-data);
-  font-size: var(--fs-2xs);
-  padding: 2px 6px;
-  background: none;
-  color: var(--dim);
-  border: 1px solid var(--border);
-  border-radius: 1px;
-  cursor: pointer;
-  transition: color 0.12s, border-color 0.12s, background-color 0.12s;
-}
-.lab-btn:hover { color: var(--accent); border-color: var(--accent); }
-.lab-btn.active {
-  color: var(--accent-hover);
-  border-color: var(--accent);
-  background: var(--accent-bg);
 }
 
 

--- a/frontend/css/styles.css
+++ b/frontend/css/styles.css
@@ -8,6 +8,29 @@
 /* === Variables === */
 :root {
   --sidebar-width: 270px;
+
+  /* Type scale. Replaces 19 ad-hoc rem values that included 0.62 / 0.63 / 0.65 -- sizes
+     nobody can tell apart but every one of which had to be maintained. Six steps, named
+     by role, on whole pixels so a monospace grid stays crisp. */
+  --fs-2xs: 0.625rem;   /* 10px — micro labels only, never running text */
+  --fs-xs:  0.6875rem;  /* 11px — venue line, chips, buttons */
+  --fs-sm:  0.75rem;    /* 12px — utility text */
+  --fs-md:  0.8125rem;  /* 13px — event titles, body */
+  --fs-lg:  0.9375rem;  /* 15px — toolbar title, modal headings */
+  --fs-xl:  1.125rem;   /* 18px — modal title */
+
+  /* Two font stacks with different jobs: Space Mono carries the identity, IBM Plex Mono
+     carries the data. Plex holds its counters at 11-13px where Space Mono's fill in. */
+  --font-identity: 'Space Mono', ui-monospace, monospace;
+  --font-data:     'IBM Plex Mono', 'Space Mono', ui-monospace, monospace;
+  --font-pixel:    'Silkscreen', 'Space Mono', ui-monospace, monospace;
+
+  /* Ink for text sitting on a venue-colored tile. Mixed from --text rather than fixed, so
+     each palette gets an off-white with its own cast. Deliberately not #fff: pure white on
+     a saturated field blooms at the edges and reads softer than the same measured
+     contrast in an off-white. */
+  --tile-ink:     color-mix(in srgb, white 62%, var(--text));
+  --tile-ink-dim: color-mix(in srgb, white 20%, var(--text));
   --bg:           #1a1008;
   --surface:      #241609;
   --surface2:     #2e1d0c;
@@ -699,19 +722,34 @@ a:hover { color: var(--accent-hover); text-decoration: underline; }
   padding: 2px 32px 2px 4px; /* right padding reserves space for heart + hide */
   overflow: hidden;
 }
+/* Event title.
+   Was Space Mono 700 at 12px, which is the readability complaint that started this branch.
+   Bold works against a monospace at this size: Space Mono's counters are tight to begin
+   with, and at 12px on a saturated field they close up, so the letterforms lose the shapes
+   that tell them apart. The fix is the opposite of the instinct -- less weight, slightly
+   more size, and a little tracking to open the rhythm. */
 .ev-title {
-  font-family: 'Space Mono', monospace;
-  font-size: 0.75rem;
-  font-weight: 700;
+  font-family: var(--font-data);
+  font-size: var(--fs-md);       /* 13px, up from 12 */
+  font-weight: 500;              /* down from 700 */
+  letter-spacing: 0.005em;
+  line-height: 1.35;
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
-  color: #fff;
+  color: var(--tile-ink);
 }
+/* Venue line.
+   Was 10.1px at 78% alpha. Two problems: 10px is under the floor for a mono, and
+   compositing white over 22 different saturated hues shifted the result differently on
+   every tile. Now 11px in a solid mixed ink, so it reads the same everywhere. */
 .ev-venue {
-  font-family: 'Space Mono', monospace;
-  font-size: 0.63rem;
-  color: rgba(255,255,255,0.78);
+  font-family: var(--font-data);
+  font-size: var(--fs-xs);       /* 11px, up from ~10.1 */
+  font-weight: 400;
+  letter-spacing: 0.015em;
+  line-height: 1.3;
+  color: var(--tile-ink-dim);
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -1249,3 +1287,248 @@ html[data-mode="light"] .fc-daygrid-event .ev-hide  { color: rgba(0,0,0,0.3);  }
 }
 .site-credit a { color: var(--accent); text-decoration: none; }
 .site-credit a:hover { color: var(--accent-hover); }
+
+
+/* ═══════════════════════════════════════════════════════════════════════════
+   VISUAL REFRESH — feature/visual-refresh
+   Tile treatments, CRT texture, and the night-density equalizer.
+   ═══════════════════════════════════════════════════════════════════════════ */
+
+/* ── Tile treatment: gutter ──────────────────────────────────────────────────
+   Alternative to the filled tile. The venue color moves to a 3px left rule and the
+   tile sits on the surface, so event text is never on a saturated field and contrast
+   is identical for all 22 venues. Reads like a log gutter or a diff marker, which
+   suits the terminal frame.
+
+   Specificity note: the light-mode rules further up are (0,3,1). These carry .fc as
+   well to reach (0,4,1) so they win in both modes rather than only in dark.
+   background-color needs !important because FullCalendar writes the venue color to
+   the element as an inline style. */
+
+html[data-tiles="gutter"] .fc .fc-daygrid-event {
+  background-color: var(--surface2) !important;
+  border: none !important;
+}
+html[data-tiles="gutter"] .fc .fc-daygrid-event .ev {
+  border-left: 3px solid var(--venue-color, var(--accent));
+  padding-left: 6px;
+}
+html[data-tiles="gutter"] .fc .fc-daygrid-event .ev-title { color: var(--text); }
+/* Not plain --muted: measured at 4.07:1 on --surface2, which is under the 4.5 floor for
+   11px text. Lifted toward --text until it clears, in every palette and both modes. */
+html[data-tiles="gutter"] .fc .fc-daygrid-event .ev-venue {
+  color: color-mix(in srgb, var(--muted) 60%, var(--text));
+}
+html[data-tiles="gutter"] .fc .fc-daygrid-event:hover {
+  background-color: color-mix(in srgb, var(--venue-color, var(--accent)) 14%, var(--surface2)) !important;
+}
+html[data-tiles="gutter"] .fc .fc-daygrid-event .ev-heart,
+html[data-tiles="gutter"] .fc .fc-daygrid-event .ev-hide {
+  color: var(--dim);
+}
+
+/* The list view already draws on the surface, so it only needs the same gutter. */
+html[data-tiles="gutter"] .fc .fc-list-event .ev {
+  border-left: 3px solid var(--venue-color, var(--accent));
+  padding-left: 6px;
+}
+
+
+/* ── CRT texture: phosphor glow ──────────────────────────────────────────────
+   Accent-colored bloom on identity text only. Never applied to event text, where it
+   would undo the readability work above. */
+
+html[data-glow="on"] .ascii-title {
+  text-shadow: 0 0 6px color-mix(in srgb, var(--accent) 55%, transparent),
+               0 0 14px color-mix(in srgb, var(--accent) 25%, transparent);
+}
+html[data-glow="on"] .site-title,
+html[data-glow="on"] .site-subtitle,
+html[data-glow="on"] .fc .fc-toolbar-title,
+html[data-glow="on"] .filter-label,
+html[data-glow="on"] .ls-text {
+  text-shadow: 0 0 5px color-mix(in srgb, var(--accent) 40%, transparent);
+}
+html[data-glow="on"] .cursor,
+html[data-glow="on"] .ls-cursor {
+  box-shadow: 0 0 6px color-mix(in srgb, var(--accent) 70%, transparent);
+}
+
+/* Light mode gets a much weaker bloom: glow on a paper-white ground reads as a printing
+   error rather than as phosphor. */
+html[data-glow="on"][data-mode="light"] .ascii-title {
+  text-shadow: 0 0 4px color-mix(in srgb, var(--accent) 22%, transparent);
+}
+
+
+/* ── CRT texture: scanlines ──────────────────────────────────────────────────
+   Chrome surfaces only — the header and the sidebar. Deliberately never over the
+   calendar grid or event tiles, where a 50% duty cycle over 11px text is exactly the
+   kind of decoration that costs legibility. */
+
+html[data-scanlines="on"] .app-header::after,
+html[data-scanlines="on"] .sidebar::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  z-index: 3;
+  background: repeating-linear-gradient(
+    to bottom,
+    color-mix(in srgb, var(--bg) 55%, transparent) 0px,
+    color-mix(in srgb, var(--bg) 55%, transparent) 1px,
+    transparent 1px,
+    transparent 3px
+  );
+}
+html[data-scanlines="on"] .sidebar { position: relative; }
+
+
+/* ── Night-density equalizer ─────────────────────────────────────────────────
+   Fourteen bars, one per night, height = number of shows. Sits above the filters it
+   answers to, so changing a filter and watching the bars redraw is a single glance.
+   Built from discrete cells rather than a scaled height so the pixel grid is real. */
+
+.eq-section { padding-bottom: 0.15rem; }
+
+.eq-strip {
+  border: 1px solid var(--border);
+  border-radius: 2px;
+  background: var(--bg);
+  padding: 7px 7px 5px;
+}
+
+.equalizer {
+  display: flex;
+  align-items: flex-end;
+  gap: 2px;
+  height: 54px;           /* 8 cells × 5px + 7 gaps × 2px */
+}
+
+.eq-bar {
+  flex: 1 1 0;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  padding: 0;
+  background: none;
+  border: none;
+  cursor: pointer;
+  height: 100%;
+}
+
+/* Sunday gets a hairline so a fortnight reads as two weeks rather than fourteen days. */
+.eq-bar.eq-week-start { box-shadow: -2px 0 0 -1px var(--border); }
+
+.eq-cell {
+  flex: 1 1 0;
+  border-radius: 0;                        /* square cells — this is a pixel grid */
+  background: var(--surface2);
+  transition: background-color 0.22s ease, opacity 0.22s ease;
+  /* Bars fill left to right, cells bottom to top, so a redraw sweeps rather than snaps. */
+  transition-delay: calc(var(--bar-index) * 18ms + (7 - var(--cell-index)) * 12ms);
+}
+.eq-cell.on  { background: var(--accent); }
+.eq-cell.cap { background: var(--accent-hover); }
+
+.eq-bar:hover  .eq-cell.on,
+.eq-bar:focus-visible .eq-cell.on,
+.eq-bar.is-active .eq-cell.on { background: var(--accent-hover); }
+
+.eq-bar:hover .eq-cell,
+.eq-bar.is-active .eq-cell { background: color-mix(in srgb, var(--accent) 22%, var(--surface2)); }
+
+.eq-bar:focus-visible { outline: 1px solid var(--accent); outline-offset: 1px; }
+
+/* Idle shimmer on the top lit cell only — a slow phosphor flicker, not a bounce. The
+   per-bar delay keeps the fourteen out of lockstep. */
+.eq-cell.cap {
+  animation: eqFlicker 3.4s ease-in-out infinite;
+  animation-delay: calc(var(--bar-index) * 240ms);
+}
+@keyframes eqFlicker {
+  0%, 84%, 100% { opacity: 1; }
+  90%           { opacity: 0.55; }
+}
+
+.eq-ruler {
+  display: flex;
+  justify-content: space-between;
+  margin-top: 5px;
+  font-family: var(--font-pixel);
+  font-size: 6px;
+  letter-spacing: 0.06em;
+  color: var(--dim);
+  text-transform: lowercase;
+  user-select: none;
+}
+
+.eq-readout {
+  font-family: var(--font-data);
+  font-size: var(--fs-2xs);
+  color: var(--muted);
+  margin-top: 0.35rem;
+  min-height: 1.2em;
+  letter-spacing: 0.02em;
+}
+
+
+/* ── Design lab (temporary) ──────────────────────────────────────────────────
+   Comparison controls for this branch. Remove alongside the markup in index.html and
+   the lab section of js/design.js once the direction is chosen. */
+
+.lab-section {
+  border-top: 1px dashed var(--border);
+  padding-top: 0.75rem;
+  margin-top: 0.4rem;
+}
+.lab-label::after {
+  content: " ·branch";
+  color: var(--dim);
+  font-style: italic;
+}
+.lab-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+  margin-bottom: 0.3rem;
+}
+.lab-row-label {
+  font-family: var(--font-data);
+  font-size: var(--fs-2xs);
+  color: var(--muted);
+}
+.lab-group { display: flex; gap: 3px; }
+.lab-btn {
+  font-family: var(--font-data);
+  font-size: var(--fs-2xs);
+  padding: 2px 6px;
+  background: none;
+  color: var(--dim);
+  border: 1px solid var(--border);
+  border-radius: 1px;
+  cursor: pointer;
+  transition: color 0.12s, border-color 0.12s, background-color 0.12s;
+}
+.lab-btn:hover { color: var(--accent); border-color: var(--accent); }
+.lab-btn.active {
+  color: var(--accent-hover);
+  border-color: var(--accent);
+  background: var(--accent-bg);
+}
+
+
+/* ── Reduced motion ──────────────────────────────────────────────────────────
+   The equalizer's meaning is in the bar heights, which survive intact. Only the
+   sweep and the flicker are dropped. */
+
+@media (prefers-reduced-motion: reduce) {
+  .eq-cell {
+    transition-delay: 0ms !important;
+    transition-duration: 0ms !important;
+    animation: none !important;
+  }
+  .cursor, .ls-cursor { animation: none !important; }
+}

--- a/frontend/css/styles.css
+++ b/frontend/css/styles.css
@@ -31,6 +31,15 @@
      contrast in an off-white. */
   --tile-ink:     color-mix(in srgb, white 62%, var(--text));
   --tile-ink-dim: color-mix(in srgb, white 20%, var(--text));
+
+  /* Hearted shows in the equalizer. Deliberately off-palette -- it is the one thing in
+     the strip that is not "how busy is that night", so it should not be a shade of the
+     accent. Matches the heart on an event tile (#ff8fa8), which is where the association
+     is learned. Overridden below for wisteria, where pink on pink says nothing, and
+     darkened for light mode, where the bright pink measures 2.0:1 on warm paper and
+     graphics want 3:1. */
+  --eq-fav:       #ff8fa8;
+  --eq-fav-hover: #ffb3c4;
   --bg:           #1a1008;
   --surface:      #241609;
   --surface2:     #2e1d0c;
@@ -161,6 +170,30 @@ html[data-mode="light"][data-palette="wisteria"] {
   --accent-hover: #6a1888;
   --accent-bg:    rgba(136,40,168,0.10);
   --today-bg:     rgba(136,40,168,0.06);
+}
+
+/* === Equalizer favorite color =============================================
+   Order matters and the specificities are deliberate. The two single-attribute rules
+   are both (0,1,1), so wisteria is written second to win in dark mode; the compound
+   rule is (0,2,1) and so still wins for wisteria + light. */
+
+/* Light mode: #ff8fa8 measures 2.0:1 against the warm-paper background, under the 3:1
+   graphics floor. This one is 3.66:1 and still reads as the same pink. */
+html[data-mode="light"] {
+  --eq-fav:       #d94f74;
+  --eq-fav-hover: #b83a5c;
+}
+
+/* Wisteria is a pink-purple palette, so a pink overlay would say nothing. Soft sky blue
+   is the opposite side of the wheel and stays gentle rather than alarming. */
+html[data-palette="wisteria"] {
+  --eq-fav:       #8ad5f0;
+  --eq-fav-hover: #b0e6f8;
+}
+
+html[data-mode="light"][data-palette="wisteria"] {
+  --eq-fav:       #1f7fa8;
+  --eq-fav-hover: #12617f;
 }
 
 /* Durham Bulls light: warm desaturated brown bg, navy text */
@@ -1338,50 +1371,54 @@ html[data-tiles="gutter"] .fc .fc-list-event .ev {
    Accent-colored bloom on identity text only. Never applied to event text, where it
    would undo the readability work above. */
 
+/* Four layers rather than two: a tight hot core, a bright inner bloom, then two wide
+   falloffs. Real phosphor bloom is a steep core with a long tail, and stacking the radii
+   gets closer to that than turning one shadow up would -- a single wide shadow at high
+   opacity just goes muddy. */
 html[data-glow="on"] .ascii-title {
-  text-shadow: 0 0 6px color-mix(in srgb, var(--accent) 55%, transparent),
-               0 0 14px color-mix(in srgb, var(--accent) 25%, transparent);
+  text-shadow: 0 0 2px  color-mix(in srgb, var(--accent) 85%, transparent),
+               0 0 9px  color-mix(in srgb, var(--accent) 75%, transparent),
+               0 0 22px color-mix(in srgb, var(--accent) 45%, transparent),
+               0 0 42px color-mix(in srgb, var(--accent) 22%, transparent);
 }
 html[data-glow="on"] .site-title,
 html[data-glow="on"] .site-subtitle,
 html[data-glow="on"] .fc .fc-toolbar-title,
 html[data-glow="on"] .filter-label,
 html[data-glow="on"] .ls-text {
-  text-shadow: 0 0 5px color-mix(in srgb, var(--accent) 40%, transparent);
+  text-shadow: 0 0 2px  color-mix(in srgb, var(--accent) 60%, transparent),
+               0 0 8px  color-mix(in srgb, var(--accent) 62%, transparent),
+               0 0 18px color-mix(in srgb, var(--accent) 30%, transparent);
 }
 html[data-glow="on"] .cursor,
 html[data-glow="on"] .ls-cursor {
-  box-shadow: 0 0 6px color-mix(in srgb, var(--accent) 70%, transparent);
+  box-shadow: 0 0 4px  color-mix(in srgb, var(--accent) 90%, transparent),
+              0 0 12px color-mix(in srgb, var(--accent) 55%, transparent);
 }
 
-/* Light mode gets a much weaker bloom: glow on a paper-white ground reads as a printing
-   error rather than as phosphor. */
+/* Footer. Radius is kept tight here on purpose: bloom has to scale with type size, and
+   the wide falloff that reads as phosphor on the 14px ASCII art smears 10px italic into
+   mush. Same effect, sized for the text it sits on. */
+html[data-glow="on"] .site-credit,
+html[data-glow="on"] .site-credit a {
+  text-shadow: 0 0 3px color-mix(in srgb, var(--accent) 55%, transparent),
+               0 0 9px color-mix(in srgb, var(--accent) 28%, transparent);
+}
+
+/* Light mode stays much weaker: bloom on a paper-white ground reads as a printing error
+   rather than as phosphor, because there is no dark surround for light to spill into. */
 html[data-glow="on"][data-mode="light"] .ascii-title {
-  text-shadow: 0 0 4px color-mix(in srgb, var(--accent) 22%, transparent);
+  text-shadow: 0 0 4px color-mix(in srgb, var(--accent) 26%, transparent);
+}
+html[data-glow="on"][data-mode="light"] .site-credit,
+html[data-glow="on"][data-mode="light"] .site-credit a {
+  text-shadow: 0 0 3px color-mix(in srgb, var(--accent) 18%, transparent);
 }
 
 
-/* ── CRT texture: scanlines ──────────────────────────────────────────────────
-   Chrome surfaces only — the header and the sidebar. Deliberately never over the
-   calendar grid or event tiles, where a 50% duty cycle over 11px text is exactly the
-   kind of decoration that costs legibility. */
-
-html[data-scanlines="on"] .app-header::after,
-html[data-scanlines="on"] .sidebar::after {
-  content: "";
-  position: absolute;
-  inset: 0;
-  pointer-events: none;
-  z-index: 3;
-  background: repeating-linear-gradient(
-    to bottom,
-    color-mix(in srgb, var(--bg) 55%, transparent) 0px,
-    color-mix(in srgb, var(--bg) 55%, transparent) 1px,
-    transparent 1px,
-    transparent 3px
-  );
-}
-html[data-scanlines="on"] .sidebar { position: relative; }
+/* Scanlines were tried here and cut: a 1-in-3 duty cycle lands on the same scale as the
+   ASCII art's own strokes and the 11px sidebar text, so it read as interference rather
+   than as texture. The glow above carries the CRT reference on its own. */
 
 
 /* ── Night-density equalizer ─────────────────────────────────────────────────
@@ -1432,12 +1469,34 @@ html[data-scanlines="on"] .sidebar { position: relative; }
 .eq-cell.on  { background: var(--accent); }
 .eq-cell.cap { background: var(--accent-hover); }
 
+/* Hearted shows fill the base of each bar in --eq-fav, so a bar reads bottom-up as
+   "this many are mine, this many more are on". Declared after .cap so a bar that is
+   entirely hearted stays pink rather than taking the accent cap color.
+
+   The inset rim is not decoration. Pink and the phosphor palette's green sit at almost
+   identical luminance (1.02:1), which is the red-green colorblind failure case exactly --
+   they would flatten to the same grey. The rim makes hearted cells legible as a texture
+   rather than only as a hue. Position carries it too: hearted cells are always the
+   contiguous base of a bar, and the readout and aria-label both say "N hearted" in
+   words, so the color is the third cue rather than the only one. */
+.eq-cell.fav,
+.eq-cell.fav.cap {
+  background: var(--eq-fav);
+  box-shadow: inset 0 0 0 1px color-mix(in srgb, white 45%, transparent);
+}
+
 .eq-bar:hover  .eq-cell.on,
 .eq-bar:focus-visible .eq-cell.on,
 .eq-bar.is-active .eq-cell.on { background: var(--accent-hover); }
 
 .eq-bar:hover .eq-cell,
 .eq-bar.is-active .eq-cell { background: color-mix(in srgb, var(--accent) 22%, var(--surface2)); }
+
+/* Must come after the .on hover rules above. Both are (0,4,0), so order decides, and
+   written any earlier the hearted cells would flip to the accent color on hover. */
+.eq-bar:hover .eq-cell.fav,
+.eq-bar:focus-visible .eq-cell.fav,
+.eq-bar.is-active .eq-cell.fav { background: var(--eq-fav-hover); }
 
 .eq-bar:focus-visible { outline: 1px solid var(--accent); outline-offset: 1px; }
 

--- a/frontend/css/styles.css
+++ b/frontend/css/styles.css
@@ -632,11 +632,16 @@ a:hover { color: var(--accent-hover); text-decoration: underline; }
 
 /* === Calendar === */
 .calendar-container {
-  padding: 1.1rem 1.25rem;
+  /* Top spacing is a margin on .fc rather than padding here. A sticky element pins to the
+     padding box, so with padding-top the toolbar stopped 1.1rem below the container's top
+     edge and scrolling rows showed through the strip above it. As a margin the same gap
+     scrolls away with the content, and the toolbar pins flush. */
+  padding: 0 1.25rem 1.1rem;
   background: var(--bg);
   overflow-y: auto;
   height: 100%;
 }
+.calendar-container > .fc { margin-top: 1.1rem; }
 
 /* FullCalendar overrides */
 .fc {
@@ -1372,24 +1377,24 @@ html[data-mode="light"] .fc .fc-list-event-dot {
    gets closer to that than turning one shadow up would -- a single wide shadow at high
    opacity just goes muddy. */
 html[data-glow="on"] .ascii-title {
-  text-shadow: 0 0 2px  color-mix(in srgb, var(--accent) 68%, transparent),
-               0 0 9px  color-mix(in srgb, var(--accent) 58%, transparent),
-               0 0 22px color-mix(in srgb, var(--accent) 33%, transparent),
-               0 0 42px color-mix(in srgb, var(--accent) 15%, transparent);
+  text-shadow: 0 0 2px  color-mix(in srgb, var(--accent) 51%, transparent),
+               0 0 9px  color-mix(in srgb, var(--accent) 44%, transparent),
+               0 0 22px color-mix(in srgb, var(--accent) 25%, transparent),
+               0 0 42px color-mix(in srgb, var(--accent) 11%, transparent);
 }
 html[data-glow="on"] .site-title,
 html[data-glow="on"] .site-subtitle,
 html[data-glow="on"] .fc .fc-toolbar-title,
 html[data-glow="on"] .filter-label,
 html[data-glow="on"] .ls-text {
-  text-shadow: 0 0 2px  color-mix(in srgb, var(--accent) 46%, transparent),
-               0 0 8px  color-mix(in srgb, var(--accent) 46%, transparent),
-               0 0 18px color-mix(in srgb, var(--accent) 21%, transparent);
+  text-shadow: 0 0 2px  color-mix(in srgb, var(--accent) 34%, transparent),
+               0 0 8px  color-mix(in srgb, var(--accent) 34%, transparent),
+               0 0 18px color-mix(in srgb, var(--accent) 16%, transparent);
 }
 html[data-glow="on"] .cursor,
 html[data-glow="on"] .ls-cursor {
-  box-shadow: 0 0 4px  color-mix(in srgb, var(--accent) 70%, transparent),
-              0 0 12px color-mix(in srgb, var(--accent) 40%, transparent);
+  box-shadow: 0 0 4px  color-mix(in srgb, var(--accent) 52%, transparent),
+              0 0 12px color-mix(in srgb, var(--accent) 30%, transparent);
 }
 
 /* Calendar chrome: weekday headers, day numbers, and the list view's date headers.
@@ -1402,15 +1407,15 @@ html[data-glow="on"] .fc .fc-col-header-cell-cushion,
 html[data-glow="on"] .fc .fc-daygrid-day-number,
 html[data-glow="on"] .fc .fc-list-day-text,
 html[data-glow="on"] .fc .fc-list-day-side-text {
-  text-shadow: 0 0 4px  color-mix(in srgb, currentColor 40%, transparent),
-               0 0 10px color-mix(in srgb, currentColor 18%, transparent);
+  text-shadow: 0 0 4px  color-mix(in srgb, currentColor 30%, transparent),
+               0 0 10px color-mix(in srgb, currentColor 14%, transparent);
 }
 
 /* Today's number is the one number that is meant to catch the eye, so it gets a little
    more than its neighbours rather than the same amount. */
 html[data-glow="on"] .fc .fc-day-today .fc-daygrid-day-number {
-  text-shadow: 0 0 3px  color-mix(in srgb, var(--accent) 58%, transparent),
-               0 0 11px color-mix(in srgb, var(--accent) 30%, transparent);
+  text-shadow: 0 0 3px  color-mix(in srgb, var(--accent) 44%, transparent),
+               0 0 11px color-mix(in srgb, var(--accent) 22%, transparent);
 }
 
 /* Footer. Radius is kept tight here on purpose: bloom has to scale with type size, and
@@ -1418,24 +1423,46 @@ html[data-glow="on"] .fc .fc-day-today .fc-daygrid-day-number {
    mush. Same effect, sized for the text it sits on. */
 html[data-glow="on"] .site-credit,
 html[data-glow="on"] .site-credit a {
-  text-shadow: 0 0 3px color-mix(in srgb, var(--accent) 44%, transparent),
-               0 0 9px color-mix(in srgb, var(--accent) 20%, transparent);
+  text-shadow: 0 0 3px color-mix(in srgb, var(--accent) 33%, transparent),
+               0 0 9px color-mix(in srgb, var(--accent) 15%, transparent);
 }
 
 /* Light mode stays much weaker: bloom on a paper-white ground reads as a printing error
    rather than as phosphor, because there is no dark surround for light to spill into. */
 html[data-glow="on"][data-mode="light"] .ascii-title {
-  text-shadow: 0 0 4px color-mix(in srgb, var(--accent) 20%, transparent);
+  text-shadow: 0 0 4px color-mix(in srgb, var(--accent) 15%, transparent);
 }
 html[data-glow="on"][data-mode="light"] .site-credit,
 html[data-glow="on"][data-mode="light"] .site-credit a {
-  text-shadow: 0 0 3px color-mix(in srgb, var(--accent) 14%, transparent);
+  text-shadow: 0 0 3px color-mix(in srgb, var(--accent) 10%, transparent);
 }
 
 
 /* Scanlines were tried here and cut: a 1-in-3 duty cycle lands on the same scale as the
    ASCII art's own strokes and the 11px sidebar text, so it read as interference rather
    than as texture. The glow above carries the CRT reference on its own. */
+
+
+/* ── Sticky calendar chrome ──────────────────────────────────────────────────
+   The toolbar and the weekday header are both sticky, and FullCalendar pins both at
+   top: 0 of the scroll container. The toolbar wins on z-index (5 against 3) and has an
+   opaque background, so it sat directly on top of SUN/MON/TUE and hid it completely.
+   Invisible until now, because nothing scrolled the month grid far enough to notice --
+   opening the view at today is what surfaced it.
+
+   Offsetting the header by the toolbar's height stacks them instead. The height is
+   measured rather than hardcoded: the toolbar wraps to two rows at narrow widths, and a
+   fixed value would leave a gap there or overlap again. app.js keeps --fc-toolbar-h
+   current with a ResizeObserver; the fallback covers the frame before it first runs.
+
+   The selector carries .fc-scrollgrid-section-sticky only to win the cascade. FullCalendar
+   sets this with `.fc .fc-scrollgrid-section-header.fc-scrollgrid-section-sticky > *`,
+   which is (0,3,0); the obvious `.fc .fc-scrollgrid-section-header > th` is (0,2,1) and
+   loses, because three classes outrank two classes and an element. It also injects its CSS
+   into a runtime <style> tag, so source order is not reliably ours either. */
+.fc .fc-scrollgrid-section-header.fc-scrollgrid-section-sticky > th {
+  top: var(--fc-toolbar-h, 40px);
+}
 
 
 /* ── Night-density equalizer ─────────────────────────────────────────────────

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -154,14 +154,6 @@
             <button class="lab-btn" data-lab-key="glow" data-lab-value="on"  aria-pressed="false">on</button>
           </div>
         </div>
-
-        <div class="lab-row">
-          <span class="lab-row-label">Scanlines</span>
-          <div class="lab-group">
-            <button class="lab-btn" data-lab-key="scanlines" data-lab-value="off" aria-pressed="false">off</button>
-            <button class="lab-btn" data-lab-key="scanlines" data-lab-value="on"  aria-pressed="false">on</button>
-          </div>
-        </div>
       </div>
 
       <!-- Ko-fi (mobile only — lives at bottom of sidebar) -->

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -8,7 +8,13 @@
   <link rel="icon" type="image/svg+xml" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'%3E%3Crect width='16' height='16' fill='%23f0922e'/%3E%3C/svg%3E">
 
   <link rel="preconnect" href="https://fonts.googleapis.com">
-  <link href="https://fonts.googleapis.com/css2?family=Orbitron:wght@900&family=Space+Mono:ital,wght@0,400;0,700;1,400;1,700&display=swap" rel="stylesheet">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <!-- Space Mono: identity layer (ASCII title, labels, chrome).
+       IBM Plex Mono: data layer (event titles, venue lines, list view) - drawn for
+       interface density, so it holds shape at 11-13px where Space Mono's tight counters
+       fill in. Silkscreen: true bitmap face, currently used only for the equalizer's
+       week ruler; loaded so pixel treatments can be tried elsewhere without a round trip. -->
+  <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:ital,wght@0,400;0,500;0,600;1,400&family=Orbitron:wght@900&family=Silkscreen:wght@400;700&family=Space+Mono:ital,wght@0,400;0,700;1,400;1,700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/fullcalendar@6.1.15/index.global.min.css">
   <link rel="stylesheet" href="/css/styles.css">
 
@@ -61,6 +67,17 @@
       <!-- Search -->
       <div class="filter-section search-wrapper">
         <input type="text" id="search-input" placeholder="search artists/events...">
+      </div>
+
+      <!-- Night-density equalizer. Sits above the filters it responds to, so changing a
+           filter and watching the bars redraw reads as one motion. -->
+      <div class="filter-section eq-section">
+        <div class="filter-label">Next 14 nights</div>
+        <div class="eq-strip">
+          <div class="equalizer" id="equalizer" role="img" aria-label="Show density for the next 14 nights"></div>
+          <div class="eq-ruler" aria-hidden="true"><span>today</span><span>+1wk</span></div>
+        </div>
+        <p class="eq-readout" id="eq-readout" aria-live="polite"></p>
       </div>
 
       <!-- City Filter -->
@@ -116,6 +133,37 @@
 
       </div>
 
+      <!-- Design lab — comparison controls for the feature/visual-refresh branch.
+           Remove this block, js/design.js's lab section, and the matching CSS once the
+           direction is settled. -->
+      <div class="filter-section lab-section">
+        <div class="filter-label lab-label">Design lab</div>
+
+        <div class="lab-row">
+          <span class="lab-row-label">Tiles</span>
+          <div class="lab-group">
+            <button class="lab-btn" data-lab-key="tiles" data-lab-value="fill"   aria-pressed="false">fill</button>
+            <button class="lab-btn" data-lab-key="tiles" data-lab-value="gutter" aria-pressed="false">gutter</button>
+          </div>
+        </div>
+
+        <div class="lab-row">
+          <span class="lab-row-label">Glow</span>
+          <div class="lab-group">
+            <button class="lab-btn" data-lab-key="glow" data-lab-value="off" aria-pressed="false">off</button>
+            <button class="lab-btn" data-lab-key="glow" data-lab-value="on"  aria-pressed="false">on</button>
+          </div>
+        </div>
+
+        <div class="lab-row">
+          <span class="lab-row-label">Scanlines</span>
+          <div class="lab-group">
+            <button class="lab-btn" data-lab-key="scanlines" data-lab-value="off" aria-pressed="false">off</button>
+            <button class="lab-btn" data-lab-key="scanlines" data-lab-value="on"  aria-pressed="false">on</button>
+          </div>
+        </div>
+      </div>
+
       <!-- Ko-fi (mobile only — lives at bottom of sidebar) -->
       <div class="kofi-sidebar">
         <p class="kofi-pitch">help me pay for this domain</p>
@@ -151,6 +199,8 @@
   <script defer src="https://cdn.jsdelivr.net/npm/fullcalendar@6.1.15/index.global.min.js"></script>
 
   <!-- App JS -->
+  <script defer src="/js/design.js"></script>
+  <script defer src="/js/equalizer.js"></script>
   <script defer src="/js/config.js"></script>
   <script defer src="/js/filters.js"></script>
   <script defer src="/js/modal.js"></script>

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -133,29 +133,6 @@
 
       </div>
 
-      <!-- Design lab — comparison controls for the feature/visual-refresh branch.
-           Remove this block, js/design.js's lab section, and the matching CSS once the
-           direction is settled. -->
-      <div class="filter-section lab-section">
-        <div class="filter-label lab-label">Design lab</div>
-
-        <div class="lab-row">
-          <span class="lab-row-label">Tiles</span>
-          <div class="lab-group">
-            <button class="lab-btn" data-lab-key="tiles" data-lab-value="fill"   aria-pressed="false">fill</button>
-            <button class="lab-btn" data-lab-key="tiles" data-lab-value="gutter" aria-pressed="false">gutter</button>
-          </div>
-        </div>
-
-        <div class="lab-row">
-          <span class="lab-row-label">Glow</span>
-          <div class="lab-group">
-            <button class="lab-btn" data-lab-key="glow" data-lab-value="off" aria-pressed="false">off</button>
-            <button class="lab-btn" data-lab-key="glow" data-lab-value="on"  aria-pressed="false">on</button>
-          </div>
-        </div>
-      </div>
-
       <!-- Ko-fi (mobile only — lives at bottom of sidebar) -->
       <div class="kofi-sidebar">
         <p class="kofi-pitch">help me pay for this domain</p>

--- a/frontend/js/app.js
+++ b/frontend/js/app.js
@@ -47,6 +47,84 @@ function _updateEqualizer(events) {
   }
 }
 
+// ── Scroll the month grid to today ───────────────────────────────────────────
+//
+// The month view renders at its full height inside .calendar-container, which is the
+// element that scrolls. Late in a month that puts today's row below the fold, so the page
+// opens on a stretch of days that have already happened.
+//
+// Only dayGrid needs this. The list view is built as a 180-day window starting today, so
+// its first row already is today.
+const _TODAY_HEADROOM = 90; // px of earlier weeks left visible above today, for context
+let _scrolledToTodayOnce = false;
+
+function _scrollToToday(smooth) {
+  const container = document.querySelector(".calendar-container");
+  const cell = document.querySelector(".fc-day-today");
+  if (!container || !cell) return;
+
+  const cellRect = cell.getBoundingClientRect();
+  const boxRect  = container.getBoundingClientRect();
+
+  // Leave it alone when today's row is already fully in view. Scrolling a reader back to
+  // where they already are is worse than not scrolling at all.
+  if (cellRect.top >= boxRect.top && cellRect.bottom <= boxRect.bottom) return;
+
+  const target = container.scrollTop + (cellRect.top - boxRect.top) - _TODAY_HEADROOM;
+  const reduced = window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+
+  container.scrollTo({
+    top: Math.max(0, target),
+    behavior: smooth && !reduced ? "smooth" : "auto",
+  });
+}
+
+// Row heights depend on how many events land in each cell, so this has to run after the
+// tiles are in the DOM.
+//
+// Two frames when the tab is visible: one for FullCalendar's own paint, one for the layout
+// that follows it. But requestAnimationFrame does not fire at all while a tab is in the
+// background, so a timer backs it up -- without it, a page opened in a background tab is
+// still sitting at the top of the month whenever someone gets round to looking at it.
+// Whichever fires first wins; the other finds the work already done.
+function _scrollToTodayWhenSettled(smooth) {
+  let done = false;
+  const run = function () {
+    if (done) return;
+    done = true;
+    _scrollToToday(smooth);
+  };
+
+  requestAnimationFrame(function () { requestAnimationFrame(run); });
+  setTimeout(run, 120);
+}
+
+// ── Sticky header offset ─────────────────────────────────────────────────────
+//
+// The toolbar and the weekday header are both sticky at top: 0, so the toolbar's opaque
+// background covered SUN/MON/TUE entirely. styles.css offsets the header by
+// --fc-toolbar-h; this keeps that value honest. Measured rather than hardcoded because the
+// toolbar wraps to two rows at narrow widths.
+let _toolbarObserver = null;
+
+function _trackToolbarHeight() {
+  const root = document.querySelector(".fc");
+  const toolbar = document.querySelector(".fc-header-toolbar");
+  if (!root || !toolbar) return;
+
+  const apply = function () {
+    root.style.setProperty("--fc-toolbar-h", toolbar.offsetHeight + "px");
+  };
+  apply();
+
+  // Height changes on wrap, on font load, and on a view switch -- all of which a resize
+  // handler alone would miss.
+  if (window.ResizeObserver && !_toolbarObserver) {
+    _toolbarObserver = new ResizeObserver(apply);
+    _toolbarObserver.observe(toolbar);
+  }
+}
+
 const _loadingScreenStart = Date.now();
 let _initialLoadComplete = false;  // guards the function-source fetch against re-fetching from API
 let _loadingScreenDismissed = false;
@@ -179,6 +257,11 @@ document.addEventListener("DOMContentLoaded", function () {
       right: "dayGridMonth,listUpcoming",
     },
     height: "auto",
+    // Pin SUN/MON/TUE while the month grid scrolls. Previously nobody scrolled far enough
+    // for it to matter; now that the view opens at today, the header would otherwise be
+    // above the fold from the first paint and you would have to scroll up to learn which
+    // column is which.
+    stickyHeaderDates: true,
     fixedWeekCount: false,
     displayEventTime: false,
     eventSources: [
@@ -274,10 +357,42 @@ document.addEventListener("DOMContentLoaded", function () {
         calendar.changeView(target);
       }
     },
+    datesSet: function (info) {
+      // Fires on every view or date change -- paging months, hitting "today", and the
+      // first render. Scroll only when the range on screen actually contains today, so
+      // paging to an unrelated month leaves the scroll position alone.
+      //
+      // Deliberately not fired by a filter change: those call refetchEvents(), which does
+      // not change the date range, so someone reading a later week is not yanked back.
+      // Runs for every view: the toolbar exists in list view too, and re-observing after
+      // a view switch is what keeps the measured height current.
+      _trackToolbarHeight();
+
+      if (info.view.type.indexOf("dayGrid") !== 0) return;
+      const now = new Date();
+      if (now >= info.start && now < info.end) {
+        // Instant on first paint -- the page should simply open at today, with nothing to
+        // animate from. Smooth afterwards, when someone has hit "today" or paged back to
+        // this month and the movement tells them where they were taken.
+        _scrollToTodayWhenSettled(_scrolledToTodayOnce);
+        _scrolledToTodayOnce = true;
+      }
+    },
     loading: function (isLoading) {
       if (!isLoading) {
         if (!_loadingScreenDismissed) {
           _loadingScreenDismissed = true;
+
+          // Re-run the scroll once the tiles exist. datesSet fires before the fetch
+          // resolves, so the position it computed was against an empty grid and every row
+          // below today has since grown. Instant, not smooth: a correction to where the
+          // page already sits, not a movement anyone should watch.
+          //
+          // Inside this branch on purpose. `loading` also fires for the refetch behind
+          // every filter change, and scrolling there would drag someone reading a later
+          // week back to today each time they toggled a venue.
+          _scrollToTodayWhenSettled(false);
+
           const elapsed = Date.now() - _loadingScreenStart;
           const delay = Math.max(0, 1000 - elapsed);
           setTimeout(function () {

--- a/frontend/js/app.js
+++ b/frontend/js/app.js
@@ -200,7 +200,18 @@ document.addEventListener("DOMContentLoaded", function () {
                   const safe = normalizeVenueColor(ev.backgroundColor);
                   ev.backgroundColor = safe;
                   ev.borderColor     = safe;
-                  if (ev.extendedProps) ev.extendedProps.venue_color = safe;
+                  if (ev.extendedProps) {
+                    ev.extendedProps.venue_color = safe;
+                    // The gutter rule needs a brighter variant on a dark surface: these
+                    // colors were authored as backgrounds behind white text, so all 22
+                    // measure under 3:1 as a 3px rule on --surface2. Both variants are
+                    // carried and CSS picks by mode.
+                    if (typeof venueRuleColors === "function") {
+                      const rule = venueRuleColors(safe);
+                      ev.extendedProps.venue_rule_dark  = rule.dark;
+                      ev.extendedProps.venue_rule_light = rule.light;
+                    }
+                  }
                 });
               }
               _allEventsCache = data;
@@ -292,6 +303,15 @@ document.addEventListener("DOMContentLoaded", function () {
       }
     },
     eventDidMount: function (info) {
+      // Publish the gutter rule colors on the event element rather than on .ev inside it.
+      // The list view's colored dot is drawn by FullCalendar as a sibling of the title
+      // cell, so a property set on .ev would not reach it.
+      const p = info.event.extendedProps;
+      if (p && p.venue_rule_dark) {
+        info.el.style.setProperty("--venue-rule-dark", p.venue_rule_dark);
+        info.el.style.setProperty("--venue-rule-light", p.venue_rule_light);
+      }
+
       // Restore heart state for events loaded after page init.
       if (typeof isFavorited === "function" && isFavorited(info.event.id)) {
         const btn = info.el.querySelector(".ev-heart");

--- a/frontend/js/app.js
+++ b/frontend/js/app.js
@@ -38,6 +38,15 @@ document.addEventListener("DOMContentLoaded", function () {
 
 // FullCalendar initialization
 let calendar;
+
+// Feed the night-density equalizer whatever the calendar is about to draw. Guarded rather
+// than assumed present so the calendar still renders if equalizer.js fails to load.
+function _updateEqualizer(events) {
+  if (window.Equalizer && typeof window.Equalizer.update === "function") {
+    window.Equalizer.update(events);
+  }
+}
+
 const _loadingScreenStart = Date.now();
 let _initialLoadComplete = false;  // guards the function-source fetch against re-fetching from API
 let _loadingScreenDismissed = false;
@@ -181,16 +190,33 @@ document.addEventListener("DOMContentLoaded", function () {
               return r.json();
             })
             .then(function (data) {
+              // Clamp every venue color to a readable luminance band before anything
+              // renders. Venue colors are hand-authored in seed.py with no contrast check;
+              // normalizing here fixes both modes at once (dark mode paints them as tile
+              // backgrounds, light mode as tile text) and keeps any future light color
+              // from reopening the same hole. See js/design.js.
+              if (typeof normalizeVenueColor === "function") {
+                data.forEach(function (ev) {
+                  const safe = normalizeVenueColor(ev.backgroundColor);
+                  ev.backgroundColor = safe;
+                  ev.borderColor     = safe;
+                  if (ev.extendedProps) ev.extendedProps.venue_color = safe;
+                });
+              }
               _allEventsCache = data;
               _initialLoadComplete = true;
-              successCallback(_getFilteredEvents());
+              const visible = _getFilteredEvents();
+              _updateEqualizer(visible);
+              successCallback(visible);
             })
             .catch(function (err) {
               console.error("Failed to fetch events:", err);
               failureCallback(err);
             });
         } else {
-          successCallback(_getFilteredEvents());
+          const visible = _getFilteredEvents();
+          _updateEqualizer(visible);
+          successCallback(visible);
         }
       },
     ],
@@ -285,6 +311,9 @@ document.addEventListener("DOMContentLoaded", function () {
   });
 
   calendar.render();
+  // `let calendar` lives in the script scope, not on window, so the equalizer's
+  // click-to-jump cannot reach it without this.
+  window.calendar = calendar;
 
   // ── Heart / favorite click handler ──────────────────────────────────────
   // Use capture phase so we intercept before FullCalendar's eventClick fires.

--- a/frontend/js/config.js
+++ b/frontend/js/config.js
@@ -1,5 +1,15 @@
 // API configuration
-const API_BASE = window.location.origin;
+//
+// Frontend-only preview escape hatch. `python -m http.server 8080` inside frontend/ serves
+// the static files with no API behind them, so port 8080 on localhost reads from
+// production instead. Scoped to that exact port on purpose: the docker-compose stack
+// serves the real app on :8000 and must keep talking to its own local API.
+// CORS permits this — allow_origins is "*" with allow_credentials off.
+const API_BASE =
+  (location.hostname === "localhost" || location.hostname === "127.0.0.1") &&
+  location.port === "8080"
+    ? "https://triangle-shows.net"
+    : window.location.origin;
 
 // Spotify — paste your Client ID from https://developer.spotify.com/dashboard
 // Register redirect URIs: https://triangle-shows.org and http://localhost:8000

--- a/frontend/js/design.js
+++ b/frontend/js/design.js
@@ -1,20 +1,25 @@
 /**
- * Venue-color normalization and the design-lab toggles.
+ * Venue-color conditioning for the calendar.
  *
- * Role: Loaded before app.js. Exposes normalizeVenueColor(), which app.js applies to
- * every event as it arrives, and wires the sidebar's design-lab controls to attributes
- * on <html> that styles.css keys off.
+ * Role: Loaded before app.js, which applies both functions here to every event as it
+ * arrives. Pure color math -- no DOM beyond setting the glow attribute at the end.
  *
- * Why normalization exists. Venue colors are authored by hand in backend/app/seed.py and
- * nothing checks them for contrast. The Carolina Theatre's #F5D765 renders white-on-yellow
- * at 1.42:1 in dark mode, and venue-colored-text-on-warm-paper at roughly 1.2:1 in light
- * mode -- unreadable in both. Rather than hand-fixing that one value and waiting for the
- * next light venue color to reopen the same hole, every color is clamped to a luminance
- * band on the way in. Hue and saturation survive, so venues stay distinguishable.
+ * Venue colors are authored by hand in backend/app/seed.py and nothing checks them for
+ * contrast. Two separate problems follow, and each gets its own pass:
  *
- * The band is derived, not guessed: TARGET_CONTRAST is set by the dimmest text that sits
- * on a tile (the venue line, --tile-ink-dim), not by the title. Meet the floor for the
- * quieter of the two and the louder one follows.
+ * normalizeVenueColor() caps how light a color may be. Its original job was white text on
+ * a filled tile; tiles are now gutter-ruled, so what it actually guards today is the rule
+ * against the light-mode surface -- a pale venue color would vanish on warm paper, which
+ * is exactly what The Carolina Theatre's old #F5D765 did.
+ *
+ * venueRuleColors() solves the opposite problem. Every seeded color is dark, because they
+ * were drawn to sit behind white text, and a dark rule on a dark surface is invisible: all
+ * 22 measured between 1.14:1 and 2.51:1 against --surface2, under the 3:1 a graphic needs.
+ * It emits a brightened variant for dark mode and leaves the original for light.
+ *
+ * Both walk the value in small steps rather than solving directly, because luminance per
+ * unit of HSL lightness varies enormously by hue -- yellow is far brighter than blue at
+ * the same nominal lightness.
  */
 
 (function (global) {
@@ -97,9 +102,10 @@
 
   // --- Normalization ---
 
-  // The venue line uses --tile-ink-dim (#e2dace, luminance ~0.70). Holding that to the
-  // WCAG 4.5:1 minimum for small text caps tile luminance at ~0.117, which is a white
-  // contrast of ~6.3. Rounded up for margin.
+  // Originally derived from white text on a filled tile. The tiles are gutter-ruled now,
+  // so the number is kept for a different reason: a color this dark is guaranteed to clear
+  // 3:1 as a rule against every light-mode --surface2, measured at 4.85:1 or better across
+  // all five palettes. Loosening it would let a pale venue color disappear on warm paper.
   const TARGET_CONTRAST = 6.5;
 
   // Below this, a hue reads as grey and two venues become hard to tell apart. Darkening a
@@ -151,76 +157,65 @@
     return result;
   }
 
-  // --- Design lab ---
+  // --- Gutter rule colors ---
   //
-  // Exploration controls for this branch: they let the two tile treatments and the two CRT
-  // textures be compared on real data instead of in the abstract. Each writes one attribute
-  // on <html> and persists it. Remove this block, its markup, and the [data-tiles="gutter"]
-  // / [data-glow] / [data-scanlines] rules once the direction is settled.
+  // The venue palette was authored for the old filled tile: every color is a dark
+  // background meant to sit behind white text. As a 3px rule on a dark surface those same
+  // colors are nearly invisible -- measured across all 22, they land between 1.14:1 and
+  // 2.51:1 against --surface2, where a graphic needs 3:1. All 22 failed.
+  //
+  // They are fine on the light surface (4.85:1 and up), so only dark mode needs a
+  // brightened variant. Both are emitted per event and CSS picks by mode.
 
-  // Glow defaults on -- it was kept after the comparison pass. Scanlines were dropped
-  // outright rather than defaulted off, so no stale attribute is left on <html>.
-  const LAB_KEYS = {
-    tiles: { attr: "data-tiles", storage: "ts-lab-tiles", fallback: "fill" },
-    glow:  { attr: "data-glow",  storage: "ts-lab-glow",  fallback: "on"   },
-  };
+  // 4:1 against the lightest dark --surface2 across the five palettes (durham, #0e2340).
+  // Targeting the lightest one means the result clears every palette, not just amber.
+  const RULE_TARGET_LUMINANCE = 0.2166;
 
-  function _read(key) {
-    const spec = LAB_KEYS[key];
-    try {
-      return localStorage.getItem(spec.storage) || spec.fallback;
-    } catch (e) {
-      return spec.fallback;
+  // Darkening a color to normalize it also drains saturation, and a rule that has gone
+  // grey stops identifying its venue. Restored before brightening.
+  const RULE_MIN_SATURATION = 0.45;
+
+  const _ruleCache = Object.create(null);
+
+  /**
+   * Rule colors for one venue: { dark, light }.
+   *
+   * `light` is the color unchanged -- it is already dark enough to read on warm paper.
+   * `dark` is the same hue lifted until it clears the target against a dark surface.
+   */
+  function venueRuleColors(hex) {
+    if (!hex) return { dark: hex, light: hex };
+    if (_ruleCache[hex]) return _ruleCache[hex];
+
+    const rgb = hexToRgb(hex);
+    if (!rgb) {
+      _ruleCache[hex] = { dark: hex, light: hex };
+      return _ruleCache[hex];
     }
-  }
 
-  function setLabOption(key, value) {
-    const spec = LAB_KEYS[key];
-    if (!spec) return;
+    const hsl = rgbToHsl(rgb);
+    const hue = hsl[0];
+    const saturation = Math.max(hsl[1], RULE_MIN_SATURATION);
 
-    document.documentElement.setAttribute(spec.attr, value);
-    try {
-      localStorage.setItem(spec.storage, value);
-    } catch (e) {
-      /* Private browsing: the choice still applies, it just will not persist. */
+    // Stepped rather than solved directly, for the same reason as normalizeVenueColor:
+    // luminance per unit of HSL lightness varies a lot by hue.
+    let out = rgb;
+    let lightness = hsl[2];
+    while (lightness < 1) {
+      out = hslToRgb([hue, saturation, lightness]);
+      if (relativeLuminance(out) >= RULE_TARGET_LUMINANCE) break;
+      lightness += 0.01;
     }
 
-    document.querySelectorAll('.lab-btn[data-lab-key="' + key + '"]').forEach(function (btn) {
-      const active = btn.getAttribute("data-lab-value") === value;
-      btn.classList.toggle("active", active);
-      btn.setAttribute("aria-pressed", active ? "true" : "false");
-    });
-
-    // The tile treatments differ in text color, so the equalizer's own tinting follows.
-    if (key === "tiles" && global.Equalizer && global.Equalizer.refresh) {
-      global.Equalizer.refresh();
-    }
+    _ruleCache[hex] = { dark: rgbToHex(out), light: hex };
+    return _ruleCache[hex];
   }
 
-  function initDesignLab() {
-    Object.keys(LAB_KEYS).forEach(function (key) {
-      setLabOption(key, _read(key));
-    });
-
-    document.querySelectorAll(".lab-btn").forEach(function (btn) {
-      btn.addEventListener("click", function () {
-        setLabOption(btn.getAttribute("data-lab-key"), btn.getAttribute("data-lab-value"));
-      });
-    });
-  }
-
-  // Applied before first paint so tiles never flash the wrong treatment.
-  Object.keys(LAB_KEYS).forEach(function (key) {
-    document.documentElement.setAttribute(LAB_KEYS[key].attr, _read(key));
-  });
-
-  if (document.readyState === "loading") {
-    document.addEventListener("DOMContentLoaded", initDesignLab);
-  } else {
-    initDesignLab();
-  }
+  // The gutter tile treatment is now unconditional in the stylesheet, so it needs no
+  // attribute. The glow still keys off one, which keeps it a single line to turn off.
+  document.documentElement.setAttribute("data-glow", "on");
 
   // --- Exports ---
   global.normalizeVenueColor = normalizeVenueColor;
-  global.setLabOption = setLabOption;
+  global.venueRuleColors = venueRuleColors;
 })(window);

--- a/frontend/js/design.js
+++ b/frontend/js/design.js
@@ -1,0 +1,225 @@
+/**
+ * Venue-color normalization and the design-lab toggles.
+ *
+ * Role: Loaded before app.js. Exposes normalizeVenueColor(), which app.js applies to
+ * every event as it arrives, and wires the sidebar's design-lab controls to attributes
+ * on <html> that styles.css keys off.
+ *
+ * Why normalization exists. Venue colors are authored by hand in backend/app/seed.py and
+ * nothing checks them for contrast. The Carolina Theatre's #F5D765 renders white-on-yellow
+ * at 1.42:1 in dark mode, and venue-colored-text-on-warm-paper at roughly 1.2:1 in light
+ * mode -- unreadable in both. Rather than hand-fixing that one value and waiting for the
+ * next light venue color to reopen the same hole, every color is clamped to a luminance
+ * band on the way in. Hue and saturation survive, so venues stay distinguishable.
+ *
+ * The band is derived, not guessed: TARGET_CONTRAST is set by the dimmest text that sits
+ * on a tile (the venue line, --tile-ink-dim), not by the title. Meet the floor for the
+ * quieter of the two and the louder one follows.
+ */
+
+(function (global) {
+  "use strict";
+
+  // --- Contrast math (WCAG 2.1 relative luminance) ---
+
+  function _srgbToLinear(channel) {
+    return channel <= 0.04045
+      ? channel / 12.92
+      : Math.pow((channel + 0.055) / 1.055, 2.4);
+  }
+
+  function relativeLuminance(rgb) {
+    const r = _srgbToLinear(rgb[0] / 255);
+    const g = _srgbToLinear(rgb[1] / 255);
+    const b = _srgbToLinear(rgb[2] / 255);
+    return 0.2126 * r + 0.7152 * g + 0.0722 * b;
+  }
+
+  function contrastWithWhite(rgb) {
+    return 1.05 / (relativeLuminance(rgb) + 0.05);
+  }
+
+  // --- Color space conversion ---
+
+  function hexToRgb(hex) {
+    const m = /^#?([0-9a-f]{6})$/i.exec(String(hex || "").trim());
+    if (!m) return null;
+    const n = parseInt(m[1], 16);
+    return [(n >> 16) & 255, (n >> 8) & 255, n & 255];
+  }
+
+  function rgbToHex(rgb) {
+    return (
+      "#" +
+      rgb
+        .map(function (c) {
+          return Math.max(0, Math.min(255, Math.round(c)))
+            .toString(16)
+            .padStart(2, "0");
+        })
+        .join("")
+    );
+  }
+
+  function rgbToHsl(rgb) {
+    const r = rgb[0] / 255, g = rgb[1] / 255, b = rgb[2] / 255;
+    const max = Math.max(r, g, b), min = Math.min(r, g, b);
+    const l = (max + min) / 2;
+    if (max === min) return [0, 0, l];
+
+    const d = max - min;
+    const s = l > 0.5 ? d / (2 - max - min) : d / (max + min);
+    let h;
+    if (max === r)      h = ((g - b) / d + (g < b ? 6 : 0)) / 6;
+    else if (max === g) h = ((b - r) / d + 2) / 6;
+    else                h = ((r - g) / d + 4) / 6;
+    return [h, s, l];
+  }
+
+  function hslToRgb(hsl) {
+    const h = hsl[0], s = hsl[1], l = hsl[2];
+    if (s === 0) return [l * 255, l * 255, l * 255];
+
+    const q = l < 0.5 ? l * (1 + s) : l + s - l * s;
+    const p = 2 * l - q;
+
+    function hue(t) {
+      if (t < 0) t += 1;
+      if (t > 1) t -= 1;
+      if (t < 1 / 6) return p + (q - p) * 6 * t;
+      if (t < 1 / 2) return q;
+      if (t < 2 / 3) return p + (q - p) * (2 / 3 - t) * 6;
+      return p;
+    }
+
+    return [hue(h + 1 / 3) * 255, hue(h) * 255, hue(h - 1 / 3) * 255];
+  }
+
+  // --- Normalization ---
+
+  // The venue line uses --tile-ink-dim (#e2dace, luminance ~0.70). Holding that to the
+  // WCAG 4.5:1 minimum for small text caps tile luminance at ~0.117, which is a white
+  // contrast of ~6.3. Rounded up for margin.
+  const TARGET_CONTRAST = 6.5;
+
+  // Below this, a hue reads as grey and two venues become hard to tell apart. Darkening a
+  // pale color drops its saturation, so it is restored afterwards.
+  const MIN_SATURATION = 0.30;
+
+  const _cache = Object.create(null);
+
+  /**
+   * Darken a venue color until white text on it clears TARGET_CONTRAST.
+   *
+   * Returns the input unchanged when it already passes, which is 21 of the 22 seeded
+   * venues -- this is a floor, not a restyle. Unparseable input is returned as-is so a
+   * missing color never throws inside a render path.
+   */
+  function normalizeVenueColor(hex) {
+    if (!hex) return hex;
+    if (_cache[hex] !== undefined) return _cache[hex];
+
+    const rgb = hexToRgb(hex);
+    if (!rgb) {
+      _cache[hex] = hex;
+      return hex;
+    }
+
+    if (contrastWithWhite(rgb) >= TARGET_CONTRAST) {
+      _cache[hex] = hex;
+      return hex;
+    }
+
+    const hsl = rgbToHsl(rgb);
+    const hue = hsl[0];
+    const saturation = Math.max(hsl[1], MIN_SATURATION);
+
+    // Walk lightness down in small steps rather than solving directly: perceived
+    // luminance varies enormously by hue at a fixed HSL lightness (yellow is far brighter
+    // than blue), so stepping until the measurement passes is both simpler and correct
+    // for every hue.
+    let lightness = hsl[2];
+    let out = rgb;
+    while (lightness > 0.04) {
+      lightness -= 0.01;
+      out = hslToRgb([hue, saturation, lightness]);
+      if (contrastWithWhite(out) >= TARGET_CONTRAST) break;
+    }
+
+    const result = rgbToHex(out);
+    _cache[hex] = result;
+    return result;
+  }
+
+  // --- Design lab ---
+  //
+  // Exploration controls for this branch: they let the two tile treatments and the two CRT
+  // textures be compared on real data instead of in the abstract. Each writes one attribute
+  // on <html> and persists it. Remove this block, its markup, and the [data-tiles="gutter"]
+  // / [data-glow] / [data-scanlines] rules once the direction is settled.
+
+  const LAB_KEYS = {
+    tiles:      { attr: "data-tiles",      storage: "ts-lab-tiles",      fallback: "fill" },
+    glow:       { attr: "data-glow",       storage: "ts-lab-glow",       fallback: "off"  },
+    scanlines:  { attr: "data-scanlines",  storage: "ts-lab-scanlines",  fallback: "off"  },
+  };
+
+  function _read(key) {
+    const spec = LAB_KEYS[key];
+    try {
+      return localStorage.getItem(spec.storage) || spec.fallback;
+    } catch (e) {
+      return spec.fallback;
+    }
+  }
+
+  function setLabOption(key, value) {
+    const spec = LAB_KEYS[key];
+    if (!spec) return;
+
+    document.documentElement.setAttribute(spec.attr, value);
+    try {
+      localStorage.setItem(spec.storage, value);
+    } catch (e) {
+      /* Private browsing: the choice still applies, it just will not persist. */
+    }
+
+    document.querySelectorAll('.lab-btn[data-lab-key="' + key + '"]').forEach(function (btn) {
+      const active = btn.getAttribute("data-lab-value") === value;
+      btn.classList.toggle("active", active);
+      btn.setAttribute("aria-pressed", active ? "true" : "false");
+    });
+
+    // The tile treatments differ in text color, so the equalizer's own tinting follows.
+    if (key === "tiles" && global.Equalizer && global.Equalizer.refresh) {
+      global.Equalizer.refresh();
+    }
+  }
+
+  function initDesignLab() {
+    Object.keys(LAB_KEYS).forEach(function (key) {
+      setLabOption(key, _read(key));
+    });
+
+    document.querySelectorAll(".lab-btn").forEach(function (btn) {
+      btn.addEventListener("click", function () {
+        setLabOption(btn.getAttribute("data-lab-key"), btn.getAttribute("data-lab-value"));
+      });
+    });
+  }
+
+  // Applied before first paint so tiles never flash the wrong treatment.
+  Object.keys(LAB_KEYS).forEach(function (key) {
+    document.documentElement.setAttribute(LAB_KEYS[key].attr, _read(key));
+  });
+
+  if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", initDesignLab);
+  } else {
+    initDesignLab();
+  }
+
+  // --- Exports ---
+  global.normalizeVenueColor = normalizeVenueColor;
+  global.setLabOption = setLabOption;
+})(window);

--- a/frontend/js/design.js
+++ b/frontend/js/design.js
@@ -158,10 +158,11 @@
   // on <html> and persists it. Remove this block, its markup, and the [data-tiles="gutter"]
   // / [data-glow] / [data-scanlines] rules once the direction is settled.
 
+  // Glow defaults on -- it was kept after the comparison pass. Scanlines were dropped
+  // outright rather than defaulted off, so no stale attribute is left on <html>.
   const LAB_KEYS = {
-    tiles:      { attr: "data-tiles",      storage: "ts-lab-tiles",      fallback: "fill" },
-    glow:       { attr: "data-glow",       storage: "ts-lab-glow",       fallback: "off"  },
-    scanlines:  { attr: "data-scanlines",  storage: "ts-lab-scanlines",  fallback: "off"  },
+    tiles: { attr: "data-tiles", storage: "ts-lab-tiles", fallback: "fill" },
+    glow:  { attr: "data-glow",  storage: "ts-lab-glow",  fallback: "on"   },
   };
 
   function _read(key) {

--- a/frontend/js/equalizer.js
+++ b/frontend/js/equalizer.js
@@ -1,0 +1,211 @@
+/**
+ * The night-density equalizer -- a pixel bar meter for the next two weeks.
+ *
+ * Role: Loaded before app.js, which calls Equalizer.update() with the filtered event list
+ * on every calendar render. Each bar is one night; its height is how many shows are on
+ * that night, so the strip answers "when is there anything on" at a glance -- something
+ * the month grid cannot show, since a busy Saturday and a quiet one occupy the same cell.
+ *
+ * It reads as a flourish and behaves as one, but every bar is real data. It redraws
+ * whenever a filter changes, which is why it lives at the top of the filter column: the
+ * cause and its effect are visible together.
+ *
+ * Bars are built from discrete stacked cells rather than a scaled height, so the pixel
+ * grid is real geometry and each cell can be lit, delayed, and flickered on its own.
+ */
+
+(function (global) {
+  "use strict";
+
+  const NIGHTS = 14;   // two weeks: long enough to show a rhythm, short enough to stay legible
+  const CELLS  = 8;    // vertical resolution of one bar
+  const MIN_SCALE = 6; // floor for the bar scale — see the comment in update()
+
+  let _root     = null;
+  let _readout  = null;
+  let _bars     = [];  // { el, cells[], date, key, count }
+  let _lastData = [];
+  let _focused  = 0;   // roving tabindex position
+
+  // --- Date helpers ---
+
+  // Local-date key, deliberately not toISOString(): that converts to UTC first, which
+  // shifts the date by one for anyone west of Greenwich after 7pm -- the exact hours this
+  // site is used.
+  function _key(d) {
+    return (
+      d.getFullYear() +
+      "-" + String(d.getMonth() + 1).padStart(2, "0") +
+      "-" + String(d.getDate()).padStart(2, "0")
+    );
+  }
+
+  function _startOfToday() {
+    const d = new Date();
+    d.setHours(0, 0, 0, 0);
+    return d;
+  }
+
+  const DAY_NAMES = ["sun", "mon", "tue", "wed", "thu", "fri", "sat"];
+
+  function _label(date, count) {
+    const day = DAY_NAMES[date.getDay()];
+    const num = date.getDate();
+    if (count === 0) return day + " " + num + " · nothing on";
+    return day + " " + num + " · " + count + (count === 1 ? " show" : " shows");
+  }
+
+  // --- Build ---
+
+  function init() {
+    _root    = document.getElementById("equalizer");
+    _readout = document.getElementById("eq-readout");
+    if (!_root) return;
+
+    const today = _startOfToday();
+    _root.innerHTML = "";
+    _bars = [];
+
+    for (let i = 0; i < NIGHTS; i++) {
+      const date = new Date(today);
+      date.setDate(today.getDate() + i);
+
+      const bar = document.createElement("button");
+      bar.type = "button";
+      bar.className = "eq-bar";
+      bar.tabIndex = i === 0 ? 0 : -1;
+      // Staggered so a redraw sweeps left to right instead of snapping all at once.
+      bar.style.setProperty("--bar-index", String(i));
+      // Marks the start of each week so a fortnight reads as two weeks, not fourteen days.
+      if (date.getDay() === 0) bar.classList.add("eq-week-start");
+
+      const cells = [];
+      for (let c = 0; c < CELLS; c++) {
+        const cell = document.createElement("i");
+        cell.className = "eq-cell";
+        cell.style.setProperty("--cell-index", String(c));
+        bar.appendChild(cell);
+        cells.push(cell);
+      }
+
+      const entry = { el: bar, cells: cells, date: date, key: _key(date), count: 0 };
+      _bars.push(entry);
+
+      bar.addEventListener("mouseenter", function () { _showReadout(entry); });
+      bar.addEventListener("focus",      function () { _showReadout(entry); });
+      bar.addEventListener("click",      function () { _jumpTo(entry); });
+      bar.addEventListener("keydown",    _onKeydown);
+
+      _root.appendChild(bar);
+    }
+
+    _root.addEventListener("mouseleave", _clearReadout);
+    update(_lastData);
+  }
+
+  // --- Interaction ---
+
+  function _showReadout(entry) {
+    if (_readout) _readout.textContent = _label(entry.date, entry.count);
+    _bars.forEach(function (b) { b.el.classList.toggle("is-active", b === entry); });
+  }
+
+  function _clearReadout() {
+    if (_readout) _readout.textContent = _summary();
+    _bars.forEach(function (b) { b.el.classList.remove("is-active"); });
+  }
+
+  function _jumpTo(entry) {
+    if (!global.calendar || typeof global.calendar.gotoDate !== "function") return;
+    global.calendar.gotoDate(entry.date);
+  }
+
+  // Roving tabindex: the strip is one tab stop and arrows move within it, rather than
+  // dropping fourteen stops between search and the city filters.
+  function _onKeydown(e) {
+    let next = null;
+    if (e.key === "ArrowRight") next = Math.min(_focused + 1, _bars.length - 1);
+    else if (e.key === "ArrowLeft") next = Math.max(_focused - 1, 0);
+    else if (e.key === "Home") next = 0;
+    else if (e.key === "End") next = _bars.length - 1;
+    else return;
+
+    e.preventDefault();
+    _bars[_focused].el.tabIndex = -1;
+    _focused = next;
+    _bars[_focused].el.tabIndex = 0;
+    _bars[_focused].el.focus();
+  }
+
+  // --- Render ---
+
+  function _summary() {
+    const total = _bars.reduce(function (sum, b) { return sum + b.count; }, 0);
+    if (total === 0) return "nothing in the next two weeks";
+    return total + (total === 1 ? " show" : " shows") + " in the next two weeks";
+  }
+
+  /**
+   * Recompute every bar from a FullCalendar event array.
+   *
+   * Safe to call on every render: it is a count over events already in memory, and the
+   * cell classes it sets are idempotent.
+   */
+  function update(events) {
+    _lastData = events || [];
+    if (!_root || _bars.length === 0) return;
+
+    const counts = Object.create(null);
+    _lastData.forEach(function (ev) {
+      // Accept both the raw feed shape (start: "YYYY-MM-DD") and a Date, so this works
+      // whether it is handed cached JSON or live calendar objects.
+      const raw = ev && ev.start;
+      if (!raw) return;
+      const key = typeof raw === "string" ? raw.slice(0, 10) : _key(raw);
+      counts[key] = (counts[key] || 0) + 1;
+    });
+
+    let peak = 0;
+    _bars.forEach(function (bar) {
+      bar.count = counts[bar.key] || 0;
+      if (bar.count > peak) peak = bar.count;
+    });
+
+    // Scale to the busiest night in view so the shape stays readable under a narrow
+    // filter -- but floor that scale, or a filter leaving only single-show nights makes
+    // every one of them a full-height bar, which reads as "packed" when it means "one
+    // show". With the floor, one show is one cell whether or not anything else is on.
+    const scale = Math.max(peak, MIN_SCALE);
+
+    _bars.forEach(function (bar) {
+      let lit = 0;
+      if (bar.count > 0) {
+        lit = Math.max(1, Math.round((bar.count / scale) * CELLS));
+      }
+
+      bar.cells.forEach(function (cell, index) {
+        // Cell 0 is the bottom of the bar: DOM order is top-down, so invert.
+        const height = CELLS - index;
+        cell.classList.toggle("on", height <= lit);
+        cell.classList.toggle("cap", height === lit && lit > 0);
+      });
+
+      bar.el.classList.toggle("is-empty", bar.count === 0);
+      bar.el.setAttribute("aria-label", _label(bar.date, bar.count));
+    });
+
+    if (_root) _root.setAttribute("aria-label", _summary());
+    _clearReadout();
+  }
+
+  function refresh() { update(_lastData); }
+
+  // --- Exports ---
+  global.Equalizer = { init: init, update: update, refresh: refresh };
+
+  if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", init);
+  } else {
+    init();
+  }
+})(window);

--- a/frontend/js/equalizer.js
+++ b/frontend/js/equalizer.js
@@ -48,11 +48,15 @@
 
   const DAY_NAMES = ["sun", "mon", "tue", "wed", "thu", "fri", "sat"];
 
-  function _label(date, count) {
+  function _label(date, count, favCount) {
     const day = DAY_NAMES[date.getDay()];
     const num = date.getDate();
     if (count === 0) return day + " " + num + " · nothing on";
-    return day + " " + num + " · " + count + (count === 1 ? " show" : " shows");
+    const shows = count + (count === 1 ? " show" : " shows");
+    // Favourites are colour-coded in the bar; say it in words too, so the readout and the
+    // screen-reader label carry the same information the color does.
+    const hearted = favCount ? ", " + favCount + " hearted" : "";
+    return day + " " + num + " · " + shows + hearted;
   }
 
   // --- Build ---
@@ -88,7 +92,7 @@
         cells.push(cell);
       }
 
-      const entry = { el: bar, cells: cells, date: date, key: _key(date), count: 0 };
+      const entry = { el: bar, cells: cells, date: date, key: _key(date), count: 0, favCount: 0 };
       _bars.push(entry);
 
       bar.addEventListener("mouseenter", function () { _showReadout(entry); });
@@ -106,7 +110,7 @@
   // --- Interaction ---
 
   function _showReadout(entry) {
-    if (_readout) _readout.textContent = _label(entry.date, entry.count);
+    if (_readout) _readout.textContent = _label(entry.date, entry.count, entry.favCount);
     _bars.forEach(function (b) { b.el.classList.toggle("is-active", b === entry); });
   }
 
@@ -142,7 +146,9 @@
   function _summary() {
     const total = _bars.reduce(function (sum, b) { return sum + b.count; }, 0);
     if (total === 0) return "nothing in the next two weeks";
-    return total + (total === 1 ? " show" : " shows") + " in the next two weeks";
+    const fav = _bars.reduce(function (sum, b) { return sum + b.favCount; }, 0);
+    return total + (total === 1 ? " show" : " shows") + " in the next two weeks" +
+           (fav ? " · " + fav + " hearted" : "");
   }
 
   /**
@@ -156,6 +162,9 @@
     if (!_root || _bars.length === 0) return;
 
     const counts = Object.create(null);
+    const favCounts = Object.create(null);
+    const hasFavorites = typeof isFavorited === "function";
+
     _lastData.forEach(function (ev) {
       // Accept both the raw feed shape (start: "YYYY-MM-DD") and a Date, so this works
       // whether it is handed cached JSON or live calendar objects.
@@ -163,11 +172,15 @@
       if (!raw) return;
       const key = typeof raw === "string" ? raw.slice(0, 10) : _key(raw);
       counts[key] = (counts[key] || 0) + 1;
+      if (hasFavorites && ev.id !== undefined && isFavorited(ev.id)) {
+        favCounts[key] = (favCounts[key] || 0) + 1;
+      }
     });
 
     let peak = 0;
     _bars.forEach(function (bar) {
       bar.count = counts[bar.key] || 0;
+      bar.favCount = favCounts[bar.key] || 0;
       if (bar.count > peak) peak = bar.count;
     });
 
@@ -183,15 +196,25 @@
         lit = Math.max(1, Math.round((bar.count / scale) * CELLS));
       }
 
+      // Hearted shows occupy the base of the bar, so a bar reads bottom-up as "this many
+      // are mine, this many more are on". Rounded up and capped at the lit height: one
+      // favourite among five shows should be visibly one cell, not rounded away to none.
+      let favLit = 0;
+      if (bar.favCount > 0) {
+        favLit = Math.min(lit, Math.max(1, Math.round((bar.favCount / bar.count) * lit)));
+      }
+
       bar.cells.forEach(function (cell, index) {
         // Cell 0 is the bottom of the bar: DOM order is top-down, so invert.
         const height = CELLS - index;
-        cell.classList.toggle("on", height <= lit);
+        const isOn = height <= lit;
+        cell.classList.toggle("on", isOn);
+        cell.classList.toggle("fav", isOn && height <= favLit);
         cell.classList.toggle("cap", height === lit && lit > 0);
       });
 
       bar.el.classList.toggle("is-empty", bar.count === 0);
-      bar.el.setAttribute("aria-label", _label(bar.date, bar.count));
+      bar.el.setAttribute("aria-label", _label(bar.date, bar.count, bar.favCount));
     });
 
     if (_root) _root.setAttribute("aria-label", _summary());

--- a/frontend/js/favorites.js
+++ b/frontend/js/favorites.js
@@ -22,6 +22,11 @@ function toggleFavorite(eventId, eventData) {
   saveFavorites(favs);
   _refreshHeartUI(eventId, !!favs[eventId]);
   updateBottomBar();
+  // Repaint the equalizer so the hearted portion of each bar tracks the change
+  // immediately, rather than waiting for the next calendar refetch.
+  if (window.Equalizer && typeof window.Equalizer.refresh === "function") {
+    window.Equalizer.refresh();
+  }
 }
 
 function _refreshHeartUI(eventId, hearted) {


### PR DESCRIPTION
Visual refresh of the calendar, keeping the ASCII title and the CRT palettes. Three things: fixing the event-tile readability problem, replacing the filled tile with a venue-colored gutter, and adding a night-density equalizer to the filter column.

## The readability problem, and what it actually was

Event titles were **Space Mono 700 at 12px**. Bold works against a monospace at that size — Space Mono's counters are tight to begin with, and on a saturated tile they close up until the letterforms stop being distinguishable. Titles are now IBM Plex Mono 500 at 13px with a little tracking. Space Mono keeps the identity layer (ASCII title, labels, chrome); Plex takes the data layer, where it holds shape at 11–13px.

The venue line moved from 10.1px at 78% alpha to 11px in a solid color. Compositing white over 22 different hues was landing on a different result on every tile.

Underneath that was a worse problem nobody had measured. **The Carolina Theatre's `#F5D765` rendered at 1.42:1** — not a near-miss, unreadable — and it was broken in light mode too, differently, because light mode painted venue colors as *text*. It's now `#5f5a0b`, a citrine that joins the jewel-tone family every other venue uses and measures 7.11:1. Hue is 56° rather than a browner gold so there's ~30° between it and Stanczyks' espresso, the nearest warm tone and also a Durham venue.

`js/design.js` also clamps every venue color to a luminance band on the way in, so this doesn't reopen the next time a light color is added. 21 of 22 pass untouched.

## Tiles: venue color as a gutter

Text now always sits on the surface rather than on a saturated field, so contrast is constant instead of varying per venue, and lighter type weights start working.

Committing to this surfaced a problem the text audit had missed, because a rule is a *graphic*, not text. **The venue palette was authored for the filled tile** — every color is a dark background meant to sit behind white text. As a 3px rule on a dark surface all 22 measured between 1.14:1 and 2.51:1 against `--surface2`, under the 3:1 floor. Every one failed. They're fine on the light surface, so `venueRuleColors()` emits a brightened variant for dark mode and keeps the original for light.

Measured on the rendered DOM:

| | rule | title | venue line |
|---|---|---|---|
| Dark | 4.29:1 | 10.53:1 | 6.11:1 |
| Light | 5.42:1 | 13.59:1 | 7.96:1 |

No failures in either. Earlier passes covered all 5 palettes × light/dark × 22 venues — 220 combinations per treatment, zero below the 4.5:1 text floor.

## The equalizer

Fourteen bars in the sidebar, one per night, height = number of shows. It answers "when is there anything on" at a glance, which the month grid structurally can't — a packed Saturday and a quiet one are the same cell. It redraws on every filter change, which is why it sits above the filters rather than in a corner.

Hearted shows fill the base of each bar, so a bar reads bottom-up as "this many are mine, this many more are on." Pink by default, matching the heart on an event tile; soft sky blue under the wisteria palette, where pink on pink would say nothing; darkened in light mode, where the bright pink measures 2.0:1 on warm paper against a 3:1 graphics floor.

**Accessibility note worth reading:** pink and the phosphor palette's green sit at 1.02:1 luminance — the red-green colorblind case exactly, where both flatten to the same grey. Hearted cells carry an inset rim so they read as a texture rather than only a hue, they're always the contiguous base of a bar, and the readout and `aria-label` both say "N hearted" in words. Color is the third cue, not the only one.

The strip is one tab stop with arrow-key navigation rather than fourteen stops between search and the city filters.

## Opening at today

The month grid renders at full height inside the scrolling container, so late in a month the site opened on days that had already happened. It now scrolls to today on load and whenever the visible range contains today. It no-ops when today is already on screen, and is deliberately **not** wired to filter changes — those call `refetchEvents()`, which doesn't change the date range, so toggling a venue won't drag you back from whatever week you were reading.

That scrolling exposed two latent layout bugs, both invisible while nothing scrolled far enough to hit them:

- **The weekday header was completely hidden.** FullCalendar sticks both it and the toolbar at `top: 0`, and the toolbar wins on z-index with an opaque background. The header is now offset by the toolbar's measured height. The override needs `.fc-scrollgrid-section-sticky` in its selector purely to win the cascade — FullCalendar's rule is (0,3,0) and the obvious `.fc .fc-scrollgrid-section-header > th` is (0,2,1), which silently loses.
- **Rows showed through above the toolbar.** A sticky element pins to the padding box, so the container's `padding-top` left a strip with live content scrolling behind it. That spacing is now a margin on `.fc`.

## Also in here

- **Phosphor glow** on the ASCII title, headings, footer, weekday headers, day numbers, and list-view date headers. Calendar chrome glows in `currentColor` rather than `--accent`, since those elements aren't all accent-colored and phosphor emits the colour it's already showing.
- **Scanlines were tried and cut.** A 1-in-3 duty cycle landed on the same scale as the ASCII art's own strokes and the 11px sidebar text, so it read as interference.
- **19 ad-hoc font sizes collapsed into a six-step scale.** Values like 0.62 / 0.63 / 0.65 rem were indistinguishable but each had to be maintained.
- `requestAnimationFrame` is backed by a timer wherever it gates layout work — rAF doesn't fire in a background tab, so a page opened in one would never have scrolled.
- Reduced motion respected: the equalizer's bar heights carry its meaning and survive intact; only the sweep and flicker are dropped.

## Two things to flag

1. **`config.js` gained a dev escape hatch** — `localhost:8080` reads from the production API so the frontend can be previewed statically. Scoped to that exact port so the docker-compose stack on `:8000` keeps using its own local API. Happy to drop it if you'd rather it not ship.
2. **The Carolina Theatre's new color needs a deploy to appear.** It's a `seed.py` change, and `seed_venues()` overwrites every field on startup, so it lands on the next deploy with no migration.

The design lab that carried the fill-vs-gutter and glow comparisons has been removed, along with its markup, CSS, and localStorage keys.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
