### PR TITLE
Version CSS and JS URLs so a deploy cannot serve new HTML against cached assets

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -12,7 +12,9 @@ asyncpg-compatible PostgreSQL; Alembic migrations in backend/alembic/.
 # --- Imports ---
 import asyncio
 import logging
+import os
 from contextlib import asynccontextmanager
+from functools import lru_cache
 from pathlib import Path
 from typing import Optional
 
@@ -264,8 +266,92 @@ frontend_candidates = [
     Path(__file__).parent.parent.parent / "frontend",  # local dev
     Path("/frontend"),  # Docker
 ]
-for frontend_dir in frontend_candidates:
-    if frontend_dir.exists():
-        # Mounted last so API routes take priority over the catch-all html=True handler
-        app.mount("/", StaticFiles(directory=str(frontend_dir), html=True), name="frontend")
+
+_frontend_dir: Optional[Path] = None
+for candidate in frontend_candidates:
+    if candidate.exists():
+        _frontend_dir = candidate
         break
+
+
+# --- Asset versioning on index.html ---
+#
+# index.html references /css/*.css and /js/*.js at fixed URLs. Cloudflare caches those at
+# the edge for hours on the free plan, while index.html itself is never edge-cached
+# (cf-cache-status: DYNAMIC). After a deploy that combination serves *new* HTML against
+# *old* assets, which is worse than serving an entirely stale page: on the 2026-08-28
+# release the new markup loaded a new equalizer.js against a styles.css that had no rules
+# for it, and visitors got a row of unstyled buttons in the sidebar.
+#
+# Substituting {{ASSET_VERSION}} with the commit SHA gives every deploy fresh asset URLs,
+# so the edge treats them as new objects and there is nothing left to purge by hand.
+#
+# Done at request time from the env var rather than by rewriting the file at image build:
+# GIT_COMMIT is already in the container (cloudbuild.yaml passes it as a build arg,
+# Dockerfile promotes it to ENV, health.py reads it), and this way the checked-in
+# index.html stays a file that runs as-is in local dev.
+
+ASSET_VERSION_PLACEHOLDER = "{{ASSET_VERSION}}"
+
+
+def _asset_version() -> str:
+    """Cache-busting token for static asset URLs.
+
+    The commit SHA in production. Unset locally and in CI, where "dev" is correct: there is
+    no CDN in front of either, and the browser revalidates against the local server.
+    """
+    return os.environ.get("GIT_COMMIT", "dev")[:12]
+
+
+@lru_cache(maxsize=1)
+def _index_html() -> Optional[str]:
+    """index.html with the asset version substituted, read once per container.
+
+    Cached because neither the file nor GIT_COMMIT changes within the life of a container.
+    Returns None when there is no frontend directory, which is the case in the API-only
+    test runs -- the caller then falls through to a 404 rather than raising.
+    """
+    if _frontend_dir is None:
+        return None
+
+    index_path = _frontend_dir / "index.html"
+    if not index_path.is_file():
+        return None
+
+    html = index_path.read_text(encoding="utf-8")
+    return html.replace(ASSET_VERSION_PLACEHOLDER, _asset_version())
+
+
+@app.get("/", include_in_schema=False)
+@app.get("/index.html", include_in_schema=False)
+async def serve_index():
+    """Serve the templated index.html.
+
+    Registered before the StaticFiles mount below, which would otherwise answer "/" with
+    the raw file and leave the placeholder in the markup.
+
+    no-store rather than a short max-age: this document is what names the versioned asset
+    URLs, so a cached copy of it defeats the whole mechanism by continuing to point at the
+    previous deploy's files.
+    """
+    from fastapi.responses import HTMLResponse, PlainTextResponse
+
+    html = _index_html()
+    if html is None:
+        return PlainTextResponse("Frontend not available", status_code=404)
+
+    return HTMLResponse(
+        html,
+        headers={
+            "Cache-Control": "no-store, must-revalidate",
+            # Surfaces which build a page came from without opening devtools, which is how
+            # the stale-asset problem went unnoticed for as long as it did.
+            "X-Asset-Version": _asset_version(),
+        },
+    )
+
+
+if _frontend_dir is not None:
+    # Mounted last so API routes and serve_index above take priority over the catch-all
+    # html=True handler.
+    app.mount("/", StaticFiles(directory=str(_frontend_dir), html=True), name="frontend")

--- a/backend/tests/test_asset_versioning.py
+++ b/backend/tests/test_asset_versioning.py
@@ -1,0 +1,145 @@
+"""
+Tests for the versioned asset URLs on index.html.
+
+What this protects. index.html references /css and /js at fixed URLs, and Cloudflare caches
+those at the edge for hours while never caching index.html itself. After a deploy that
+serves new HTML against old assets, which is worse than serving a wholly stale page: on the
+2026-08-28 release the new markup loaded a new equalizer.js against a styles.css with no
+rules for it, and the sidebar rendered as unstyled buttons. Appending ?v=<commit sha> makes
+every deploy a new URL at the edge.
+
+The mechanism has two halves and a test that only checks one of them passes for the wrong
+reason, so both are pinned:
+
+  1. The response contains no unsubstituted placeholder. On its own this also passes if
+     index.html simply never had a placeholder in it.
+  2. The file on disk still contains the placeholder, and the response carries a real
+     version token in its place.
+
+The CDN assertion is here because the substitution is a string replace over the whole
+document: a broader pattern that caught the FullCalendar or Google Fonts URLs would append
+a query string to a third-party request, which is both wrong and hard to notice.
+"""
+
+import re
+
+import pytest
+from fastapi.testclient import TestClient
+
+from app.main import (
+    ASSET_VERSION_PLACEHOLDER,
+    _asset_version,
+    _frontend_dir,
+    _index_html,
+    app,
+)
+
+
+needs_frontend = pytest.mark.skipif(
+    _frontend_dir is None, reason="no frontend directory in this checkout"
+)
+
+
+@pytest.fixture
+def client():
+    return TestClient(app)
+
+
+@pytest.fixture
+def index_body(client):
+    response = client.get("/")
+    assert response.status_code == 200, "index.html is not being served at /"
+    return response.text
+
+
+@needs_frontend
+class TestPlaceholderIsSubstituted:
+    def test_no_placeholder_survives_into_the_response(self, index_body):
+        assert ASSET_VERSION_PLACEHOLDER not in index_body
+
+    def test_the_source_file_really_does_contain_the_placeholder(self):
+        """Guards against the first assertion passing because nothing needed substituting.
+
+        If someone removes the placeholders from index.html, the whole mechanism silently
+        stops working while every other test here still passes.
+        """
+        raw = (_frontend_dir / "index.html").read_text(encoding="utf-8")
+        assert ASSET_VERSION_PLACEHOLDER in raw
+
+    def test_local_assets_carry_the_version_token(self, index_body):
+        version = _asset_version()
+        assert f"/css/styles.css?v={version}" in index_body
+        for script in ("app.js", "config.js", "design.js", "equalizer.js"):
+            assert f"/js/{script}?v={version}" in index_body
+
+    def test_every_local_asset_is_versioned_not_just_some(self, index_body):
+        """A partially versioned page is the exact failure being fixed: the mixed state,
+        where some files come from the new deploy and some from cache."""
+        unversioned = re.findall(r'(?:href|src)="(/(?:css|js)/[^"?]+\.(?:css|js))"', index_body)
+        assert unversioned == [], f"local assets missing ?v=: {unversioned}"
+
+
+@needs_frontend
+class TestThirdPartyUrlsAreUntouched:
+    def test_cdn_and_font_urls_have_no_version_query(self, index_body):
+        for host in ("cdn.jsdelivr.net", "fonts.googleapis.com", "fonts.gstatic.com"):
+            for url in re.findall(rf'"(https://{re.escape(host)}[^"]*)"', index_body):
+                assert "?v=" not in url, f"third-party URL was versioned: {url}"
+
+
+@needs_frontend
+class TestTheDocumentItselfIsNotCached:
+    def test_cache_control_forbids_storing_the_html(self, client):
+        """The load-bearing header. This document is what names the versioned asset URLs,
+        so a cached copy keeps pointing at the previous deploy's files and the versioning
+        buys nothing."""
+        cache_control = client.get("/").headers.get("cache-control", "")
+        assert "no-store" in cache_control
+
+    def test_index_html_path_behaves_like_the_root(self, client):
+        """Both routes exist, so a link to /index.html cannot bypass the substitution and
+        get the raw file from the StaticFiles mount."""
+        response = client.get("/index.html")
+        assert response.status_code == 200
+        assert ASSET_VERSION_PLACEHOLDER not in response.text
+        assert "no-store" in response.headers.get("cache-control", "")
+
+
+class TestVersionToken:
+    def test_falls_back_to_dev_when_git_commit_is_unset(self, monkeypatch):
+        """Local dev and CI have no GIT_COMMIT, and must still serve a usable page."""
+        monkeypatch.delenv("GIT_COMMIT", raising=False)
+        assert _asset_version() == "dev"
+
+    def test_uses_the_commit_sha_when_present(self, monkeypatch):
+        monkeypatch.setenv("GIT_COMMIT", "0123456789abcdef0123456789abcdef01234567")
+        assert _asset_version() == "0123456789ab"
+
+    def test_token_is_url_safe(self, monkeypatch):
+        """It goes straight into a query string, so anything needing escaping would produce
+        a subtly wrong URL rather than an error."""
+        monkeypatch.setenv("GIT_COMMIT", "06bdf7f132dc5fec7d541ce40e353d69a2784966")
+        assert re.fullmatch(r"[A-Za-z0-9._-]+", _asset_version())
+
+    def test_changing_the_sha_changes_the_asset_urls(self, monkeypatch):
+        """The property the whole fix depends on: a new deploy must produce new URLs.
+
+        _index_html is lru_cached, since neither the file nor the SHA changes within a
+        container's life, so the cache is cleared here to exercise a fresh render.
+        """
+        if _frontend_dir is None:
+            pytest.skip("no frontend directory in this checkout")
+
+        monkeypatch.setenv("GIT_COMMIT", "a" * 40)
+        _index_html.cache_clear()
+        first = _index_html()
+
+        monkeypatch.setenv("GIT_COMMIT", "b" * 40)
+        _index_html.cache_clear()
+        second = _index_html()
+
+        assert first != second
+        assert "?v=" + "a" * 12 in first
+        assert "?v=" + "b" * 12 in second
+
+        _index_html.cache_clear()

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -16,7 +16,7 @@
        week ruler; loaded so pixel treatments can be tried elsewhere without a round trip. -->
   <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:ital,wght@0,400;0,500;0,600;1,400&family=Orbitron:wght@900&family=Silkscreen:wght@400;700&family=Space+Mono:ital,wght@0,400;0,700;1,400;1,700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/fullcalendar@6.1.15/index.global.min.css">
-  <link rel="stylesheet" href="/css/styles.css">
+  <link rel="stylesheet" href="/css/styles.css?v={{ASSET_VERSION}}">
 
   <!-- Google Analytics -->
   <script async src="https://www.googletagmanager.com/gtag/js?id=G-S37F3PHK0R"></script>
@@ -168,12 +168,12 @@
   <script defer src="https://cdn.jsdelivr.net/npm/fullcalendar@6.1.15/index.global.min.js"></script>
 
   <!-- App JS -->
-  <script defer src="/js/design.js"></script>
-  <script defer src="/js/equalizer.js"></script>
-  <script defer src="/js/config.js"></script>
-  <script defer src="/js/filters.js"></script>
-  <script defer src="/js/modal.js"></script>
-  <script defer src="/js/favorites.js"></script>
-  <script defer src="/js/app.js"></script>
+  <script defer src="/js/design.js?v={{ASSET_VERSION}}"></script>
+  <script defer src="/js/equalizer.js?v={{ASSET_VERSION}}"></script>
+  <script defer src="/js/config.js?v={{ASSET_VERSION}}"></script>
+  <script defer src="/js/filters.js?v={{ASSET_VERSION}}"></script>
+  <script defer src="/js/modal.js?v={{ASSET_VERSION}}"></script>
+  <script defer src="/js/favorites.js?v={{ASSET_VERSION}}"></script>
+  <script defer src="/js/app.js?v={{ASSET_VERSION}}"></script>
 </body>
 </html>


### PR DESCRIPTION
Closes #72.

`index.html` now carries `?v={{ASSET_VERSION}}` on its local CSS and JS, substituted with the commit SHA, so every deploy produces asset URLs the edge has never seen and "remember to purge the Cloudflare cache" leaves the release process.

## Why this is worth fixing properly

`index.html` is `cf-cache-status: DYNAMIC` — never edge-cached — so it goes new the instant a deploy lands, while the assets it names stay cached for hours. The page and its stylesheet actively disagree, which is a worse failure than an entirely stale site.

Measured minutes after the 2026-08-28 release:

| Asset | Served | On disk | Edge |
|---|---|---|---|
| `index.html` | new | — | `DYNAMIC` |
| `js/design.js` (new file) | new | — | `MISS` |
| `js/equalizer.js` (new file) | new | — | `MISS` |
| `css/styles.css` | **31,723 B** | 47,894 B | `HIT` |
| `js/app.js` | **13,340 B** | 21,905 B | `HIT` |

Brand-new files were fetched from origin because nothing had cached them; modified files came from cache. So the new markup loaded a new `equalizer.js` against a `styles.css` with no rules for it, and the sidebar rendered as a row of unstyled native buttons. An all-stale site would merely have looked like the previous design.

## Approach

Substituted **at request time** from `GIT_COMMIT`, not by rewriting the file at image build.

The plumbing already existed end to end: `cloudbuild.yaml:62` passes `--build-arg=GIT_COMMIT=$COMMIT_SHA`, `Dockerfile:20-21` promotes it to `ENV`, and `health.py:80` already reads it. Reading the env var keeps the checked-in `index.html` a file that runs as-is locally, rather than a template that doesn't. Falls back to `dev` when `GIT_COMMIT` is unset — local dev and CI, where there's no CDN in front and the browser revalidates against the local server.

Three details that matter:

- **Route order.** Registered before the `StaticFiles` mount, which would otherwise answer `/` with the raw file and leave the placeholder in the markup. `/index.html` is routed too, so a direct link can't bypass the substitution.
- **`Cache-Control: no-store` on the HTML.** This document is what *names* the versioned asset URLs. A cached copy keeps pointing at the previous deploy's files and the versioning buys nothing.
- **`X-Asset-Version` response header.** Which build a page came from is now visible without opening devtools. Not having that is part of why this went unnoticed for as long as it did.

## Tests

11 new tests, and they pin **both** halves of the mechanism deliberately. Asserting only that no placeholder survives into the response would pass equally well if `index.html` had never contained a placeholder — so there's a companion assertion that the file on disk still contains one. Also:

- No local asset is left unversioned — a partially versioned page is precisely the mixed state being fixed.
- Third-party URLs are untouched. The substitution is a string replace over the whole document, and a broader pattern would append a query string to CDN and Google Fonts requests, which is wrong and hard to spot.
- Changing the SHA changes the URLs — the property the whole fix depends on.

Full suite: **249 passed, 4 skipped.**

`tests/test_dedupe_past_events.py` can't be collected in the docker-compose container because `./tools` isn't mounted — pre-existing and unrelated, but worth knowing if you run tests that way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
