### PR TITLE
Stop the Ticketmaster API key reaching logs, the database, and the scrape response

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,22 @@ The authoritative source is [`backend/app/seed.py`](backend/app/seed.py) — eac
 
 ---
 
+## Credentials in request URLs
+
+The Ticketmaster Discovery API authenticates with a query parameter (`?apikey=`) rather than a header, so every request URL the Ticketmaster scraper builds *is* a live credential. Four sinks would otherwise carry it out of the process, and closing one leaves the others open:
+
+| Sink | Closed by |
+|---|---|
+| `httpx` logs every request at INFO with the full query string | `app.main.configure_logging` pins the `httpx` logger to WARNING |
+| `httpx.HTTPStatusError` embeds the URL in `str(e)`, which is logged on a failed scrape | `RedactingFormatter`, installed on every log handler in the process (so it covers exception tracebacks too) |
+| An exception escaping a *route* is re-raised by Starlette's `ServerErrorMiddleware` and logged by the ASGI server on its own error logger — which has `propagate=False` and its own handler, so it never passes a root handler | the same sweep: `configure_logging` wraps *every* handler, not root's, via `redaction.redact_handler`, which preserves each handler's existing format instead of replacing it |
+| That same string is persisted to `scrape_logs.error_message` and returned in the per-venue result dict from `POST /api/scrape` | `manager.scrape_venue` redacts once, before all three uses |
+| `POST /api/scrape`'s catch-all also returns `detail=str(e)`, but on failures *outside* `scrape_venue` — session construction, a scraper import — that never pass through its redaction | `main.trigger_scrape` redacts independently, in its own `except` block |
+
+`backend/app/redaction.py::redact_credentials` is the shared helper. It is a **denylist** of parameter names and therefore never complete — a new scraper authenticating with an unlisted parameter needs an entry there and a case in the parametrized test in `backend/tests/test_redaction.py`, not a nearby entry that happens to look similar. Only the value is removed, so a redacted URL still says which venue was being fetched and with what paging.
+
+---
+
 ## Tech stack
 
 | Layer | Technology |

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -23,16 +23,82 @@ from fastapi.staticfiles import StaticFiles
 
 from app.config import settings
 from app.database import async_session
+from app.redaction import redact_credentials, redact_handler
 from app.seed import seed_venues
 from app.scheduler import scheduler, configure_scheduler
 from app.api import events, venues, health, feeds, admin
 from app import tokens
 
 # --- Logging setup ---
-logging.basicConfig(
-    level=getattr(logging, settings.LOG_LEVEL),
-    format="%(asctime)s [%(levelname)s] %(name)s: %(message)s",
-)
+
+LOG_FORMAT = "%(asctime)s [%(levelname)s] %(name)s: %(message)s"
+
+
+def configure_logging() -> None:
+    """Configure process-wide logging, with credential redaction on every sink.
+
+    Two measures, because the Ticketmaster Discovery API authenticates with a query
+    parameter and so every request URL the scraper builds is a live credential:
+
+    * ``httpx`` is pinned to WARNING. It logs the full URL of every request at INFO,
+      which put the key in the log store once per Ticketmaster venue per scrape cycle.
+      Our scrapers already emit their own per-request line naming the venue, so what is
+      lost is the HTTP status of a *successful* request; a failure still raises and is
+      logged.
+    * **Every handler in the process** — root's and everybody else's — is wrapped by
+      :func:`~app.redaction.redact_handler`, which scrubs the values out of anything
+      that renders a URL, including the exception tracebacks the httpx pin cannot
+      reach (``httpx.HTTPStatusError`` carries the request URL in its own message
+      regardless of the logger's level).
+
+      Root handlers alone are not enough. Starlette's ``ServerErrorMiddleware`` always
+      re-raises after invoking the bare-``Exception`` handler, and the ASGI server then
+      logs the full traceback itself on a logger it configures with ``propagate=False``
+      and its own handler — which no root handler ever sees. Under uvicorn that is the
+      ``uvicorn`` logger; under ``gunicorn -k UvicornWorker`` it is ``gunicorn.error``.
+      Naming those loggers here instead would make this a snapshot of today's
+      dependency set whose failure mode is a *silent* one: swap the server — an
+      ordinary deployment change touching no application code — and the sink reopens
+      with no signal and no failing test, because a test can only reach for the same
+      names the code does. Sweeping every handler is immune to that by construction.
+
+      This is safe to apply indiscriminately precisely because ``redact_handler``
+      wraps rather than replaces: a handler somebody else owns (uvicorn's access
+      formatter, a structured/JSON handler a deployment installs on root) keeps its
+      exact layout, and the wrap is idempotent, so repeat calls never nest.
+
+    Called at import, where the plain ``basicConfig`` call it replaces used to sit, so
+    the configuration is in place before the app serves anything — and exposed as a
+    function so tests can assert on it rather than importing for its side effects
+    alone. uvicorn builds its logging config in ``Config.__init__``, before it imports
+    the app, so its handlers already exist by the time this runs under a real server;
+    the sweep simply finds fewer of them under pytest or a bare interpreter.
+
+    Residue worth knowing: handlers installed *after* this runs are not covered. That
+    is a narrower bet than the one a name-based enumeration makes, but it is still a
+    bet — if a future dependency installs a handler lazily, call this again once it has.
+    """
+    logging.basicConfig(level=getattr(logging, settings.LOG_LEVEL), format=LOG_FORMAT)
+
+    # Snapshot the registry before walking it. loggerDict is the live dict that
+    # logging.getLogger() inserts into, and the filter below runs Python between
+    # iterations, so a thread creating a logger mid-sweep would raise "dictionary
+    # changed size during iteration" out of a function that runs at import — turning a
+    # logging refinement into the app failing to boot. list() materializes in one
+    # C-level pass, which cannot observe a concurrent resize.
+    loggers = [logging.getLogger()] + [
+        existing
+        for existing in list(logging.root.manager.loggerDict.values())
+        if isinstance(existing, logging.Logger)
+    ]
+    for each in loggers:
+        for handler in each.handlers:
+            redact_handler(handler)
+
+    logging.getLogger("httpx").setLevel(logging.WARNING)
+
+
+configure_logging()
 logger = logging.getLogger(__name__)
 
 
@@ -253,7 +319,12 @@ async def trigger_scrape(
             return {"results": results, "reclassified": manager.last_reclassify}
     except Exception as e:
         logger.error(f"[trigger_scrape] Unhandled error: {e}", exc_info=True)
-        raise HTTPException(status_code=500, detail=str(e))
+        # This endpoint is unauthenticated whenever SCRAPE_ALLOWED_SERVICE_ACCOUNTS is
+        # unset, and failures here happen *outside* scrape_venue (session construction,
+        # a scraper import, the reclassify pass) — before the manager's own redaction
+        # runs — so this catch-all has to scrub independently rather than rely on the
+        # per-venue result dict having been scrubbed already.
+        raise HTTPException(status_code=500, detail=redact_credentials(str(e)))
 
 
 # --- Static file serving ---

--- a/backend/app/redaction.py
+++ b/backend/app/redaction.py
@@ -1,0 +1,128 @@
+"""Scrub credential-bearing query parameters out of text before it leaves the process.
+
+Role: shared by every sink a request URL can escape through — :func:`redact_handler`,
+which ``app.main.configure_logging`` applies to every log handler in the process
+(covering messages, exception tracebacks, and the handlers owned by whatever ASGI
+server is running, which log unhandled-request tracebacks on loggers that set
+``propagate=False`` and so are invisible to any root handler), and the non-logging
+sinks: the ``scrape_logs.error_message`` column and the per-venue result dict in
+``app.scrapers.manager.scrape_venue``, plus the ``detail`` of the 500 that
+``app.main.trigger_scrape`` raises — ``POST /api/scrape`` is unauthenticated unless
+``SCRAPE_ALLOWED_SERVICE_ACCOUNTS`` is set.
+
+Why this exists: the Ticketmaster Discovery API authenticates with a query parameter
+rather than a header, so the scraper's request URL *is* a credential. ``httpx`` logs
+that URL in full at INFO on every request, and ``httpx.HTTPStatusError`` embeds it in
+its ``str()`` — which the scrape manager interpolates into a log line, persists to the
+database, and returns to the caller. Redacting in one place would have closed one
+route out of four.
+
+This is the backstop, not the primary defense. ``configure_logging`` also pins the
+``httpx`` logger to WARNING so the high-volume emitter is switched off outright: a
+denylist of parameter names should not be the only thing standing between a live
+credential and a log store.
+
+Requires: nothing outside the standard library — deliberately import-light so any
+layer can call it without a dependency cycle.
+"""
+
+import logging
+import re
+
+# --- Redaction ---
+
+REDACTED = "<redacted>"
+
+# Parameter names whose values are credentials. Matched as a *suffix* behind an optional
+# `[\w-]*` prefix, so `csrf_token`, `x-api-key` and `client_secret` are all caught rather
+# than requiring an exact spelling. `sig` is the one exact-only entry: as a suffix it
+# would fire on innocuous names, and the lookbehind is what keeps it from matching inside
+# a longer word.
+#
+# This is a denylist, and a denylist is never complete. It covers what this codebase
+# actually sends; when a new scraper authenticates with an unlisted parameter name, add
+# it here and to the parametrized test rather than relying on the entry that happens to
+# be closest.
+_CREDENTIAL_QUERY_RE = re.compile(
+    r"(?i)"
+    r"(?<![\w-])"
+    r"((?:[\w-]*(?:api[-_]?key|access[-_]?token|token|secret|password|signature)|sig)=)"
+    # A value runs to the next parameter separator or to whatever delimiter the
+    # surrounding text uses — a quote in an exception message, an angle bracket in
+    # rendered markup, or the end of the string.
+    r"([^&\s\"'<>]+)"
+)
+
+
+def redact_credentials(text):
+    """Replace credential query-parameter values in `text`, leaving everything else intact.
+
+    Non-string input is returned unchanged so call sites can pass an exception object or
+    ``None`` without guarding first.
+
+    Idempotent by construction: the placeholder opens with ``<``, which the value pattern
+    excludes, so a second pass finds nothing left to match. That matters because the
+    formatter and the manager both apply this, and a failed Ticketmaster scrape goes
+    through both.
+
+    Only the *value* is removed — the parameter name and every non-credential parameter
+    survive, so a redacted URL still says which venue was being fetched and with what
+    paging. A log line that has been scrubbed into uselessness gets replaced by one that
+    isn't.
+    """
+    if not isinstance(text, str):
+        return text
+    # Group 1 of the pattern always ends in a literal `=`, so text without one cannot
+    # match — a provable short-circuit, not a heuristic. Worth the line because the
+    # pattern is deliberately anchorless (a leading `(?i)`, an alternation, and a
+    # lookbehind leave the engine no literal prefix to seek on), so it costs roughly
+    # 50ns per character and retries at every position. This now runs over every line
+    # every handler in the process renders, tracebacks included; the miss case is the
+    # overwhelmingly common one.
+    if "=" not in text:
+        return text
+    return _CREDENTIAL_QUERY_RE.sub(rf"\g<1>{REDACTED}", text)
+
+
+# --- Logging installation point ---
+
+
+class RedactingFormatter(logging.Formatter):
+    """Scrubs credentials from whatever another formatter rendered, keeping its layout.
+
+    Deliberately a formatter rather than a ``logging.Filter``. A filter sees
+    ``record.msg`` and ``record.args`` before they are combined, and never sees the
+    rendered exception traceback at all — so an ``exc_info=True`` call site would walk
+    straight past it carrying the URL in the traceback text. Formatting is the single
+    point where message, arguments, and traceback have all become one string.
+
+    Deliberately *wraps* an inner formatter rather than rendering from its own format
+    string. Most handlers this runs against belong to somebody else — uvicorn installs
+    its own ``DefaultFormatter``/``AccessFormatter``, and a deployment may install a
+    structured/JSON handler on the root logger — and replacing their formatter outright
+    would silently reshape those log lines (the access log in particular renders from
+    record *args*, not from a plain ``%(message)s``). Wrapping keeps every handler's
+    output byte-identical apart from the credential values, which means the same
+    mechanism is safe to apply to every handler in the process without first deciding
+    who owns it. Attach to *handlers*, not to loggers: a formatter belongs to a handler
+    by design, and the handler is what every propagated record passes through.
+    """
+
+    def __init__(self, inner: logging.Formatter) -> None:
+        super().__init__()
+        self._inner = inner
+
+    def format(self, record: logging.LogRecord) -> str:
+        return redact_credentials(self._inner.format(record))
+
+
+def redact_handler(handler: logging.Handler) -> None:
+    """Ensure `handler` scrubs credentials, leaving its existing format alone.
+
+    Idempotent: a handler already carrying a :class:`RedactingFormatter` is left as-is,
+    so repeated ``configure_logging()`` calls (import, then a test) don't nest wrappers.
+    """
+    existing = handler.formatter
+    if isinstance(existing, RedactingFormatter):
+        return
+    handler.setFormatter(RedactingFormatter(existing or logging.Formatter()))

--- a/backend/app/scrapers/manager.py
+++ b/backend/app/scrapers/manager.py
@@ -28,6 +28,7 @@ from sqlalchemy.dialects.postgresql import insert as pg_insert
 from app.config import settings
 from app.classifier import classification_updates, reclassify_floor, ALWAYS_LIVE_VENUE_SLUGS
 from app.models import Venue, Event, ScrapeLog, SeriesOverride
+from app.redaction import redact_credentials
 from app.scrapers.base import BaseScraper, ScrapedEvent
 from app.scrapers.ticketmaster import TicketmasterScraper
 
@@ -295,20 +296,28 @@ class ScrapeManager:
             }
 
         except Exception as e:
-            logger.error(f"[{venue_slug}] Scrape failed: {e}")
+            # httpx.HTTPStatusError stringifies to include the full request URL, and the
+            # Ticketmaster scraper authenticates with an ?apikey= query parameter — so the
+            # raw exception text is a live credential. It reaches three sinks from here:
+            # this log line, the scrape_logs row below, and the dict returned to
+            # POST /api/scrape. Redact once, at the top.
+            message = redact_credentials(str(e))
+            logger.error(f"[{venue_slug}] Scrape failed: {message}")
             try:
                 # Roll back the failed transaction before writing the error log,
                 # otherwise the commit below will also fail.
                 await self.session.rollback()
                 log.status = "failed"
-                log.error_message = str(e)[:2000]  # cap length to fit DB column
+                log.error_message = message[:2000]  # cap length to fit DB column
                 log.finished_at = datetime.utcnow()
                 log.duration_seconds = (log.finished_at - log.started_at).total_seconds()
                 self.session.add(log)
                 await self.session.commit()
             except Exception as log_err:
-                logger.warning(f"[{venue_slug}] Could not write error log: {log_err}")
-            return {"venue": venue_slug, "status": "failed", "error": str(e)}
+                logger.warning(
+                    f"[{venue_slug}] Could not write error log: {redact_credentials(str(log_err))}"
+                )
+            return {"venue": venue_slug, "status": "failed", "error": message}
 
     # --- Upsert helpers ---
 

--- a/backend/tests/test_redaction.py
+++ b/backend/tests/test_redaction.py
@@ -1,0 +1,491 @@
+"""Regression tests for credential leakage out of the application.
+
+The Ticketmaster Discovery API authenticates with a query parameter (``?apikey=``),
+so every request URL the scraper builds carries a live credential. That URL escapes
+the process by four independent routes, and a fix that closes one leaves the others
+open:
+
+1. ``httpx`` logs every request at INFO with the full query string, so a *healthy*
+   scrape writes the key to the log store once per Ticketmaster venue per cycle.
+2. ``httpx.HTTPStatusError`` embeds the request URL in its ``str()``, and
+   ``manager.scrape_venue`` interpolates that into ``logger.error`` — so a *failed*
+   scrape logs the key even with httpx itself silenced.
+3. That same exception string is persisted to ``scrape_logs.error_message`` and
+   returned in the per-venue result dict, which ``POST /api/scrape`` hands back.
+4. An exception escaping a route is re-raised by Starlette's ``ServerErrorMiddleware``
+   and logged by the ASGI server on a logger it configures with ``propagate=False``
+   and its own handler, which no root handler ever sees.
+
+Route 3 is why redaction cannot live in the logging layer alone: that sink is not a
+log. Route 4 is why the logging half has to sweep every handler in the process rather
+than root's. The shared helper is the contract; the formatter and the manager are its
+installation points.
+"""
+
+import asyncio
+import contextlib
+import io
+import logging
+import threading
+
+import httpx
+import pytest
+
+from app.redaction import RedactingFormatter, redact_credentials, redact_handler
+
+
+# Shaped exactly like the URL the Ticketmaster scraper builds
+# (app/scrapers/ticketmaster.py), with a placeholder standing in for the live key.
+FAKE_KEY = "s3cr3tKEYvalue0123456789abcdefgh"
+TM_URL = (
+    "https://app.ticketmaster.com/discovery/v2/events.json"
+    f"?apikey={FAKE_KEY}&venueId=KovZpZAdEEvA&size=200&page=0&sort=date%2Casc"
+)
+
+
+@pytest.fixture
+def preserved_logging():
+    """Snapshot and restore global logging state around a test that reconfigures it.
+
+    ``app.main.configure_logging`` mutates process-wide state — root's level and
+    handlers, and the level, handlers and formatter of every pre-existing logger.
+    Without this, a test that trips it takes the rest of the session down with it.
+    """
+    root = logging.getLogger()
+    saved_root_level = root.level
+    saved_root_handlers = root.handlers[:]
+    saved_formatters = [(handler, handler.formatter) for handler in root.handlers]
+    saved_loggers = [
+        (logger, logger.level, logger.disabled, logger.handlers[:], logger.propagate)
+        for logger in logging.Logger.manager.loggerDict.values()
+        if isinstance(logger, logging.Logger)
+    ]
+    try:
+        yield
+    finally:
+        root.setLevel(saved_root_level)
+        root.handlers[:] = saved_root_handlers
+        # configure_logging() swaps formatters in place on handlers it did not create,
+        # so restoring the handler list alone would leave the new formatter installed.
+        for handler, formatter in saved_formatters:
+            handler.setFormatter(formatter)
+        for logger, level, disabled, handlers, propagate in saved_loggers:
+            logger.setLevel(level)
+            logger.disabled = disabled
+            logger.handlers[:] = handlers
+            logger.propagate = propagate
+
+
+def _tm_error() -> httpx.HTTPStatusError:
+    """The exact exception httpx raises on a Ticketmaster 401, key and all."""
+    request = httpx.Request("GET", TM_URL)
+    return httpx.HTTPStatusError(
+        f"Client error '401 Unauthorized' for url '{TM_URL}'",
+        request=request,
+        response=httpx.Response(401, request=request),
+    )
+
+
+# --- The shared helper ---
+
+
+@pytest.mark.parametrize(
+    "param",
+    ["apikey", "api_key", "access_token", "token", "secret", "password", "signature", "sig"],
+)
+def test_credential_query_params_are_redacted(param):
+    """Every parameter name we treat as a credential loses its value."""
+    redacted = redact_credentials(f"https://example.test/x?{param}={FAKE_KEY}&venueId=1")
+    assert FAKE_KEY not in redacted
+    assert f"{param}=" in redacted, "the parameter name is kept — only the value is scrubbed"
+    assert "venueId=1" in redacted
+
+
+@pytest.mark.parametrize("param", ["APIKEY", "ApiKey", "Api_Key", "Access_Token"])
+def test_redaction_is_case_insensitive(param):
+    """Query-parameter casing varies across APIs; a case-sensitive match would miss them."""
+    assert FAKE_KEY not in redact_credentials(f"https://example.test/x?{param}={FAKE_KEY}")
+
+
+def test_non_credential_params_survive():
+    """Redaction must not destroy the diagnostic value of a logged URL."""
+    redacted = redact_credentials(TM_URL)
+    assert FAKE_KEY not in redacted
+    for kept in ("venueId=KovZpZAdEEvA", "size=200", "page=0", "sort=date%2Casc"):
+        assert kept in redacted, f"{kept} is diagnostic, not secret, and should survive"
+    assert "app.ticketmaster.com/discovery/v2/events.json" in redacted
+
+
+def test_value_at_end_of_string_is_redacted():
+    """No trailing ampersand to anchor on — the common shape when the key is the last param."""
+    assert FAKE_KEY not in redact_credentials(f"https://example.test/x?venueId=1&apikey={FAKE_KEY}")
+
+
+def test_redaction_stops_at_the_end_of_the_value_not_the_end_of_the_line():
+    """A credential in the *last* query parameter must not swallow the text after the URL.
+
+    This is httpx's exact log shape, and the case that separates a correct value pattern
+    from a lazy one: with the key last, a pattern that only stops at `&` runs to the end
+    of the record and eats the HTTP status — redacting far more than the secret. Nothing
+    leaks either way, so only an assertion on the *surviving* text catches it.
+    """
+    line = (
+        f"HTTP Request: GET https://app.ticketmaster.com/x?venueId=KovZpZAdEEvA&apikey={FAKE_KEY} "
+        '"HTTP/1.1 200 OK"'
+    )
+    redacted = redact_credentials(line)
+
+    assert FAKE_KEY not in redacted
+    assert '"HTTP/1.1 200 OK"' in redacted, "redaction ran past the value and ate the status"
+    assert "venueId=KovZpZAdEEvA" in redacted
+
+
+def test_redaction_stops_at_a_closing_quote():
+    """httpx.HTTPStatusError renders the URL inside single quotes; the closing quote is
+    the only boundary when the credential is the final parameter."""
+    line = f"Client error '401 Unauthorized' for url 'https://x.test/y?apikey={FAKE_KEY}'"
+    redacted = redact_credentials(line)
+
+    assert FAKE_KEY not in redacted
+    assert redacted.endswith("'"), "the closing quote was consumed as part of the value"
+
+
+def test_redaction_is_idempotent():
+    """Applied at more than one layer, so double-application must not corrupt the text."""
+    once = redact_credentials(TM_URL)
+    assert redact_credentials(once) == once
+
+
+def test_non_string_input_is_returned_unchanged():
+    """Call sites pass exception objects and None; the helper must not raise on them."""
+    assert redact_credentials(None) is None
+    assert redact_credentials(42) == 42
+
+
+# --- The logging installation point ---
+
+
+def _capture(formatter, record):
+    """Format one record through a handler carrying `formatter`, returning the output."""
+    stream = io.StringIO()
+    handler = logging.StreamHandler(stream)
+    handler.setFormatter(formatter)
+    handler.handle(record)
+    return stream.getvalue()
+
+
+def test_formatter_redacts_the_message():
+    record = logging.LogRecord(
+        name="httpx", level=logging.INFO, pathname=__file__, lineno=1,
+        msg='HTTP Request: GET %s "HTTP/1.1 200 OK"', args=(TM_URL,), exc_info=None,
+    )
+    out = _capture(RedactingFormatter(logging.Formatter("%(message)s")), record)
+    assert FAKE_KEY not in out
+    assert "venueId=KovZpZAdEEvA" in out
+
+
+def test_formatter_redacts_the_exception_traceback():
+    """The manager logs failures by interpolation, but an exc_info=True call site puts the
+    URL in the traceback text instead — where a message-only filter never looks. That is
+    not hypothetical here: app.main.trigger_scrape logs its catch-all with exc_info=True.
+    """
+    try:
+        raise _tm_error()
+    except httpx.HTTPStatusError:
+        import sys
+
+        record = logging.LogRecord(
+            name="app.scrapers.manager", level=logging.ERROR, pathname=__file__,
+            lineno=1, msg="scrape failed", args=(), exc_info=sys.exc_info(),
+        )
+
+    out = _capture(RedactingFormatter(logging.Formatter("%(message)s")), record)
+    assert "Traceback" in out, "the test is only meaningful if the traceback was rendered"
+    assert FAKE_KEY not in out
+
+
+def test_configure_logging_installs_the_formatter_on_every_root_handler(preserved_logging):
+    """A handler without the formatter is an open sink; there is usually only one, but
+    the assertion is over all of them so an added handler cannot silently bypass this."""
+    from app.main import configure_logging
+
+    configure_logging()
+    root = logging.getLogger()
+    assert root.handlers, "expected basicConfig to have installed at least one handler"
+    for handler in root.handlers:
+        assert isinstance(handler.formatter, RedactingFormatter), (
+            f"{handler!r} would emit un-redacted output"
+        )
+
+
+def test_configure_logging_silences_httpx_request_logging(preserved_logging):
+    """The primary emitter is switched off outright rather than left to the formatter.
+
+    No regex should be the only thing between a live credential and a log store: httpx
+    logs the full URL on every successful request, so the volume alone makes it the one
+    source worth removing alongside redacting. Our own scrapers already log a
+    per-request line ('[TM] Fetching page 0 for red-hat') carrying the venue, which is
+    the part with diagnostic value.
+    """
+    from app.main import configure_logging
+
+    logging.getLogger("httpx").setLevel(logging.NOTSET)
+    configure_logging()
+
+    # Assert on the logger's *own* level rather than isEnabledFor(INFO). An effective
+    # level falls back to root's, and pytest installs its own root handlers before the
+    # app is imported — which makes logging.basicConfig() a no-op, because the standard
+    # library only applies its `level` argument when root has no handlers yet. Root
+    # therefore sits at pytest's WARNING for the whole session, and isEnabledFor(INFO)
+    # would report httpx silenced whether or not this pin exists. Equality (not <=) also
+    # pins the level from above: a genuine httpx failure must still reach the log.
+    assert logging.getLogger("httpx").level == logging.WARNING
+
+
+def test_redact_handler_scrubs_without_changing_the_existing_format():
+    """redact_handler *wraps* the handler's formatter rather than replacing it, so a
+    handler owned by someone else (uvicorn installs its own DefaultFormatter and an
+    AccessFormatter that renders from record args, not %(message)s) keeps its layout."""
+    buf = io.StringIO()
+    handler = logging.StreamHandler(buf)
+    handler.setFormatter(logging.Formatter("PREFIX %(levelname)s :: %(message)s"))
+    redact_handler(handler)
+
+    logger = logging.getLogger("test_redact_handler_format")
+    logger.propagate = False
+    logger.handlers = [handler]
+    logger.setLevel(logging.INFO)
+    logger.info("fetching %s", TM_URL)
+
+    out = buf.getvalue()
+    assert out.startswith("PREFIX INFO :: "), "the wrapped formatter's layout was lost"
+    assert FAKE_KEY not in out
+    assert "venueId=KovZpZAdEEvA" in out, "only the credential value should be removed"
+
+
+def test_redact_handler_is_idempotent():
+    """configure_logging() runs at import and again in any test that calls it, so a
+    second pass must not nest wrappers."""
+    handler = logging.StreamHandler(io.StringIO())
+    handler.setFormatter(logging.Formatter("%(message)s"))
+    redact_handler(handler)
+    first = handler.formatter
+    redact_handler(handler)
+    assert handler.formatter is first
+
+
+# --- The ASGI server sink: a non-propagating logger no root handler can reach ---
+
+
+@pytest.mark.parametrize(
+    "server_logger, child_logger",
+    [
+        ("uvicorn", "uvicorn.error"),
+        # gunicorn is named nowhere in app/**, which is the point: configure_logging
+        # sweeps every handler in the process rather than a list of dependency names,
+        # so swapping the server (`gunicorn -k UvicornWorker` is a deployment change
+        # touching no application code) cannot silently reopen the sink. A test that
+        # only ever reached for "uvicorn" would share the production code's blind spot
+        # instead of checking it.
+        ("gunicorn", "gunicorn.error"),
+    ],
+)
+def test_configure_logging_closes_any_servers_traceback_sink(
+    preserved_logging, server_logger, child_logger
+):
+    """Starlette's ServerErrorMiddleware ALWAYS re-raises after invoking the
+    bare-Exception handler, so the ASGI server logs the traceback itself on its own
+    error logger. That logger's parent is configured with propagate=False and its own
+    handler, so nothing it writes ever passes a root handler. Without the sweep, an
+    httpx.HTTPStatusError escaping any route writes a live ?apikey= in full.
+    """
+    from app.main import configure_logging
+
+    server = logging.getLogger(server_logger)
+    # Restored by hand rather than leaning on preserved_logging alone: that fixture
+    # snapshots the loggers existing when it runs, and `gunicorn` is created by this
+    # test, so it would otherwise leak its handler into the rest of the session.
+    original_handlers = server.handlers
+    original_propagate = server.propagate
+
+    buf = io.StringIO()
+    handler = logging.StreamHandler(buf)
+    handler.setFormatter(logging.Formatter("%(levelname)s: %(message)s"))
+    server.handlers = [handler]
+    server.propagate = False
+
+    try:
+        configure_logging()
+
+        try:
+            raise _tm_error()
+        except httpx.HTTPStatusError as exc:
+            logging.getLogger(child_logger).error(
+                "Exception in ASGI application\n", exc_info=exc
+            )
+
+        out = buf.getvalue()
+    finally:
+        server.handlers = original_handlers
+        server.propagate = original_propagate
+
+    assert "Exception in ASGI application" in out, "the test did not exercise the handler"
+    assert FAKE_KEY not in out, f"{server_logger}'s own handler leaked the credential"
+    assert "venueId=KovZpZAdEEvA" in out, "the diagnosis itself must survive"
+
+
+def test_configure_logging_survives_concurrent_logger_creation(preserved_logging):
+    """configure_logging sweeps every logger in the process, and the registry it reads
+    is a live dict that logging.getLogger() writes into. Walking it lazily meant any
+    thread creating a logger mid-sweep could raise "dictionary changed size during
+    iteration" — out of configure_logging, which runs at import, so the failure mode is
+    the app not booting at all.
+
+    Stress rather than a fixed scenario, because the window is a thread switch: this
+    can only ever miss the bug, never report one that isn't there, so a pass is always
+    legitimate. The round count is set where the unsnapshotted version failed on every
+    one of eight consecutive runs while the whole module still finished in about a
+    second.
+    """
+    from app.main import configure_logging
+
+    registry = logging.root.manager.loggerDict
+    # logging.Manager.getLogger mutates the registry while holding the module lock, and
+    # Manager._clear_cache iterates it lazily under that same lock on exactly that
+    # assumption — so a churn thread that skipped the lock would provoke a RuntimeError
+    # inside the standard library instead of inside the sweep, and this test would fail
+    # for a reason that has nothing to do with the code under test. Falling back to a
+    # no-op context manager keeps the test honest rather than erroring if a future
+    # release renames the private lock: the sweep is still exercised concurrently.
+    registry_lock = getattr(logging, "_lock", None) or contextlib.nullcontext()
+    names = [f"_race_probe_{n}" for n in range(500)]
+    stop = threading.Event()
+    failure: list[BaseException] = []
+
+    def churn() -> None:
+        # Adds and removes within a fixed name pool rather than creating new loggers
+        # without bound: the registry's *size* has to change to provoke the bug, but it
+        # must not grow, or the sweep under test gets slower every round and the whole
+        # suite crawls. PlaceHolder is what getLogger itself stores for intermediate
+        # names, so this is the shape the real registry churns through.
+        index = 0
+        while not stop.is_set():
+            name = names[index % len(names)]
+            with registry_lock:
+                if name in registry:
+                    registry.pop(name, None)
+                else:
+                    registry[name] = logging.PlaceHolder(logging.getLogger())
+            index += 1
+
+    churner = threading.Thread(target=churn, daemon=True)
+    churner.start()
+    try:
+        for _ in range(3000):
+            try:
+                configure_logging()
+            except RuntimeError as exc:  # pragma: no cover - the bug this pins
+                failure.append(exc)
+                break
+    finally:
+        stop.set()
+        churner.join(timeout=5)
+        for name in names:
+            registry.pop(name, None)
+
+    assert not failure, f"configure_logging raced with logger creation: {failure[0]!r}"
+
+
+# --- The non-logging sinks ---
+
+
+class _StubSession:
+    """The narrow slice of AsyncSession that scrape_venue's failure path touches.
+
+    Enough to reach the `except` block without a database, so this runs in CI's unit
+    test step — which executes before `alembic upgrade head`, and therefore against a
+    schema that does not exist yet.
+    """
+
+    def __init__(self):
+        self.added = []
+
+    async def refresh(self, obj):
+        return None
+
+    def add(self, obj):
+        self.added.append(obj)
+
+    async def flush(self):
+        return None
+
+    async def rollback(self):
+        return None
+
+    async def commit(self):
+        return None
+
+
+class _StubVenue:
+    slug = "red-hat"
+    id = 1
+    scraper_type = "ticketmaster"
+    ticketmaster_venue_id = "KovZpZAdEEvA"
+    scraper_config = None
+
+
+def test_a_failed_scrape_neither_persists_nor_returns_the_credential():
+    """manager.scrape_venue's `except` block feeds three sinks off one exception string:
+    a log line, scrape_logs.error_message, and the per-venue dict that POST /api/scrape
+    returns. Redaction happens once, above all three."""
+    from app.scrapers.manager import ScrapeManager
+
+    class ExplodingScraper:
+        async def scrape(self):
+            raise _tm_error()
+
+    session = _StubSession()
+    manager = ScrapeManager(session)
+    manager._get_scraper = lambda venue: ExplodingScraper()
+
+    result = asyncio.run(manager.scrape_venue(_StubVenue()))
+
+    assert result["status"] == "failed"
+    assert FAKE_KEY not in result["error"], "the response body leaked the credential"
+    assert "401 Unauthorized" in result["error"], "the diagnosis itself must survive"
+
+    logs = [row for row in session.added if hasattr(row, "error_message")]
+    assert logs, "expected the failure to be recorded on a ScrapeLog"
+    assert all(FAKE_KEY not in (row.error_message or "") for row in logs), (
+        "the credential was persisted to scrape_logs.error_message"
+    )
+    assert any("401 Unauthorized" in (row.error_message or "") for row in logs)
+
+
+def test_trigger_scrape_catch_all_redacts_the_credential(monkeypatch):
+    """POST /api/scrape has its own `except Exception`, separate from scrape_venue's —
+    it fires on failures *outside* scrape_venue (session construction, a scraper import)
+    that never pass through the manager's redaction, and it puts str(e) straight into
+    the response body. Forcing the session factory itself to raise reaches exactly that
+    branch.
+
+    The endpoint is unauthenticated unless SCRAPE_ALLOWED_SERVICE_ACCOUNTS names an
+    account, so on a default deployment this hands the body to any caller.
+    """
+    from fastapi.testclient import TestClient
+
+    from app.main import app
+
+    def _raising_session_factory():
+        raise _tm_error()
+
+    # trigger_scrape imports async_session inside the function body, so the name is
+    # resolved from the module at call time and patching it here takes effect.
+    monkeypatch.setattr("app.database.async_session", _raising_session_factory)
+
+    response = TestClient(app).post("/api/scrape")
+
+    assert response.status_code == 500
+    detail = response.json()["detail"]
+    assert FAKE_KEY not in detail, "the unauthenticated endpoint leaked the credential"
+    assert "401 Unauthorized" in detail, "the diagnosis itself must survive"


### PR DESCRIPTION
## The defect

The Ticketmaster Discovery API authenticates with a **query parameter**, not a header. `backend/app/scrapers/ticketmaster.py:50` puts the key straight into `params`:

```python
params = {
    "apikey": self.api_key,
    "venueId": self.venue_tm_id,
    ...
}
```

So every request URL the scraper builds *is* a live credential, and anything that renders one leaks it. There are four such sinks, and closing any one of them leaves the other three open.

**1. `httpx` request logging.** `httpx` logs every request at INFO with the full query string. On a *healthy* run that writes the key to the log store once per Ticketmaster venue per scrape cycle — four venues today (`README.md` scraper map), every six hours.

**2. The failed-scrape log line.** `httpx.HTTPStatusError` embeds the request URL in its own `str()`. `backend/app/scrapers/manager.py:299` interpolates that into a log line, so a failed scrape leaks the key even with `httpx` itself silenced.

**3. The database and the API response.** That same string is persisted at `backend/app/scrapers/manager.py:304`:

```python
log.error_message = str(e)[:2000]  # cap length to fit DB column
```

and returned at `backend/app/scrapers/manager.py:311`:

```python
return {"venue": venue_slug, "status": "failed", "error": str(e)}
```

which `POST /api/scrape` hands back to the caller. A separate path reaches the same place: `backend/app/main.py:256` raises `HTTPException(status_code=500, detail=str(e))` from `trigger_scrape`'s catch-all, which fires on failures *outside* `scrape_venue` — session construction, a scraper import, the reclassify pass — that never pass through the manager at all. `require_scrape_token` is inert until `SCRAPE_ALLOWED_SERVICE_ACCOUNTS` names an account (`backend/app/main.py:214-215`), so on a deployment that has not set it, a Ticketmaster 401 or 429 hands the key to an anonymous caller.

These last two are why redaction cannot live in the logging layer alone: neither sink is a log.

**4. The ASGI server's own traceback.** This is the one a logging fix aimed at *root* would miss. Starlette's `ServerErrorMiddleware` always re-raises after invoking the bare-`Exception` handler, so the server logs the traceback itself — on `uvicorn.error` under uvicorn, `gunicorn.error` under `gunicorn -k UvicornWorker`. The parent logger is configured with `propagate=False` and its own handler, so nothing it writes ever reaches a root handler. An `httpx.HTTPStatusError` escaping any route writes a live `?apikey=` in full.

## The fix

`backend/app/redaction.py` holds one helper, `redact_credentials`, applied at every sink. It removes only the *value*: a redacted URL still names the venue, the paging and the HTTP status, because a log line scrubbed into uselessness gets replaced by one that isn't.

Three design points worth flagging in review:

- **It is installed as a `Formatter`, not a `Filter`, deliberately.** A filter sees `record.msg` and `record.args` before they are combined, and never sees the rendered exception traceback at all — so an `exc_info=True` call site would walk straight past it carrying the URL in the traceback text. `main.py`'s `trigger_scrape` catch-all is exactly such a call site, and it is retained as-is. Formatting is the single point where message, args and traceback have all become one string.

- **It wraps a handler's existing formatter rather than replacing it.** Most handlers this touches belong to somebody else — uvicorn installs its own `DefaultFormatter` and an `AccessFormatter` that renders from record *args*, not `%(message)s`, so replacing it would silently reshape the access log. Wrapping keeps every handler's output byte-identical apart from the credential values, and it is idempotent, so repeat calls never nest.

- **The sweep covers every handler in the process, not a list of logger names.** Wrapping is what makes that safe. Naming `uvicorn` here would make the code a snapshot of today's dependency set, with a *silent* failure mode: swapping the server is a deployment change touching no application code, and a test can only reach for the same names the code does, so the sink would reopen with no signal. The parametrized test therefore covers `gunicorn` too — a name that appears nowhere in `backend/app/`. It fails against a root-only or uvicorn-only implementation with the key rendered in the assertion diff.

`httpx` is additionally pinned to WARNING, so the high-volume emitter is switched off outright rather than left to a denylist of parameter names. What is lost is the HTTP status of a *successful* request; the scrapers already log their own per-request line naming the venue, and failures still raise.

The sweep reads `logging.root.manager.loggerDict` — the live dict `getLogger()` inserts into — and materializes it with `list()` before walking. Iterating it lazily lets a thread creating a logger mid-sweep raise `RuntimeError: dictionary changed size during iteration` out of a function that runs at import, which makes the failure mode the app not booting rather than a missed log line.

## Note on the denylist

`_CREDENTIAL_QUERY_RE` is a denylist of parameter names, and a denylist is never complete. It covers what this codebase actually sends. A new scraper authenticating with an unlisted parameter needs an entry there *and* a case in the parametrized test — not a nearby entry that happens to look similar. That is stated in the module docstring and in the new README section.

## Tests

29 new tests in `backend/tests/test_redaction.py`. Backend suite goes 280 passed, 4 skipped → **309 passed, 4 skipped**.

They are all synchronous and need no database, which matters here: the CI job runs `pytest tests` *before* `alembic upgrade head`, so anything DB-bound would be running against a schema that does not exist yet. The manager test drives the real `scrape_venue` failure path through a stub session and `asyncio.run`; the endpoint test uses `fastapi.testclient.TestClient`, matching `tests/test_cors.py`. No new dependencies, and no `sys.path` preamble — `backend/conftest.py` already handles that.

Each of the five behaviours was verified by mutation — reverting it turns the suite red:

| Reverted | Fails |
|---|---|
| `manager` result dict back to `str(e)` | `test_a_failed_scrape_neither_persists_nor_returns_the_credential` |
| `manager` `error_message` back to `str(e)` | same |
| `trigger_scrape` detail back to `str(e)` | `test_trigger_scrape_catch_all_redacts_the_credential` |
| sweep narrowed to root handlers | `test_configure_logging_closes_any_servers_traceback_sink` (both params) |
| `httpx` pin removed | `test_configure_logging_silences_httpx_request_logging` |
| `list()` snapshot removed | `test_configure_logging_survives_concurrent_logger_creation` (8/8 runs) |

Two things in that last row are worth a reviewer's attention, because both are places where a test can quietly stop testing anything:

- The concurrency test's churn thread mutates the logger registry **while holding `logging._lock`**, because `logging.Manager.getLogger` does. Without that, the `RuntimeError` surfaces from `Manager._clear_cache` inside the standard library rather than from the sweep, and the test fails for a reason unrelated to the code under test. It is a stress test, so a pass can only ever be a miss, never a false alarm; the round count is set where the unsnapshotted version failed on 8 consecutive runs while the module still finished in about a second.

- The `httpx` test asserts on the logger's **own** level, not `isEnabledFor(INFO)`. The standard library only applies `basicConfig`'s `level` argument when root has no handlers yet, and pytest installs root handlers before the app is imported — so under pytest root sits at WARNING for the whole session and `isEnabledFor(INFO)` reports httpx silenced whether or not the pin exists. Written that way the test passed against a build with the pin deleted.

## Also

`README.md` gains a "Credentials in request URLs" section documenting the sinks and the denylist caveat. It went in the root README rather than a new `backend/README.md`, since that is where the backend docs live.
