### PR TITLE
Escape ticket_url and image_url before interpolating them into modal attributes

### DIFF
--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -10,9 +10,33 @@ Requires: models.py (ORM objects are converted via from_attributes=True),
 
 # --- Imports ---
 
-from pydantic import BaseModel
+from pydantic import BaseModel, BeforeValidator
 from datetime import date, time, datetime
-from typing import Optional
+from typing import Annotated, Optional
+
+
+# --- Shared field types ---
+
+def _none_if_not_absolute_http_url(value):
+    """Coerce a non-absolute-http(s) ``ticket_url``/``image_url`` to ``None``.
+
+    Both fields are third-party-sourced (see
+    ``app.scrapers.base.ScrapedEvent.__post_init__``, which applies the same rule at
+    ingestion) and are rendered into HTML attributes by the web client. This is a
+    second, independent gate at the API boundary: it covers rows written before that
+    ingestion-time normalization existed, and anything that reaches the database by
+    a path other than a scraper. A relative path, a ``javascript:``/``data:`` scheme,
+    or a non-string value must never reach a client as-is, but a single malformed
+    field must not fail the whole event, so this normalizes rather than raises.
+    """
+    if not isinstance(value, str):
+        return None
+    value = value.strip()
+    return value if value.lower().startswith(("http://", "https://")) else None
+
+
+# A ticket_url/image_url, normalized to an absolute http(s) string or None.
+OptionalHttpUrl = Annotated[Optional[str], BeforeValidator(_none_if_not_absolute_http_url)]
 
 
 # --- Venue Schema ---
@@ -45,10 +69,10 @@ class EventResponse(BaseModel):
     date: date
     doors_time: Optional[time] = None
     show_time: Optional[time] = None
-    ticket_url: Optional[str] = None
+    ticket_url: OptionalHttpUrl = None
     price_min: Optional[float] = None
     price_max: Optional[float] = None
-    image_url: Optional[str] = None
+    image_url: OptionalHttpUrl = None
     genre: Optional[str] = None
     subgenre: Optional[str] = None
     status: str

--- a/backend/app/scrapers/base.py
+++ b/backend/app/scrapers/base.py
@@ -53,6 +53,31 @@ def clean_title(text: Optional[str]) -> Optional[str]:
     return re.sub(r"\s+", " ", text).strip()
 
 
+# --- Scraped-URL validation ---
+
+def _validate_absolute_http_url(value: Optional[str]) -> Optional[str]:
+    """Normalize a scraped ``ticket_url``/``image_url`` to an absolute http(s) URL.
+
+    Both fields come straight off third-party venue pages and end up interpolated
+    into HTML attributes by the web client (``frontend/js/modal.js``), and into the
+    iCal feed (``app/api/feeds.py``, which reads the ORM column directly and never
+    passes through the API response schema). A relative, scheme-relative, or
+    ``javascript:``-scheme value is not a URL any of those consumers should trust.
+    This mirrors the ``/^https?:\\/\\//i`` prefix check the web client already
+    applies to ``ticket_url``, and extends it to ``image_url``, which had none.
+
+    A non-http(s) value normalizes to ``None`` rather than raising: one bad field
+    must not turn into a scrape failure and drop an otherwise good event from the
+    calendar.
+    """
+    if not isinstance(value, str):
+        return None
+    value = value.strip()
+    if not value or not value.lower().startswith(("http://", "https://")):
+        return None
+    return value
+
+
 # --- ScrapedEvent Dataclass ---
 
 @dataclass
@@ -80,10 +105,16 @@ class ScrapedEvent:
     source_url: Optional[str] = None
 
     def __post_init__(self):
-        """Normalize the human-readable fields before anything hashes or stores them."""
+        """Normalize the human-readable and URL fields before anything hashes or stores them."""
         self.name = clean_title(self.name)
         self.artist = clean_title(self.artist)
         self.support_artists = clean_title(self.support_artists)
+        # ticket_url/image_url are third-party-sourced and are rendered into HTML
+        # attributes by the web client and into the iCal feed. Normalize both to an
+        # absolute http(s) URL or None at this single choke point, so no scraper has
+        # to remember to, and so nothing downstream has to re-derive the rule.
+        self.ticket_url = _validate_absolute_http_url(self.ticket_url)
+        self.image_url = _validate_absolute_http_url(self.image_url)
 
     @property
     def hash(self) -> str:

--- a/backend/tests/test_event_response_url_validation.py
+++ b/backend/tests/test_event_response_url_validation.py
@@ -1,0 +1,69 @@
+"""Unit tests for EventResponse's ticket_url/image_url normalization.
+
+Pure Pydantic-model tests — no database. This is the second, independent gate on
+these two fields: app.scrapers.base.ScrapedEvent.__post_init__ already normalizes
+them at ingestion (tests/test_scraped_event_url_validation.py), but EventResponse is
+what the events list endpoint actually serves, regardless of how a row reached the
+database — a row written before the ingestion-time gate existed, or by any future
+path that does not go through ScrapedEvent. Both gates must independently null out a
+malformed value rather than raise, so one bad field never fails a whole event.
+"""
+
+from datetime import date
+
+from app.schemas import EventResponse
+
+
+def _min_fields(**overrides):
+    fields = dict(
+        id=1,
+        venue_id=1,
+        name="Test Show",
+        date=date(2026, 1, 1),
+        status="on_sale",
+        source="manual",
+    )
+    fields.update(overrides)
+    return fields
+
+
+def test_well_formed_https_ticket_url_passes_through_unchanged():
+    ev = EventResponse(**_min_fields(ticket_url="https://tickets.example.com/42?ref=abc&utm_source=site"))
+    assert ev.ticket_url == "https://tickets.example.com/42?ref=abc&utm_source=site"
+
+
+def test_well_formed_http_image_url_passes_through_unchanged():
+    ev = EventResponse(**_min_fields(image_url="http://cdn.example.com/poster.jpg"))
+    assert ev.image_url == "http://cdn.example.com/poster.jpg"
+
+
+def test_javascript_scheme_ticket_url_becomes_none():
+    ev = EventResponse(**_min_fields(ticket_url="javascript:alert(document.cookie)"))
+    assert ev.ticket_url is None
+
+
+def test_relative_image_url_becomes_none():
+    ev = EventResponse(**_min_fields(image_url="/images/poster.jpg"))
+    assert ev.image_url is None
+
+
+def test_attribute_breakout_payload_that_still_starts_with_https_is_not_this_layers_job():
+    # The prefix check alone cannot stop a `"` later in the string — that is the
+    # frontend _h() escaping's job, in frontend/js/modal.js. A value that starts with
+    # a real https:// scheme is a well-formed absolute URL as far as this validator is
+    # concerned and passes through unchanged. Documented here so a future reader does
+    # not mistake this gate for the whole fix.
+    payload = 'https://evil.example/show?ref=1" onmouseover="alert(1)'
+    ev = EventResponse(**_min_fields(ticket_url=payload))
+    assert ev.ticket_url == payload
+
+
+def test_non_string_becomes_none():
+    ev = EventResponse(**_min_fields(ticket_url=12345))
+    assert ev.ticket_url is None
+
+
+def test_none_stays_none():
+    ev = EventResponse(**_min_fields())
+    assert ev.ticket_url is None
+    assert ev.image_url is None

--- a/backend/tests/test_scraped_event_url_validation.py
+++ b/backend/tests/test_scraped_event_url_validation.py
@@ -1,0 +1,87 @@
+"""Unit tests for ScrapedEvent's ticket_url/image_url normalization.
+
+Pure-function tests — no database, no HTTP. Both fields are scraped off third-party
+venue pages and are rendered directly into HTML attributes by the web client
+(frontend/js/modal.js) and into the iCal feed (app/api/feeds.py).
+ScrapedEvent.__post_init__ normalizes anything that isn't an absolute http(s) URL to
+None before it ever reaches the database.
+
+The constraint under test throughout: a malformed value nulls the field out, it never
+raises and never drops the event — see test_malformed_url_does_not_prevent_event_construction.
+"""
+
+from datetime import date
+
+from app.scrapers.base import ScrapedEvent
+
+
+def _event(**overrides) -> ScrapedEvent:
+    fields = dict(name="Test Show", date=date(2026, 1, 1), venue_slug="test-venue", source="manual")
+    fields.update(overrides)
+    return ScrapedEvent(**fields)
+
+
+def test_well_formed_https_ticket_url_passes_through_unchanged():
+    ev = _event(ticket_url="https://tickets.example.com/42?ref=abc&utm_source=site")
+    assert ev.ticket_url == "https://tickets.example.com/42?ref=abc&utm_source=site"
+
+
+def test_well_formed_http_image_url_passes_through_unchanged():
+    ev = _event(image_url="http://cdn.example.com/poster.jpg")
+    assert ev.image_url == "http://cdn.example.com/poster.jpg"
+
+
+def test_https_prefix_is_case_insensitive():
+    ev = _event(ticket_url="HTTPS://tickets.example.com/42")
+    assert ev.ticket_url == "HTTPS://tickets.example.com/42"
+
+
+def test_surrounding_whitespace_is_trimmed():
+    ev = _event(ticket_url="  https://tickets.example.com/42  ")
+    assert ev.ticket_url == "https://tickets.example.com/42"
+
+
+def test_javascript_scheme_becomes_none():
+    ev = _event(ticket_url="javascript:alert(document.cookie)")
+    assert ev.ticket_url is None
+
+
+def test_data_scheme_becomes_none():
+    ev = _event(image_url="data:text/html,<script>alert(1)</script>")
+    assert ev.image_url is None
+
+
+def test_relative_path_becomes_none():
+    ev = _event(image_url="/images/poster.jpg")
+    assert ev.image_url is None
+
+
+def test_scheme_relative_url_becomes_none():
+    ev = _event(image_url="//evil.example/poster.jpg")
+    assert ev.image_url is None
+
+
+def test_blank_and_whitespace_only_become_none():
+    assert _event(ticket_url="").ticket_url is None
+    assert _event(ticket_url="   ").ticket_url is None
+
+
+def test_non_string_becomes_none_rather_than_raising():
+    # A JSON-LD feed can hand a scraper a dict/list where a URL string belongs.
+    ev = _event(ticket_url=12345, image_url={"url": "https://x"})
+    assert ev.ticket_url is None
+    assert ev.image_url is None
+
+
+def test_none_stays_none():
+    ev = _event()
+    assert ev.ticket_url is None
+    assert ev.image_url is None
+
+
+def test_malformed_url_does_not_prevent_event_construction():
+    # The core constraint: a bad field is dropped, never the event.
+    ev = _event(name="Still Shows Up", ticket_url="not a url at all", image_url="also not a url")
+    assert ev.name == "Still Shows Up"
+    assert ev.ticket_url is None
+    assert ev.image_url is None

--- a/frontend/js/modal.js
+++ b/frontend/js/modal.js
@@ -1,8 +1,16 @@
 // Event detail modal
 
 // Escape user-visible text before injecting into innerHTML.
+//
+// Coerce before escaping. Every value that reaches here comes from API JSON with no
+// client-side type check, and a bare `(s || "")` hands any *truthy* non-string straight
+// to .replace(), which exists only on String.prototype — a numeric image_url would throw
+// a TypeError partway through openModal and the modal would not open at all. Coercing
+// first also means the escape runs over the coerced text, so a value whose toString()
+// carries a `"` cannot slip it past.
 function _h(s) {
-  return (s || "").replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;").replace(/"/g, "&quot;");
+  return String(s == null ? "" : s)
+    .replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;").replace(/"/g, "&quot;");
 }
 
 const modal = document.getElementById("event-modal");
@@ -10,6 +18,10 @@ const modalOverlay = document.getElementById("modal-overlay");
 
 function _buildEventRow(ev) {
   const p = ev.extendedProps;
+  // Prefix-checked, not sanitized: /^https?:\/\//i constrains how the string starts,
+  // not what it contains, so a value like `https://x/" onmouseover=...` still passes.
+  // The _h() at the render site below is what makes it safe to interpolate — see the
+  // fuller note on openModal's safeUrl.
   const safeUrl = p.ticket_url && /^https?:\/\//i.test(p.ticket_url) ? p.ticket_url : null;
 
   let badge = "";
@@ -30,7 +42,7 @@ function _buildEventRow(ev) {
       </div>
       ${p.support_artists ? `<div class="modal-group-support">with ${_h(p.support_artists)}</div>` : ""}
       ${meta ? `<div class="modal-group-meta">${meta}</div>` : ""}
-      ${safeUrl ? `<a href="${safeUrl}" target="_blank" rel="noopener" class="btn-tickets btn-tickets-sm">Get Tickets</a>` : ""}
+      ${safeUrl ? `<a href="${_h(safeUrl)}" target="_blank" rel="noopener" class="btn-tickets btn-tickets-sm">Get Tickets</a>` : ""}
     </div>`;
 }
 
@@ -82,9 +94,12 @@ function openModal(eventInfo) {
     }
   }
 
-  // Image
+  // Image — image_url is scraped from third-party venue pages and has no prefix check
+  // at all. It also needs no click or hover to reach the browser: a broken src fires
+  // onerror the instant this markup is assigned to innerHTML. Escape it like every
+  // other interpolated field.
   const imageHtml = props.image_url
-    ? `<img src="${props.image_url}" alt="${_h(props.name)}" class="modal-image">`
+    ? `<img src="${_h(props.image_url)}" alt="${_h(props.name)}" class="modal-image">`
     : "";
 
   // Status badge
@@ -126,10 +141,13 @@ function openModal(eventInfo) {
     ? `<div class="modal-support">with ${_h(props.support_artists)}</div>`
     : "";
 
-  // Ticket button — only allow http/https URLs
+  // Ticket button — only allow http/https URLs. That check constrains how the string
+  // *starts*; it does not stop a `"` further in from closing the href attribute early
+  // (`https://x/" onmouseover=...` passes it). The _h() at the render site below is what
+  // neutralizes that, as it does for _buildEventRow's matching list-row variant.
   const safeUrl = props.ticket_url && /^https?:\/\//i.test(props.ticket_url) ? props.ticket_url : null;
   const ticketBtn = safeUrl
-    ? `<a href="${safeUrl}" target="_blank" rel="noopener" class="btn-tickets">Get Tickets</a>`
+    ? `<a href="${_h(safeUrl)}" target="_blank" rel="noopener" class="btn-tickets">Get Tickets</a>`
     : "";
 
   el.innerHTML = `

--- a/frontend/tests/modal.test.js
+++ b/frontend/tests/modal.test.js
@@ -1,0 +1,201 @@
+// Attribute-injection regression tests for ../js/modal.js.
+//
+// Run with:  node --test frontend/tests/modal.test.js
+//
+// These are not wired into .github/workflows/ci.yml, which installs Python and runs
+// pytest only. They need no dependencies beyond Node's own test runner, so they can be
+// run by hand or added to CI as a step whenever that is worth doing.
+//
+// modal.js is a plain <script> (no module.exports) that touches `document` at load
+// time, so it cannot be require()d directly. The loader below evaluates it into a vm
+// context holding a minimal DOM stub instead — top-level function declarations become
+// properties of the sandbox object, so the assertions run against modal.js's actual
+// `_buildEventRow` / `openModal` template code rather than a reimplementation of it.
+
+const { test } = require("node:test");
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const path = require("node:path");
+const vm = require("node:vm");
+
+const MODAL_JS = path.join(__dirname, "..", "js", "modal.js");
+
+// A stand-in for a DOM element, carrying just the surface modal.js touches.
+// `classList.addedClasses` records every class added, so a test can assert the script
+// actually acted on a specific element rather than merely that a stub had the method.
+function stubElement() {
+  const addedClasses = [];
+  const removedClasses = [];
+  return {
+    innerHTML: "",
+    classList: {
+      addedClasses,
+      removedClasses,
+      add(cls) { addedClasses.push(cls); },
+      remove(cls) { removedClasses.push(cls); },
+    },
+    addEventListener() {},
+  };
+}
+
+// Evaluates modal.js into a fresh vm context alongside the three elements it looks up
+// at load time, and returns both the populated sandbox and those elements.
+function loadModal() {
+  const elements = {
+    "event-modal": stubElement(),
+    "modal-overlay": stubElement(),
+    "modal-content": stubElement(),
+  };
+  const sandbox = {
+    document: {
+      getElementById: (id) => elements[id] || stubElement(),
+      querySelector: () => null,
+      querySelectorAll: () => [],
+      addEventListener() {},
+    },
+  };
+  vm.createContext(sandbox);
+  // filename surfaces the real path in stack traces from inside the sandbox.
+  vm.runInContext(fs.readFileSync(MODAL_JS, "utf8"), sandbox, { filename: MODAL_JS });
+  return { sandbox, elements };
+}
+
+function singleEvent(extendedProps) {
+  return {
+    event: {
+      id: "42",
+      extendedProps: {
+        date: "2026-08-08",
+        name: "Show Name",
+        venue_slug: "cats-cradle",
+        venue_name: "Cat's Cradle",
+        venue_city: "Carrboro",
+        ...extendedProps,
+      },
+    },
+  };
+}
+
+function groupRowEvent(extendedProps) {
+  return {
+    id: "42",
+    title: "Show Title",
+    extendedProps: { venue_slug: "cats-cradle", ...extendedProps },
+  };
+}
+
+// A `"` placed after a real https:// prefix still passes the safeUrl prefix check,
+// which is exactly why that check alone was never sufficient — only escaping closes
+// the gap.
+const TICKET_URL_BREAKOUT = 'https://evil.example/show?ref=1" onmouseover="alert(document.cookie)';
+// image_url has no prefix check at all in modal.js; a broken `src` fires `onerror` the
+// moment the modal opens, no click required.
+const IMAGE_URL_BREAKOUT = 'x" onerror="alert(document.cookie)';
+
+function assertNoAttributeBreakout(html) {
+  // The vulnerability signature: a *raw* `"` immediately followed by an
+  // onerror=/onmouseover= attribute — what a successful break-out renders as (the
+  // injected quote closing src/href early, followed by a sibling event-handler
+  // attribute). A raw `"` only ever appears there if escaping failed; once _h() runs
+  // that quote is `&quot;`, an entity rather than a `"` character, so this regex —
+  // unlike a plain substring check — does not false-positive on the harmless case
+  // where "onerror=" appears as escaped text inside a still-intact attribute value.
+  assert.equal(/"\s+on(error|mouseover)\s*=/.test(html), false);
+}
+
+test("_buildEventRow escapes a double-quote in ticket_url so it cannot break out of the <a> attribute", () => {
+  const { sandbox } = loadModal();
+  const html = sandbox._buildEventRow(groupRowEvent({ ticket_url: TICKET_URL_BREAKOUT }));
+
+  assertNoAttributeBreakout(html);
+  assert.match(
+    html,
+    /href="https:\/\/evil\.example\/show\?ref=1&quot; onmouseover=&quot;alert\(document\.cookie\)"/
+  );
+});
+
+test("openModal escapes a double-quote in ticket_url so it cannot break out of the <a> attribute", () => {
+  const { sandbox, elements } = loadModal();
+  sandbox.openModal(singleEvent({ ticket_url: TICKET_URL_BREAKOUT }));
+  const html = elements["modal-content"].innerHTML;
+
+  assertNoAttributeBreakout(html);
+  assert.match(
+    html,
+    /href="https:\/\/evil\.example\/show\?ref=1&quot; onmouseover=&quot;alert\(document\.cookie\)"/
+  );
+});
+
+test("openModal escapes a double-quote in image_url so the onerror payload cannot reach the <img> attribute", () => {
+  const { sandbox, elements } = loadModal();
+  sandbox.openModal(singleEvent({ image_url: IMAGE_URL_BREAKOUT }));
+  const html = elements["modal-content"].innerHTML;
+
+  assertNoAttributeBreakout(html);
+  // The whole payload, quotes included, must land inside one escaped src="..."
+  // attribute rather than spilling into a sibling onerror="..." attribute.
+  assert.match(
+    html,
+    /<img src="x&quot; onerror=&quot;alert\(document\.cookie\)" alt="Show Name" class="modal-image">/
+  );
+});
+
+test("openModal renders a well-formed ticket_url with query params as an identical working link", () => {
+  const { sandbox, elements } = loadModal();
+  sandbox.openModal(singleEvent({ ticket_url: "https://tickets.example.com/42?ref=abc&utm_source=site" }));
+  const html = elements["modal-content"].innerHTML;
+
+  // & is escaped to &amp; in the attribute (correct HTML), which the browser resolves
+  // back to the identical URL — it is not a behavior change.
+  assert.match(html, /href="https:\/\/tickets\.example\.com\/42\?ref=abc&amp;utm_source=site"/);
+  // Confirms the modal actually opened: classList.add("active") ran against the real
+  // #event-modal element, not just that the stub still has an `add` method.
+  assert.deepEqual(elements["event-modal"].classList.addedClasses, ["active"]);
+});
+
+test("openModal renders a well-formed image_url with query params as an identical working <img src>", () => {
+  const { sandbox, elements } = loadModal();
+  sandbox.openModal(singleEvent({ image_url: "https://cdn.example.com/poster.jpg?w=800&h=600" }));
+  const html = elements["modal-content"].innerHTML;
+
+  assert.match(
+    html,
+    /<img src="https:\/\/cdn\.example\.com\/poster\.jpg\?w=800&amp;h=600" alt="Show Name" class="modal-image">/
+  );
+});
+
+// --- _h() must not throw on a non-string value ---
+//
+// The fields _h() receives come from JSON the API returns, and nothing in the client
+// type-checks them. `(s || "")` passed any *truthy* non-string straight to .replace(),
+// which exists only on String.prototype — so a numeric image_url threw a TypeError
+// inside openModal and the modal never opened at all. image_url is the exposed call
+// site because its guard (`props.image_url ? …`) is a bare truthiness check; safeUrl is
+// incidentally shielded because RegExp.test() coerces before _h() ever runs.
+
+test("openModal renders a non-string image_url as escaped text instead of throwing", () => {
+  const { sandbox, elements } = loadModal();
+
+  assert.doesNotThrow(() => sandbox.openModal(singleEvent({ image_url: 12345 })));
+  const html = elements["modal-content"].innerHTML;
+  assert.match(html, /<img src="12345" alt="Show Name" class="modal-image">/);
+  // The rest of the modal still rendered — a throw here aborted openModal partway and
+  // left modal-content empty.
+  assert.match(html, /<h2>Show Name<\/h2>/);
+});
+
+test("_h escapes a non-string that carries an attribute-breakout payload in its toString", () => {
+  const { sandbox } = loadModal();
+  // An object whose toString() carries the payload: coercion must happen *before*
+  // escaping, never instead of it.
+  const hostile = { toString: () => 'x" onerror="alert(1)' };
+
+  assert.equal(sandbox._h(hostile), "x&quot; onerror=&quot;alert(1)");
+});
+
+test("_h maps null and undefined to the empty string", () => {
+  const { sandbox } = loadModal();
+
+  assert.equal(sandbox._h(null), "");
+  assert.equal(sandbox._h(undefined), "");
+});


### PR DESCRIPTION
## The defect

`frontend/js/modal.js` interpolates two scraper-sourced URL fields raw into HTML attributes, while every neighbouring field in the same templates goes through the module's `_h()` escaper.

| site | code at `main` |
|---|---|
| [`modal.js:13`](https://github.com/triangle-shows/triangle-shows/blob/main/frontend/js/modal.js#L13) | `const safeUrl = p.ticket_url && /^https?:\/\//i.test(p.ticket_url) ? p.ticket_url : null;` |
| [`modal.js:33`](https://github.com/triangle-shows/triangle-shows/blob/main/frontend/js/modal.js#L33) | `` `<a href="${safeUrl}" …>` `` — grouped list-row variant |
| [`modal.js:87`](https://github.com/triangle-shows/triangle-shows/blob/main/frontend/js/modal.js#L87) | `` `<img src="${props.image_url}" alt="${_h(props.name)}" …>` `` |
| [`modal.js:130`](https://github.com/triangle-shows/triangle-shows/blob/main/frontend/js/modal.js#L130) | `const safeUrl = props.ticket_url && /^https?:\/\//i.test(props.ticket_url) ? props.ticket_url : null;` |
| [`modal.js:132`](https://github.com/triangle-shows/triangle-shows/blob/main/frontend/js/modal.js#L132) | `` `<a href="${safeUrl}" …>` `` — single-event button |

Two separate problems.

**The `ticket_url` prefix check constrains only how the string starts.** `/^https?:\/\//i` is anchored at the front and says nothing about the rest of the value. `https://x/" onmouseover=alert(1)` passes it, and the `"` then closes the `href` attribute early, turning the remainder into sibling attributes on the same `<a>`. The comment on `:130` reads "only allow http/https URLs", which is true of the scheme and easy to read as sanitization — it is not. Both `safeUrl` render sites (`:33` and `:132`) are affected.

**`image_url` has no check at all, and needs no user interaction.** Line 87 interpolates it directly, and an `<img>` with a broken `src` fires `onerror` the instant the markup is assigned to `innerHTML` — no click, no hover, no second step. It is the more exposed of the two.

Both fields come off third-party venue pages that the scrapers do not control, and both reach the browser as `extendedProps` on the FullCalendar payload.

## The frontend fix

Both fields now go through `_h()` at all three render sites. The comments at the two `safeUrl` definitions now say what the prefix check does and does not do, so the next reader does not mistake it for sanitization.

`_h()` had to stop throwing first. Its `(s || "")` passes any *truthy* non-string straight to `.replace()`, which exists only on `String.prototype`. Before this change a numeric `image_url` rendered as a harmless broken `src`, because the template literal string-coerces whatever it is handed; routing it through `_h()` unchanged would have thrown a `TypeError` partway through `openModal` and left the modal closed for that event. It now coerces with `String(s == null ? "" : s)`. The one behavioural difference — `0`/`false` render as `"0"`/`"false"` rather than `""` — is unreachable from well-formed data, and for malformed data the coerced text is more truthful than a silent blank. Coercing before escaping also closes a smaller gap: a value whose `toString()` carries a quote is now escaped rather than interpolated.

## The backend half

Defence in depth for the consumers that never touch the modal.

- **`ScrapedEvent.__post_init__`** (`app/scrapers/base.py`) normalizes `ticket_url`/`image_url` to an absolute http(s) URL or `None` at ingestion, at the same choke point where `clean_title` already normalizes the human-readable fields. This is what protects the iCal feed builder in `app/api/feeds.py`, which reads the ORM column directly and never passes through a response schema.
- **`EventResponse`** (`app/schemas.py`) adds an independent second gate via a `BeforeValidator`, so a row written before the ingestion gate existed is still served safely by the events list endpoint.

In both places a malformed value becomes `None` rather than raising, so one bad field never drops an otherwise good event from the calendar.

One thing worth flagging: `GET /api/events/fullcalendar` builds `extendedProps` as a plain dict from the ORM object ([`app/api/events.py:196`](https://github.com/triangle-shows/triangle-shows/blob/main/backend/app/api/events.py#L196)) and does not pass through `EventResponse`. For rows already in the database, the frontend escaping is therefore the gate that actually covers the modal — which is why that half is the load-bearing fix and the backend half is hardening. I left the FullCalendar path alone rather than widen this PR; happy to add the same normalization there if you'd prefer.

No migration: the column types are unchanged.

## Tests

- `backend/tests/test_scraped_event_url_validation.py` (12 tests) and `backend/tests/test_event_response_url_validation.py` (7) — pure-function/model tests, no database. They run in the existing `python -m pytest tests -q` step. One of them documents the boundary explicitly: a payload that *does* start with a real `https://` passes the backend gate unchanged, because neutralizing it is the frontend escaping's job.
- `frontend/tests/modal.test.js` (8 tests) covers the three render sites and the `_h()` coercion. It loads `modal.js` into a `vm` context with a minimal DOM stub, so it exercises the real `_buildEventRow`/`openModal` template code rather than a reimplementation.

**Your CI does not run the JS test.** `.github/workflows/ci.yml` installs Python and runs pytest, migrations, and the health check — there is no JavaScript runner in it. The test needs nothing beyond Node's built-in runner:

```
node --test frontend/tests/modal.test.js
```

Six of its eight tests fail against `main` as it stands today. Add it as a CI step if that is worth doing; I did not touch the workflow.

Local results: `299 passed, 4 skipped` from `backend/`, and 8/8 on the Node test.
