### PR TITLE
Populate image_url in the three scrapers that still leave it null

### DIFF
--- a/backend/app/scrapers/motorco.py
+++ b/backend/app/scrapers/motorco.py
@@ -22,9 +22,17 @@ from app.scrapers.base import BaseScraper, ScrapedEvent, BROWSER_HEADERS
 
 logger = logging.getLogger(__name__)
 
-# Each JS event object looks like:
-#   { title: 'Name', start: '2026-04-03 21:00', url: 'https://...', classNames: '...' }
+# Each JS event object is a flat (non-nested) block looking like:
+#   { title: 'Name', start: '2026-04-03 21:00', end: '2026-04-03 22:00',
+#     url: 'https://...', classNames: '...', backgroundImage: 'https://...' }
 #
+# The whole array is split into those `{...}` blocks first so each field can be
+# read out of one block independently. That matters for `backgroundImage`, which
+# sits after `url` and is not always present: an optional tail on the ordered
+# title/start/url pattern below would silently skip it rather than fail, and a
+# page-wide search for it could pair one event's poster with another's title.
+_EVENT_OBJECT_PATTERN = re.compile(r'\{[^{}]*\}')
+
 # `title` is free text, so it must be matched as a proper JS string literal rather
 # than with a stop-at-the-first-quote pattern. WordPress `esc_js` backslash-escapes
 # any apostrophe inside the single-quoted value, and a naive `(.+?)['"]` terminates
@@ -41,6 +49,10 @@ _EVENT_PATTERN = re.compile(
     r'[^{}]*?url\s*:\s*[\'"](?P<url>[^\'\"]+)[\'"]',
     re.S,
 )
+
+# The poster the calendar tile paints behind each event. Its value never contains
+# a quote, so the simple stop-at-the-first-quote form is sufficient.
+_IMAGE_PATTERN = re.compile(r'backgroundImage\s*:\s*[\'"]([^\'\"]+)[\'"]')
 
 # A JS string escape is a backslash followed by any single character (`\'`, `\"`,
 # `\\`, `\/`). `esc_js` only ever emits a backslash as an escape introducer, so
@@ -63,7 +75,6 @@ class MotorcoScraper(BaseScraper):
     async def scrape(self) -> list[ScrapedEvent]:
         """Fetch the Motorco calendar page and return upcoming ScrapedEvent objects."""
         url = self.config.get("url", "https://motorcomusic.com/calendar/")
-        events = []
         today = date.today()
 
         async with httpx.AsyncClient(timeout=30, follow_redirects=True, headers=BROWSER_HEADERS) as client:
@@ -71,11 +82,26 @@ class MotorcoScraper(BaseScraper):
             resp.raise_for_status()
             html = resp.text
 
-        # Deduplicate by (title, start). `finditer` yields non-overlapping matches,
-        # so this guards against the same event genuinely appearing twice in the
-        # page markup rather than against overlapping regex matches.
+        events = self._extract_events(html, today)
+
+        logger.info(f"[Motorco] Found {len(events)} upcoming events for {self.venue_slug}")
+        return events
+
+    def _extract_events(self, html: str, today: date) -> list[ScrapedEvent]:
+        """Pull every event out of the FullCalendar init JS embedded in the page.
+
+        Deduplicates by (title, start). `finditer` yields non-overlapping matches,
+        so this guards against the same event genuinely appearing twice in the
+        page markup rather than against overlapping regex matches.
+        """
+        events = []
         seen = set()
-        for m in _EVENT_PATTERN.finditer(html):
+        for block_match in _EVENT_OBJECT_PATTERN.finditer(html):
+            block = block_match.group(0)
+            m = _EVENT_PATTERN.search(block)
+            if not m:
+                continue  # not an event object, or missing a required field
+
             raw_title, raw_start, raw_url = m.group("title"), m.group("start"), m.group("url")
 
             # Skip an event object we have already seen
@@ -84,14 +110,23 @@ class MotorcoScraper(BaseScraper):
                 continue
             seen.add(key)
 
-            parsed = self._parse_event(raw_title, raw_start, raw_url, today)
+            image_match = _IMAGE_PATTERN.search(block)
+            raw_image = image_match.group(1) if image_match else None
+
+            parsed = self._parse_event(raw_title, raw_start, raw_url, today, raw_image)
             if parsed:
                 events.append(parsed)
 
-        logger.info(f"[Motorco] Found {len(events)} upcoming events for {self.venue_slug}")
         return events
 
-    def _parse_event(self, title: str, start_str: str, url: str, today: date) -> Optional[ScrapedEvent]:
+    def _parse_event(
+        self,
+        title: str,
+        start_str: str,
+        url: str,
+        today: date,
+        image_url: Optional[str] = None,
+    ) -> Optional[ScrapedEvent]:
         """Parse raw JS-extracted strings into a ScrapedEvent, or return None on failure."""
         try:
             # Collapse JS string escapes (esc_js turns an apostrophe into \'),
@@ -126,6 +161,7 @@ class MotorcoScraper(BaseScraper):
                 artist=title,
                 show_time=show_time,
                 ticket_url=url,
+                image_url=image_url,
                 source_url=url,
             )
         except Exception as e:

--- a/backend/app/scrapers/tickpick_organizer.py
+++ b/backend/app/scrapers/tickpick_organizer.py
@@ -108,6 +108,19 @@ class TickPickOrganizerScraper(BaseScraper):
 
             ticket_url = data.get("url")
 
+            # Poster — schema.org's `image` is polymorphic: a bare URL string, a
+            # list of those (take the first), an ImageObject dict (`{"url": ...}`),
+            # or a list of ImageObject dicts. Anything else — a number, a nested
+            # list, a dict with no `url` — degrades to None rather than raising.
+            # A blank or whitespace-only value becomes None too, so it can't reach
+            # the frontend as a broken <img src>.
+            image = data.get("image")
+            if isinstance(image, list):
+                image = image[0] if image else None
+            if isinstance(image, dict):
+                image = image.get("url")
+            image_url = image.strip() or None if isinstance(image, str) else None
+
             return ScrapedEvent(
                 name=name,
                 date=event_date,
@@ -116,6 +129,7 @@ class TickPickOrganizerScraper(BaseScraper):
                 artist=name,
                 show_time=show_time,
                 ticket_url=ticket_url,
+                image_url=image_url,
                 source_url=ticket_url,
             )
         except Exception as e:

--- a/backend/app/scrapers/webflow_cms.py
+++ b/backend/app/scrapers/webflow_cms.py
@@ -28,14 +28,23 @@ class WebflowCMSScraper(BaseScraper):
     Used by: Pour House
 
     Config keys:
-        url            - calendar page URL
-        base_url       - base URL for constructing event links
-        item_selector  - CSS selector for each event item (default: .show-collection-item)
-        name_selector  - CSS selector for event name within item (default: .show-name)
-        date_selector  - CSS selector for event date within item (default: .show-start-date)
-        slug_selector  - CSS selector for slug within item (default: .show-slug)
-        shows_path     - path prefix for event pages (default: /shows/)
-        date_format    - strptime format string (default: %B %d, %Y)
+        url             - calendar page URL
+        base_url        - base URL for constructing event links
+        item_selector   - CSS selector for each event item (default: .show-collection-item)
+        name_selector   - CSS selector for event name within item (default: .show-name)
+        date_selector   - CSS selector for event date within item (default: .show-start-date)
+        slug_selector   - CSS selector for slug within item (default: .show-slug)
+        shows_path      - path prefix for event pages (default: /shows/)
+        date_format     - strptime format string (default: %B %d, %Y)
+        image_selector  - CSS selector for the show-flyer <img> inside a detail-page
+                          link (default: img)
+
+    Image note: the live Pour House page renders every show twice — once in the
+    `.show-collection-item` list this scraper otherwise parses (name/date/slug
+    only, no image anywhere inside it), and again in a separate Webflow "grid"
+    list whose entries wrap an `<a href="{shows_path}<slug>">` around the flyer
+    `<img>`. There is nothing to select inside item_selector's own elements, so
+    the flyer is picked up by cross-referencing the two lists on slug.
     """
 
     async def scrape(self) -> list[ScrapedEvent]:
@@ -44,6 +53,18 @@ class WebflowCMSScraper(BaseScraper):
         if not url:
             raise ValueError(f"No URL configured for {self.venue_slug}")
 
+        async with httpx.AsyncClient(timeout=30, follow_redirects=True, headers=BROWSER_HEADERS) as client:
+            resp = await client.get(url)
+            resp.raise_for_status()
+            soup = BeautifulSoup(resp.text, "lxml")
+
+        events = self._parse_soup(soup)
+
+        logger.info(f"[WebflowCMS] Found {len(events)} events for {self.venue_slug}")
+        return events
+
+    def _parse_soup(self, soup: BeautifulSoup) -> list[ScrapedEvent]:
+        """Extract events from an already-fetched page soup."""
         # Pull selector/format overrides from config, falling back to Pour House defaults
         base_url = self.config.get("base_url", "").rstrip("/")
         item_sel = self.config.get("item_selector", ".show-collection-item")
@@ -52,59 +73,93 @@ class WebflowCMSScraper(BaseScraper):
         slug_sel = self.config.get("slug_selector", ".show-slug")
         shows_path = self.config.get("shows_path", "/shows/")
         date_fmt = self.config.get("date_format", "%B %d, %Y")
+        image_sel = self.config.get("image_selector", "img")
 
         events = []
 
-        async with httpx.AsyncClient(timeout=30, follow_redirects=True, headers=BROWSER_HEADERS) as client:
-            resp = await client.get(url)
-            resp.raise_for_status()
-            soup = BeautifulSoup(resp.text, "lxml")
+        image_by_slug = self._build_image_map(soup, shows_path, image_sel)
 
-            # --- Parse Each Event Item ---
-            for item in soup.select(item_sel):
-                name_el = item.select_one(name_sel)
-                date_el = item.select_one(date_sel)
-                slug_el = item.select_one(slug_sel)
+        # --- Parse Each Event Item ---
+        for item in soup.select(item_sel):
+            name_el = item.select_one(name_sel)
+            date_el = item.select_one(date_sel)
+            slug_el = item.select_one(slug_sel)
 
-                # Skip items missing required fields
-                if not name_el or not date_el:
-                    continue
+            # Skip items missing required fields
+            if not name_el or not date_el:
+                continue
 
-                name = name_el.get_text(strip=True)
-                date_str = date_el.get_text(strip=True)
-                # Slug is optional — used only for constructing the ticket URL
-                slug = slug_el.get_text(strip=True) if slug_el else None
+            name = name_el.get_text(strip=True)
+            date_str = date_el.get_text(strip=True)
+            # Slug is optional — used for the ticket URL and the flyer lookup
+            slug = slug_el.get_text(strip=True) if slug_el else None
 
-                if not name or not date_str:
-                    continue
+            if not name or not date_str:
+                continue
 
-                try:
-                    event_date = datetime.strptime(date_str, date_fmt).date()
-                except ValueError:
-                    logger.warning(f"[WebflowCMS] Cannot parse date '{date_str}' for {self.venue_slug}")
-                    continue
+            try:
+                event_date = datetime.strptime(date_str, date_fmt).date()
+            except ValueError:
+                logger.warning(f"[WebflowCMS] Cannot parse date '{date_str}' for {self.venue_slug}")
+                continue
 
-                # Build the event detail URL only when both base URL and slug are available
-                ticket_url = f"{base_url}{shows_path}{slug}" if (base_url and slug) else None
+            # Build the event detail URL only when both base URL and slug are available
+            ticket_url = f"{base_url}{shows_path}{slug}" if (base_url and slug) else None
 
-                # Extract age restriction from name prefix like "(18+) Artist Name"
-                age_restriction = None
-                age_match = re.match(r'^\((\d+\+)\)\s*', name)
-                if age_match:
-                    age_restriction = age_match.group(1)
-                    # Strip the age prefix so the stored name is just the artist/show title
-                    name = name[age_match.end():]
+            # Extract age restriction from name prefix like "(18+) Artist Name"
+            age_restriction = None
+            age_match = re.match(r'^\((\d+\+)\)\s*', name)
+            if age_match:
+                age_restriction = age_match.group(1)
+                # Strip the age prefix so the stored name is just the artist/show title
+                name = name[age_match.end():]
 
-                events.append(ScrapedEvent(
-                    name=name,
-                    date=event_date,
-                    venue_slug=self.venue_slug,
-                    source="webflow_cms",
-                    artist=name,
-                    ticket_url=ticket_url,
-                    source_url=ticket_url,
-                    age_restriction=age_restriction,
-                ))
+            # Best-effort: a slug with no counterpart in the grid list (markup drift,
+            # a show pulled from one list but not the other) just yields None. It
+            # never raises and never drops the event.
+            image_url = image_by_slug.get(slug) if slug else None
 
-        logger.info(f"[WebflowCMS] Found {len(events)} events for {self.venue_slug}")
+            events.append(ScrapedEvent(
+                name=name,
+                date=event_date,
+                venue_slug=self.venue_slug,
+                source="webflow_cms",
+                artist=name,
+                ticket_url=ticket_url,
+                source_url=ticket_url,
+                age_restriction=age_restriction,
+                image_url=image_url,
+            ))
+
         return events
+
+    @staticmethod
+    def _build_image_map(soup: BeautifulSoup, shows_path: str, image_sel: str) -> dict[str, str]:
+        """Map each show's slug to its flyer URL, read from the page's grid list.
+
+        Scoping by `a[href^=shows_path]` rather than by the grid list's own
+        auto-generated Webflow wrapper class keeps this working through a redesign
+        that renames the wrapper but keeps the detail-page link convention. Where a
+        slug appears more than once, the first entry in document order wins, so the
+        result is deterministic.
+        """
+        image_by_slug: dict[str, str] = {}
+        if not shows_path:
+            return image_by_slug
+
+        for link_el in soup.select(f"a[href^='{shows_path}']"):
+            href = link_el.get("href") or ""
+            slug = href.rstrip("/").rsplit("/", 1)[-1]
+            if not slug:
+                continue
+
+            img_el = link_el.select_one(image_sel)
+            if not img_el:
+                continue
+
+            # Webflow lazy-loads: some renders carry the real URL in data-src only.
+            src = img_el.get("src") or img_el.get("data-src")
+            if src and slug not in image_by_slug:
+                image_by_slug[slug] = src
+
+        return image_by_slug

--- a/backend/tests/test_motorco.py
+++ b/backend/tests/test_motorco.py
@@ -7,6 +7,9 @@ stop-at-the-first-quote pattern terminated there, storing a truncated title with
 a trailing backslash. A fetch of the live calendar showed 61 of 625 titles
 carrying such an escape.
 
+Also covers the per-event `backgroundImage` key, which the extraction reads out
+of the same `{...}` block as the title/start/url it sits alongside.
+
 Run from the backend/ directory:  pytest tests/test_motorco.py
 The extraction is pure stdlib regex, so no DB, no network and no fixtures are
 needed — the scraper's own HTTP call is not exercised here.
@@ -87,3 +90,87 @@ def test_parse_event_leaves_a_plain_title_alone():
     )
     assert parsed is not None
     assert parsed.name == _PLAIN
+
+
+# --- The per-event poster ---
+# Each event object also carries a `backgroundImage` key holding the poster the
+# calendar tile paints behind the show. A fetch of the live calendar found it on
+# all 640 event objects on the page, but a WordPress admin can always post an
+# event with no featured image, so the absent case has to degrade rather than
+# drop the event.
+
+_POSTER = "https://motorcomusic.com/wp-content/uploads/2026/07/example.jpg"
+_OTHER_POSTER = "https://motorcomusic.com/wp-content/uploads/2026/07/other.jpg"
+
+
+def _event_object_with_poster(title: str, day: str, poster: str) -> str:
+    """One JS event object carrying `end` and `backgroundImage`, as the live page does."""
+    return (
+        "{"
+        f"title: '{title}',"
+        f"start: '{day} 20:00',"
+        f"end: '{day} 21:00',"
+        "url: 'https://motorcomusic.com/event/example/',"
+        "classNames: 'tcec-event-',"
+        f"backgroundImage: '{poster}'"
+        "}"
+    )
+
+
+def _future_day(offset: int = 45) -> str:
+    """The scraper drops past events, so fixtures must be anchored ahead of today."""
+    return (date.today() + timedelta(days=offset)).isoformat()
+
+
+def test_backgroundimage_becomes_the_event_image():
+    day = _future_day()
+    js = "events: [%s]," % _event_object_with_poster(_PLAIN, day, _POSTER)
+    events = _scraper()._extract_events(js, date.today())
+    assert len(events) == 1
+    assert events[0].image_url == _POSTER
+
+
+def test_an_event_object_without_backgroundimage_is_kept_with_no_image():
+    day = _future_day()
+    js = "events: [%s]," % _event_object(_PLAIN, day)
+    events = _scraper()._extract_events(js, date.today())
+    assert len(events) == 1
+    assert events[0].image_url is None
+
+
+def test_a_poster_is_never_borrowed_from_a_neighbouring_event_object():
+    """Each poster must come from its own `{...}` block, not the next one along."""
+    js = "events: [%s,%s]," % (
+        _event_object(_ESCAPED, _future_day(45)),
+        _event_object_with_poster(_PLAIN, _future_day(46), _POSTER),
+    )
+    events = _scraper()._extract_events(js, date.today())
+    by_name = {e.name: e for e in events}
+    assert by_name["Wednesday : It's Fine"].image_url is None
+    assert by_name[_PLAIN].image_url == _POSTER
+
+
+def test_each_event_keeps_its_own_poster_across_a_mixed_array():
+    js = "events: [%s,%s]," % (
+        _event_object_with_poster(_PLAIN, _future_day(45), _POSTER),
+        _event_object_with_poster(_ESCAPED, _future_day(46), _OTHER_POSTER),
+    )
+    events = _scraper()._extract_events(js, date.today())
+    by_name = {e.name: e for e in events}
+    assert by_name[_PLAIN].image_url == _POSTER
+    assert by_name["Wednesday : It's Fine"].image_url == _OTHER_POSTER
+
+
+def test_the_other_fields_survive_alongside_a_poster():
+    day = _future_day()
+    js = "events: [%s]," % _event_object_with_poster(_ESCAPED, day, _POSTER)
+    events = _scraper()._extract_events(js, date.today())
+    assert len(events) == 1
+    event = events[0]
+    assert event.name == "Wednesday : It's Fine"
+    assert event.artist == "Wednesday : It's Fine"
+    assert event.date.isoformat() == day
+    assert event.show_time is not None
+    assert (event.show_time.hour, event.show_time.minute) == (20, 0)
+    assert event.ticket_url == "https://motorcomusic.com/event/example/"
+    assert event.source_url == "https://motorcomusic.com/event/example/"

--- a/backend/tests/test_tickpick_organizer.py
+++ b/backend/tests/test_tickpick_organizer.py
@@ -1,0 +1,105 @@
+"""
+Unit tests for app.scrapers.tickpick_organizer — the schema.org image handling.
+
+`_parse_event` never read the JSON-LD `image` property, so every Chapel of Bones
+event was stored with image_url = None regardless of what TickPick published.
+
+schema.org does not fix a single shape for `image`: it may be a bare URL string,
+a list of those, an ImageObject dict, or a list of ImageObject dicts. A fetch of
+the live organizer page confirmed the JSON-LD is reachable and this parse path is
+the one exercised (one Organization block, 50 nested Events), but none of those
+50 events populates `image` at all today — only the top-level Organization.logo
+does. So the absent-image case below is the one confirmed against live data; the
+present-image cases follow the schema.org spec and the same normalization mec.py
+and ticketmaster.py already apply.
+
+Run from the backend/ directory:  pytest tests/test_tickpick_organizer.py
+`_parse_event` is fed JSON-LD dicts directly, so there is no DB and no network.
+"""
+
+from datetime import date, timedelta
+
+from app.scrapers.tickpick_organizer import TickPickOrganizerScraper
+
+FUTURE = (date.today() + timedelta(days=30)).isoformat()
+
+# The real key set of a single Event nested under Organization.event on the live
+# page (@type, location, name, startDate, url), with `image` layered on per the
+# shape under test.
+BASE_EVENT = {
+    "@type": "Event",
+    "location": {
+        "@type": "Place",
+        "name": "Chapel of Bones",
+        "address": "600 Glenwood Ave, Raleigh, NC 27603",
+    },
+    "name": "Cat Power",
+    "startDate": f"{FUTURE}T20:00:00Z",
+    "url": "https://www.tickpick.com/organizer/event/cat-power-12345678",
+}
+
+POSTER = "https://static-o.tickpick.com/poster.jpg"
+POSTER_2 = "https://static-o.tickpick.com/poster-2.jpg"
+
+
+def _scraper() -> TickPickOrganizerScraper:
+    return TickPickOrganizerScraper("chapel-of-bones", {"organizer_id": "chapel-of-bones"})
+
+
+def _image_url(image=...):
+    data = dict(BASE_EVENT)
+    if image is not ...:
+        data["image"] = image
+    parsed = _scraper()._parse_event(data)
+    assert parsed is not None, "the event must survive whatever `image` holds"
+    return parsed.image_url
+
+
+def test_a_bare_url_string_is_taken_as_is():
+    assert _image_url(POSTER) == POSTER
+
+
+def test_a_list_of_urls_yields_the_first():
+    assert _image_url([POSTER, POSTER_2]) == POSTER
+
+
+def test_an_image_object_yields_its_url():
+    assert _image_url({"@type": "ImageObject", "url": POSTER}) == POSTER
+
+
+def test_a_list_of_image_objects_yields_the_first_url():
+    image = [
+        {"@type": "ImageObject", "url": POSTER},
+        {"@type": "ImageObject", "url": POSTER_2},
+    ]
+    assert _image_url(image) == POSTER
+
+
+def test_an_absent_image_is_none():
+    """The live shape today — every event on the page omits `image` entirely."""
+    assert _image_url() is None
+
+
+def test_an_empty_list_is_none():
+    assert _image_url([]) is None
+
+
+def test_a_blank_string_is_none_not_a_broken_img_src():
+    for blank in ("", "   ", "\n\t"):
+        assert _image_url(blank) is None
+
+
+def test_an_unrecognised_shape_is_none_rather_than_an_exception():
+    for junk in (42, [[POSTER]], {"@type": "ImageObject"}, {"url": 7}):
+        assert _image_url(junk) is None
+
+
+def test_the_fields_the_scraper_already_derived_are_unchanged():
+    parsed = _scraper()._parse_event({**BASE_EVENT, "image": POSTER})
+    assert parsed.name == "Cat Power"
+    assert parsed.artist == "Cat Power"
+    assert parsed.date == date.fromisoformat(FUTURE)
+    assert parsed.show_time is not None
+    assert (parsed.show_time.hour, parsed.show_time.minute) == (20, 0)
+    assert parsed.ticket_url == BASE_EVENT["url"]
+    assert parsed.source_url == BASE_EVENT["url"]

--- a/backend/tests/test_webflow_cms.py
+++ b/backend/tests/test_webflow_cms.py
@@ -1,0 +1,198 @@
+"""
+Unit tests for app.scrapers.webflow_cms — the show-flyer extraction.
+
+Pour House renders every show twice on one page, in two separate Webflow CMS
+lists: a "Calendar" list (`.show-collection-item`, carrying name/date/slug and no
+image at all) and a "Grid" list, whose entries wrap an `<a href="/shows/<slug>">`
+around the flyer `<img>`. A fetch of the live calendar showed 46 shows in each
+list, 0 `<img>` elements anywhere inside the calendar list, and all 46 slugs
+present on both sides — so the flyer is only reachable by joining the two lists
+on slug.
+
+Run from the backend/ directory:  pytest tests/test_webflow_cms.py
+The parsing is fed HTML fragments directly, so there is no DB and no network —
+the scraper's own HTTP call is not exercised here.
+"""
+
+from bs4 import BeautifulSoup
+
+from app.scrapers.webflow_cms import WebflowCMSScraper
+
+
+# Trimmed from the live markup at https://www.pourhouseraleigh.com/calendar:
+# the real CSS classes and nesting the scraper's selectors target. The second
+# show has no counterpart in the grid fragment, exercising the absent-flyer path.
+CALENDAR_LIST = """
+<div class="w-dyn-list">
+  <div role="list" class="show-collection-list w-dyn-items">
+    <div role="listitem" class="show-collection-item w-dyn-item">
+      <div class="show-name">(18+) Nilufer Yanya</div>
+      <div class="show-start-date">August 9, 2026</div>
+      <div class="show-slug">18-nilufer-yanya-09-aug</div>
+    </div>
+    <div role="listitem" class="show-collection-item w-dyn-item">
+      <div class="show-name">Chuquimamani-Condori</div>
+      <div class="show-start-date">August 14, 2026</div>
+      <div class="show-slug">chuquimamani-condori-14-aug</div>
+    </div>
+  </div>
+</div>
+"""
+
+NILUFER_FLYER = "https://cdn.prod.website-files.com/68f7b7271d0ad608b3ca1008/aaa_nilufer-yanya.jpeg"
+
+GRID_LIST = f"""
+<div class="uui-padding-vertical-large-3 w-dyn-list">
+  <div role="list" class="uui-layout88_list w-dyn-items">
+    <div role="listitem" class="uui-layout88_item-2 w-dyn-item">
+      <a href="/shows/18-nilufer-yanya-09-aug" class="link-block-2 w-inline-block">
+        <div class="show-image-wrapper">
+          <img loading="lazy" alt="" class="image-48" src="{NILUFER_FLYER}"/>
+        </div>
+      </a>
+    </div>
+  </div>
+</div>
+"""
+
+PAGE = f"<html><body>{CALENDAR_LIST}{GRID_LIST}</body></html>"
+
+
+def _scraper() -> WebflowCMSScraper:
+    return WebflowCMSScraper(
+        "pour-house",
+        {
+            "url": "https://www.pourhouseraleigh.com/calendar",
+            "base_url": "https://www.pourhouseraleigh.com",
+        },
+    )
+
+
+def _soup(html: str = PAGE) -> BeautifulSoup:
+    return BeautifulSoup(html, "lxml")
+
+
+def test_flyer_is_picked_up_from_the_grid_list():
+    events = _scraper()._parse_soup(_soup())
+    nilufer = next(e for e in events if "Nilufer" in e.name)
+    assert nilufer.image_url == NILUFER_FLYER
+
+
+def test_show_missing_from_the_grid_list_gets_no_flyer():
+    events = _scraper()._parse_soup(_soup())
+    chuqui = next(e for e in events if e.name == "Chuquimamani-Condori")
+    assert chuqui.image_url is None
+
+
+def test_a_page_with_no_grid_list_at_all_still_yields_every_event():
+    """Markup drift must degrade image_url to None, never raise or drop an event."""
+    events = _scraper()._parse_soup(_soup(CALENDAR_LIST))
+    assert len(events) == 2
+    assert all(e.image_url is None for e in events)
+
+
+def test_the_fields_the_scraper_already_derived_are_unchanged():
+    events = _scraper()._parse_soup(_soup())
+    nilufer = next(e for e in events if "Nilufer" in e.name)
+    assert nilufer.name == "Nilufer Yanya"
+    assert nilufer.age_restriction == "18+"
+    assert nilufer.ticket_url == "https://www.pourhouseraleigh.com/shows/18-nilufer-yanya-09-aug"
+
+
+# --- The join is by slug, never by list position ---
+# The two lists are independent Webflow collections with no guaranteed shared
+# order and no guaranteed 1:1 cardinality. Both shows below appear in the grid
+# list, but in the REVERSE order of the calendar list and with distinct flyers,
+# so a positional (zip) pairing crosses the two images and only a real slug join
+# keeps them straight.
+
+CALENDAR_TWO = """
+<div class="w-dyn-list">
+  <div role="list" class="show-collection-list w-dyn-items">
+    <div role="listitem" class="show-collection-item w-dyn-item">
+      <div class="show-name">Juana Molina</div>
+      <div class="show-start-date">September 3, 2026</div>
+      <div class="show-slug">juana-molina-03-sep</div>
+    </div>
+    <div role="listitem" class="show-collection-item w-dyn-item">
+      <div class="show-name">Jessica Pratt</div>
+      <div class="show-start-date">September 5, 2026</div>
+      <div class="show-slug">jessica-pratt-05-sep</div>
+    </div>
+  </div>
+</div>
+"""
+
+JUANA_FLYER = "https://cdn.prod.website-files.com/68f7b7271d0ad608b3ca1008/bbb_juana-molina.jpeg"
+JESSICA_FLYER = "https://cdn.prod.website-files.com/68f7b7271d0ad608b3ca1008/ccc_jessica-pratt.jpeg"
+
+GRID_TWO_REVERSED = f"""
+<div class="uui-padding-vertical-large-3 w-dyn-list">
+  <div role="list" class="uui-layout88_list w-dyn-items">
+    <div role="listitem" class="uui-layout88_item-2 w-dyn-item">
+      <a href="/shows/jessica-pratt-05-sep" class="link-block-2 w-inline-block">
+        <img loading="lazy" alt="" class="image-48" src="{JESSICA_FLYER}"/>
+      </a>
+    </div>
+    <div role="listitem" class="uui-layout88_item-2 w-dyn-item">
+      <a href="/shows/juana-molina-03-sep" class="link-block-2 w-inline-block">
+        <img loading="lazy" alt="" class="image-48" src="{JUANA_FLYER}"/>
+      </a>
+    </div>
+  </div>
+</div>
+"""
+
+
+def test_flyers_are_joined_by_slug_not_by_position():
+    events = _scraper()._parse_soup(
+        _soup(f"<html><body>{CALENDAR_TWO}{GRID_TWO_REVERSED}</body></html>")
+    )
+    by_name = {e.name: e for e in events}
+    assert by_name["Juana Molina"].image_url == JUANA_FLYER
+    assert by_name["Jessica Pratt"].image_url == JESSICA_FLYER
+
+
+def _grid_with(anchor_href: str, img_attrs: str) -> str:
+    return f"""
+    <div class="uui-padding-vertical-large-3 w-dyn-list">
+      <div role="list" class="uui-layout88_list w-dyn-items">
+        <div role="listitem" class="uui-layout88_item-2 w-dyn-item">
+          <a href="{anchor_href}" class="link-block-2 w-inline-block">
+            <img loading="lazy" alt="" class="image-48" {img_attrs}/>
+          </a>
+        </div>
+      </div>
+    </div>
+    """
+
+
+def _chuqui_flyer(grid: str) -> str:
+    events = _scraper()._parse_soup(_soup(f"<html><body>{CALENDAR_LIST}{grid}</body></html>"))
+    return next(e for e in events if e.name == "Chuquimamani-Condori").image_url
+
+
+def test_a_lazy_loaded_flyer_is_read_from_data_src():
+    """Some Webflow renders put the real URL in data-src with no plain src."""
+    lazy = "https://cdn.prod.website-files.com/68f7b7271d0ad608b3ca1008/ddd_lazy.jpeg"
+    grid = _grid_with("/shows/chuquimamani-condori-14-aug", f'data-src="{lazy}"')
+    assert _chuqui_flyer(grid) == lazy
+
+
+def test_a_trailing_slash_on_the_grid_href_still_joins():
+    """The calendar slug carries no slash; /shows/<slug>/ must still match it."""
+    flyer = "https://cdn.prod.website-files.com/68f7b7271d0ad608b3ca1008/eee_slash.jpeg"
+    grid = _grid_with("/shows/chuquimamani-condori-14-aug/", f'src="{flyer}"')
+    assert _chuqui_flyer(grid) == flyer
+
+
+def test_a_duplicated_slug_keeps_the_first_flyer_in_document_order():
+    """The grid can render one show twice; the choice must be deterministic."""
+    first = "https://cdn.prod.website-files.com/68f7b7271d0ad608b3ca1008/fff_first.jpeg"
+    second = "https://cdn.prod.website-files.com/68f7b7271d0ad608b3ca1008/999_second.jpeg"
+    grid = (
+        _grid_with("/shows/chuquimamani-condori-14-aug", f'src="{first}"')
+        + _grid_with("/shows/chuquimamani-condori-14-aug", f'src="{second}"')
+    )
+    image_by_slug = WebflowCMSScraper._build_image_map(_soup(grid), "/shows/", "img")
+    assert image_by_slug["chuquimamani-condori-14-aug"] == first


### PR DESCRIPTION
`Event.image_url` has existed since the schema was first written, `schemas.py` serializes it, and the frontend renders it in the event modal. Nine of the twelve venue scrapers populate it. Three do not, so their events reach the database with `image_url = null` and their cards and modals render with no artwork:

- `motorco.py`
- `webflow_cms.py`
- `tickpick_organizer.py`

This fills them in. The other nine (`carolina_theatre`, `eventprime`, `koka_booth`, `mec`, `rhp_events`, `squarespace`, `ticketmaster`, `tribe_events`, `venuepilot`) already set `image_url` and are untouched here — nothing in this PR changes shared code, so none of their behaviour moves.

### What each one gains

**Motorco.** Every event object in the embedded FullCalendar init array carries a `backgroundImage` key alongside `title`/`start`/`url` — the poster the calendar tile paints behind the show. A fetch of the live calendar found it on all 640 event objects on the page.

Reading it needs a second pass over the same object, because `backgroundImage` sits *after* `url` and an event can omit it: an optional tail on the existing ordered title/start/url pattern would silently skip a present key rather than fail, and a page-wide search for the key alone could pair one event's poster with another event's title. So the array is now split into its flat `{...}` blocks first and each field is read out of one block. `_EVENT_PATTERN` is unchanged, still governs which blocks count as events, and its existing tests are untouched. A block with no `backgroundImage` yields `image_url = None` and is never dropped.

Checked against the live page: the block split produces exactly the events the previous page-wide scan did — same count (55 upcoming), same names, dates, times and URLs, same dedup hashes — now with a poster on each.

**Pour House (`webflow_cms`).** The page renders every show twice, in two independent Webflow CMS lists: the `.show-collection-item` list this scraper parses, which carries name/date/slug and no image at all, and a separate "grid" list whose entries wrap an `<a href="/shows/<slug>">` around the show-flyer `<img>`. There is nothing to select inside the list the scraper reads, which is why a plain `item.select_one("img")` was never an option. The two lists are now cross-referenced on slug.

A fetch of the live page found 46 shows in each list, zero `<img>` elements anywhere inside the calendar list, and all 46 slugs present on both sides — so the join covers the whole venue.

The grid list is located by `a[href^={shows_path}]` rather than by its auto-generated Webflow wrapper class, so a redesign that renames the wrapper but keeps the detail-page link convention still works. The `<img>` selector is configurable (`image_selector`, default `img`), and no `seed.py` change is needed for that default. The lookup is best-effort throughout: a show with no counterpart in the grid list, a page with no grid list at all, a lazy-loaded flyer carried only in `data-src`, and a grid href written with a trailing slash all resolve correctly or degrade to `None`, and never drop an event. Parsing moved out of `scrape()` into `_parse_soup()` so it can be tested on HTML fragments without network.

**Chapel of Bones (`tickpick_organizer`).** `_parse_event` read `name`, `startDate` and `url` off each schema.org Event but never `image`. schema.org does not fix a single shape for it — bare URL string, list of those, `ImageObject` dict, or list of `ImageObject` dicts — so all four are normalized the way `mec.py` and `ticketmaster.py` already do. Anything else (a number, a nested list, a dict with no `url`) degrades to `None` rather than raising, since the surrounding `except` would otherwise drop the whole event. A blank or whitespace-only value becomes `None` too, so it cannot reach the frontend as a broken `<img src>`.

One caveat worth stating plainly: a fetch of the live organizer page confirms this parse path is the one exercised (one `Organization` block, 50 nested Events), but **none of those 50 events populates `image` today** — only the top-level `Organization.logo` does. So this venue gains no posters until TickPick starts publishing them per event. The absent-image case in the tests is the one confirmed against live data; the present-image cases follow the spec. Motorco and Pour House are the two venues where users see a difference immediately.

### Tests

`tests/test_webflow_cms.py` and `tests/test_tickpick_organizer.py` are new; `tests/test_motorco.py` gains a poster section below its existing title-escape tests, which are unchanged. All are parse-layer only — HTML/JS fragments and JSON-LD dicts fed straight to the parse methods, no DB and no network, matching how `test_mec.py` and `test_squarespace.py` work.

The Pour House suite includes a discriminating case for the join: two shows present in both lists, but in reverse order in the grid list with distinct flyers, so a positional (`zip`) pairing crosses the images and only a real slug join passes. Motorco has the equivalent: an event with no poster next to one with a poster, which fails if the poster is ever read from outside its own block.

`python -m pytest tests -q` from `backend/`: **302 passed, 4 skipped**. Every module in `app/scrapers/` still imports.

### Not in scope

No changes to `base.py`, `seed.py`, or the shared HTTP headers. The three normalizations of schema.org's `image` now in the tree (here, `mec.py`, `koka_booth.py`) are near-identical and could reasonably be consolidated into a shared `BaseScraper` helper alongside `parse_price` and `parse_time`, but that would mean editing two scrapers that already work, so it is left for a separate change.
