### PR TITLE
Stop a CRLF in a stored ticket_url from injecting properties into the favorites .ics

### DIFF
--- a/frontend/js/favorites.js
+++ b/frontend/js/favorites.js
@@ -146,7 +146,7 @@ function downloadFavorites() {
       `SUMMARY:${_esc(ev.title)}`,
       ...(location    ? [`LOCATION:${_esc(location)}`]    : []),
       ...(desc        ? [`DESCRIPTION:${_esc(desc)}`]     : []),
-      ...(ev.ticket_url ? [`URL:${ev.ticket_url}`]        : []),
+      ...(ev.ticket_url ? [`URL:${_escUri(ev.ticket_url)}`] : []),
       `UID:${ev.id}@triangle-shows.org`,
       "END:VEVENT"
     );
@@ -196,11 +196,38 @@ function _icsEnd(dateStr, timeStr) {
   );
 }
 
+// Escape a TEXT property value (RFC 5545 3.3.11). Order matters: the backslash pass
+// runs first so the escapes the later passes introduce are not themselves re-escaped.
+//
+// Favorites are JSON.parsed back out of localStorage and never revalidated, so nothing
+// here can assume a string — coerce with String() before calling .replace(). The
+// existing falsy early-return already absorbs null/0/"", so this only adds the
+// truthy non-string case, which used to throw.
 function _esc(str) {
   if (!str) return "";
-  return str
+  return String(str)
     .replace(/\\/g, "\\\\")
     .replace(/;/g, "\\;")
     .replace(/,/g, "\\,")
-    .replace(/\n/g, "\\n");
+    // Every line-break form collapses to the one escaped sequence. The old /\n/g
+    // pass left a bare CR untouched: a raw control character, which TEXT forbids
+    // outright, and which a lenient parser can still read as a line break.
+    .replace(/\r\n|\r|\n/g, "\\n");
+}
+
+// Sanitize a URI property value (RFC 5545 3.3.13). NOT the same as _esc: a URI is
+// not TEXT, so it must not pick up the backslash escaping of `,` `;` `\` — applying
+// that would corrupt any real ticket link containing those characters.
+//
+// What a URI value must not carry is a line break. This calendar is assembled by
+// joining property lines with CRLF, so a CR or LF surviving into a value ends the
+// property early and everything after it parses as a fresh iCalendar property the
+// attacker chose. ticket_url is stored as the scraper found it (no validation on the
+// model or the schema), and app.js writes it verbatim into the localStorage favorites
+// blob, which getFavorites() JSON.parses back with no revalidation — so the value
+// landing here is whatever a scraped venue page carried. Strip the control characters
+// rather than escape them: none is legal in a URI anyway, so this costs no real link.
+function _escUri(str) {
+  if (!str) return "";
+  return String(str).replace(/[\u0000-\u001F\u007F]/g, "");
 }

--- a/frontend/tests/favorites.test.js
+++ b/frontend/tests/favorites.test.js
@@ -1,0 +1,144 @@
+// Tests for the client-side .ics generation in ../js/favorites.js.
+//
+// favorites.js is a plain <script> (no module.exports), but it touches no browser
+// global at load time — every DOM/localStorage access sits inside a function. So it
+// loads cleanly into a vm context whose sandbox supplies only the globals
+// downloadFavorites actually reaches for (localStorage, Blob, URL, document,
+// setTimeout), and the generated calendar body can be captured from the Blob stub.
+//
+// What is under test is iCalendar *property injection*. The .ics is assembled by
+// joining property lines with CRLF, so any CR or LF that survives into a value
+// terminates that property early and everything after it is parsed as a fresh
+// iCalendar property of the attacker's choosing.
+//
+// The values here come from localStorage: ticket_url is stored as the scraper found it
+// (no validation on the model or the schema), app.js writes it verbatim into the
+// favorites blob (app.js:477), and getFavorites() JSON.parses it back with no
+// revalidation — so the value under test is whatever a scraped venue page carried.
+//
+// Run with: node --test frontend/tests/favorites.test.js
+// node:test is a Node built-in, so this file needs no package.json and no deps.
+
+const { test } = require("node:test");
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const path = require("node:path");
+const vm = require("node:vm");
+
+const FAVORITES_SRC = fs.readFileSync(path.join(__dirname, "../js/favorites.js"), "utf8");
+
+// Loads favorites.js into a fresh vm context seeded with `favorites` as the stored
+// blob. Returns the sandbox plus a `captured` handle that receives the Blob parts
+// downloadFavorites builds, so tests can assert on the exact calendar body.
+function loadFavorites(favorites = {}) {
+  const captured = {};
+  const sandbox = {
+    localStorage: {
+      getItem: (key) =>
+        key === "triangle-shows-favorites" ? JSON.stringify(favorites) : null,
+      setItem() {},
+      removeItem() {},
+    },
+    Blob: class {
+      constructor(parts, opts) {
+        captured.parts = parts;
+        captured.opts = opts;
+      }
+    },
+    URL: { createObjectURL: () => "blob:stub", revokeObjectURL() {} },
+    document: {
+      createElement: () => ({ click() {} }),
+      body: { appendChild() {}, removeChild() {} },
+      getElementById: () => null,
+      querySelectorAll: () => [],
+    },
+    setTimeout() {},
+  };
+  vm.createContext(sandbox);
+  vm.runInContext(FAVORITES_SRC, sandbox);
+  return { sandbox, captured };
+}
+
+// Runs downloadFavorites over one favorite and returns the generated calendar as an
+// array of property lines, split the way an iCalendar parser splits it.
+function generateLines(favorite) {
+  const { sandbox, captured } = loadFavorites({ [favorite.id]: favorite });
+  sandbox.downloadFavorites();
+  return captured.parts[0].split("\r\n");
+}
+
+const BASE_FAVORITE = {
+  id: "42",
+  title: "Wednesday",
+  date: "2026-08-08",
+  show_time: "20:00:00",
+  venue_name: "Cat's Cradle",
+  venue_city: "Carrboro",
+};
+
+test("downloadFavorites does not let a CRLF in ticket_url inject an iCalendar property", () => {
+  const lines = generateLines({
+    ...BASE_FAVORITE,
+    // A newline in the value ends the URL property; everything after it would be
+    // parsed as sibling properties — here an ATTENDEE and a replacement SUMMARY.
+    ticket_url:
+      "https://tickets.example.com/42\r\nATTENDEE:mailto:evil@example.com\r\nSUMMARY:Injected",
+  });
+
+  const injected = lines.filter(
+    (line) => line.startsWith("ATTENDEE") || line === "SUMMARY:Injected"
+  );
+  assert.deepEqual(injected, []);
+  // The whole payload stays inside the one URL property it was written into.
+  const urlLines = lines.filter((line) => line.startsWith("URL:"));
+  assert.equal(urlLines.length, 1);
+  assert.equal(
+    urlLines[0],
+    "URL:https://tickets.example.com/42ATTENDEE:mailto:evil@example.comSUMMARY:Injected"
+  );
+});
+
+test("downloadFavorites emits a well-formed ticket_url in URL: byte-for-byte", () => {
+  // RFC 5545 types URL as URI (3.3.13), not TEXT (3.3.11), so it must NOT pick up
+  // _esc()'s backslash escaping of `,` `;` `\` — that would corrupt any real ticket
+  // link containing them. This asserts the injection fix did not reach for _esc.
+  const url = "https://tickets.example.com/42?ref=a,b;c&utm_source=site";
+  const lines = generateLines({ ...BASE_FAVORITE, ticket_url: url });
+
+  assert.ok(lines.includes(`URL:${url}`));
+});
+
+test("downloadFavorites does not let a CRLF in a favorite's title inject an iCalendar property", () => {
+  const lines = generateLines({
+    ...BASE_FAVORITE,
+    title: "Show\r\nATTENDEE:mailto:evil@example.com",
+  });
+
+  assert.deepEqual(lines.filter((line) => line.startsWith("ATTENDEE")), []);
+  assert.ok(lines.includes("SUMMARY:Show\\nATTENDEE:mailto:evil@example.com"));
+});
+
+test("_esc collapses CRLF, bare CR, and bare LF to the escaped \\n sequence", () => {
+  const { sandbox } = loadFavorites();
+
+  // A bare CR survived the old /\n/g replace untouched, leaving a raw control
+  // character in a TEXT value (RFC 5545 forbids those outright) that a lenient
+  // parser can still read as a line break.
+  assert.equal(sandbox._esc("a\r\nb"), "a\\nb");
+  assert.equal(sandbox._esc("a\rb"), "a\\nb");
+  assert.equal(sandbox._esc("a\nb"), "a\\nb");
+  // The backslash pass still runs first, so a literal backslash doubles and the
+  // newline escape that follows is not itself re-escaped.
+  assert.equal(sandbox._esc("a\\b\nc"), "a\\\\b\\nc");
+  // TEXT escaping of , and ; is unchanged.
+  assert.equal(sandbox._esc("a,b;c"), "a\\,b\\;c");
+});
+
+test("_esc coerces a non-string instead of throwing", () => {
+  const { sandbox } = loadFavorites();
+
+  // Favorites come back out of localStorage with no type check, and `.replace` only
+  // exists on String.prototype — so a stored number reached the old _esc and threw.
+  assert.equal(sandbox._esc(12345), "12345");
+  assert.equal(sandbox._esc(null), "");
+});


### PR DESCRIPTION
## The defect

`frontend/js/favorites.js` builds the client-side "download my shows" `.ics` by joining property lines with CRLF:

```js
const blob = new Blob([lines.join("\r\n")], { type: "text/calendar;charset=utf-8" });  // favorites.js:157
```

Three of the four value-bearing lines run through `_esc`. One does not:

```js
`SUMMARY:${_esc(ev.title)}`,                                  // favorites.js:146
...(location    ? [`LOCATION:${_esc(location)}`]    : []),    // favorites.js:147
...(desc        ? [`DESCRIPTION:${_esc(desc)}`]     : []),    // favorites.js:148
...(ev.ticket_url ? [`URL:${ev.ticket_url}`]        : []),    // favorites.js:149  <-- unescaped
```

A CR or LF in `ticket_url` terminates the `URL` property early, and everything after it is parsed as a fresh iCalendar property of the attacker's choosing — an extra `ATTENDEE`, a replacement `SUMMARY`, whatever fits. The exported file then imports into Apple Calendar / Google Calendar / Outlook carrying those properties.

## Why the value is reachable

`ticket_url` is untrusted the whole way down, and nothing on the path normalizes it:

- It is stored as the scraper found it — no validation on the model (`backend/app/models.py:82`, a plain `String(1000)`) or the schema (`backend/app/schemas.py:48`). Scrapers assign it straight from a page's `href` / JSON-LD `offers.url` (e.g. `backend/app/scrapers/eventprime.py:99`, `backend/app/scrapers/koka_booth.py:143`).
- `app.js` writes it verbatim into the localStorage favorites blob: `ticket_url: p.ticket_url || ""` (`frontend/js/app.js:477`).
- `getFavorites()` reads that blob back with a bare `JSON.parse` and no revalidation (`frontend/js/favorites.js:9-12`), so a favorite persisted at any point in the past still carries exactly what was stored then.

Note that `modal.js:14` does gate the value with `/^https?:\/\//i` before rendering an anchor, but that is a render-time check in the modal only — the favorites path never sees it.

## The fix, and why `_esc` is the wrong tool

`_esc` is a TEXT escaper (RFC 5545 §3.3.11): it backslash-escapes `\`, `;` and `,`. RFC 5545 types `URL` as **URI (§3.3.13)**, not TEXT. Routing the ticket link through `_esc` would rewrite `https://example.com/x?ref=a,b;c` into `https://example.com/x?ref=a\,b\;c` and break real links — a fix that trades an injection for a correctness bug.

So this adds a separate `_escUri` that **strips control characters** rather than escaping them:

```js
function _escUri(str) {
  if (!str) return "";
  return String(str).replace(/[\u0000-\u001F\u007F]/g, "");
}
```

No control character is legal in a URI, so stripping costs nothing for a well-formed link, and every other byte passes through untouched. There is a test asserting exactly that (`URL:` is emitted byte-for-byte for a link containing `,` and `;`), so a later "simplification" to `_esc` fails rather than silently corrupting links.

## The server-side feed is not affected

Worth stating so a reviewer does not go looking in the wrong place: `backend/app/api/feeds.py` is **not** exposed. It assembles the subscription feed through the `icalendar` library rather than by hand, and that library refuses to serialize a content line holding an unescaped newline — `Contentline.__new__` asserts on it — so the payload never reaches the wire. Only the hand-joined client-side export in `favorites.js` is affected. (Side observation, not addressed here: because that is an assertion rather than sanitization, a stored `ticket_url` containing a newline would make `/feed.ics` raise instead of serving. Happy to file that separately if you want it looked at.)

## Two adjacent defects in `_esc`

Both surfaced while checking whether `_esc` could be relied on. Each is a one-line change and each is covered by a test; say the word if you would rather they were split out.

1. **A bare CR survived it.** The old pass was `.replace(/\n/g, "\\n")`, which leaves a lone `\r` in place. That is a raw control character, which TEXT forbids outright, and a lenient parser can still read it as a line break. All three line-break forms now collapse to the one escaped sequence — still applied after the backslash pass, so the escapes that pass introduces are not themselves re-escaped.
2. **It threw on a truthy non-string.** `_esc` called `.replace()` directly on a value read back out of localStorage with no type check; `.replace` only exists on `String.prototype`, so a stored number threw a `TypeError` and took the whole export down. `String(str)` first. The existing falsy early-return still absorbs `null` / `0` / `""`, so this only adds the truthy non-string case.

## Tests

`frontend/tests/favorites.test.js`, five cases: the `ticket_url` injection, the byte-for-byte URL guard described above, a `title` injection, the `_esc` line-break collapse, and the `_esc` non-string coercion. Four of the five fail against the current code and all five pass with the change.

I noticed CI has no JavaScript test runner, and I have not added one or touched `.github/workflows/ci.yml` — the backend job is unchanged. The file uses `node:test`, `node:assert/strict`, `node:fs`, `node:path` and `node:vm`, all Node built-ins, so it needs no `package.json` and no dependencies and costs nothing to carry:

```
node --test frontend/tests/favorites.test.js
```

If you would like it wired into CI, a `node --test frontend/tests` step needs only `actions/setup-node` and no install step — but that is your call, so I left it out of this change.

The diff is frontend-only; `backend/` is untouched.
