### PR TITLE
Nest venues under their city in the sidebar, with each city collapsible

### DIFF
--- a/frontend/css/styles.css
+++ b/frontend/css/styles.css
@@ -515,11 +515,71 @@ a:hover { color: var(--accent-hover); text-decoration: underline; }
   opacity: 0.45;
 }
 
-/* Venue list (rendered by JS as .venue-checkbox labels) */
-.venue-list {
+/* ── Cities & venues ───────────────────────────────────────────────────────────
+   Venues nest under a collapsible city header. Replaces the former flat .venue-list
+   and the separate city chip row. */
+
+.city-groups { display: flex; flex-direction: column; gap: 0.6rem; }
+
+/* Row for non-city chips (Spotify's "★ for you"). Takes no space while empty, so an
+   unconnected visitor sees no gap. */
+.quick-filters:not(:empty) { margin-bottom: 0.6rem; }
+
+.city-group-head { display: flex; align-items: stretch; gap: 0.3rem; }
+/* The chip fills the row so the whole width is a city filter target, and the caret
+   stays a separate, smaller hit area — one row, two distinct actions. */
+.city-group-head .city-chip { flex: 1 1 auto; text-align: left; }
+
+.city-collapse {
+  flex-shrink: 0;
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 0.3rem;
+  background: none;
+  border: 1px solid transparent;
+  border-radius: 1px;
+  cursor: pointer;
+  /* --muted, not --dim. This is the control the whole feature hangs on, and --dim
+     measures 1.83:1 against --surface in dark mode — under the 3:1 an interactive
+     element needs. --dim is fine for inert decoration, not for this. */
+  color: var(--muted);
+  font-family: 'Space Mono', monospace;
+  font-size: 0.6rem;
+  /* min-height carries the hit target to 24px; padding alone left it at 22. */
+  min-height: 24px;
+  min-width: 34px;
+  padding: 0 0.35rem;
+  transition: color 0.12s, border-color 0.12s;
+}
+.city-collapse:hover { color: var(--accent); border-color: var(--border); }
+.city-collapse:focus-visible { outline: 1px solid var(--accent); outline-offset: 1px; }
+
+.city-count { font-variant-numeric: tabular-nums; opacity: 0.75; }
+.city-caret { display: inline-block; transition: transform 0.15s ease; }
+.city-group.collapsed .city-caret { transform: rotate(-90deg); }
+
+/* Venues indented under their city, with a rule tying them to the group. */
+.city-venues {
   display: flex;
   flex-direction: column;
   gap: 0.35rem;
+  padding: 0.4rem 0 0.1rem 0.55rem;
+  margin-left: 0.2rem;
+  border-left: 1px solid var(--border);
+}
+
+/* Collapse uses display:none deliberately, and the inputs must stay in the DOM.
+   _getFilteredEvents() builds its venue map with
+   querySelectorAll(".venue-checkbox input[type=checkbox]"), so unmounting a collapsed
+   city would silently drop its venues from the filter — the calendar would disagree
+   with a sidebar the visitor cannot see. display:none keeps them queryable while
+   removing them from layout and from the tab order, which is the same thing
+   `.venue-checkbox input { display: none }` already relies on further down. */
+.city-group.collapsed .city-venues { display: none; }
+
+@media (prefers-reduced-motion: reduce) {
+  .city-caret { transition: none; }
 }
 
 .venue-checkbox {

--- a/frontend/css/styles.css
+++ b/frontend/css/styles.css
@@ -525,17 +525,18 @@ a:hover { color: var(--accent-hover); text-decoration: underline; }
    unconnected visitor sees no gap. */
 .quick-filters:not(:empty) { margin-bottom: 0.6rem; }
 
-.city-group-head { display: flex; align-items: stretch; gap: 0.3rem; }
-/* The chip fills the row so the whole width is a city filter target, and the caret
-   stays a separate, smaller hit area — one row, two distinct actions. */
+.city-group-head { display: flex; align-items: center; gap: 0.3rem; }
+/* The chip fills the row so the whole width is a city filter target, with the caret a
+   separate leading hit area — one row, two distinct actions that can't steal each
+   other's clicks. */
 .city-group-head .city-chip { flex: 1 1 auto; text-align: left; }
 
+/* Disclosure caret, leading the row like a tree view. */
 .city-collapse {
   flex-shrink: 0;
   display: flex;
   align-items: center;
-  justify-content: flex-end;
-  gap: 0.3rem;
+  justify-content: center;
   background: none;
   border: 1px solid transparent;
   border-radius: 1px;
@@ -544,28 +545,41 @@ a:hover { color: var(--accent-hover); text-decoration: underline; }
      measures 1.83:1 against --surface in dark mode — under the 3:1 an interactive
      element needs. --dim is fine for inert decoration, not for this. */
   color: var(--muted);
-  font-family: 'Space Mono', monospace;
-  font-size: 0.6rem;
-  /* min-height carries the hit target to 24px; padding alone left it at 22. */
+  /* 0.6rem was legible only if you already knew it was there. */
+  font-size: 0.95rem;
+  line-height: 1;
+  /* Square, and at the 24px hit-target minimum. */
+  width: 24px;
   min-height: 24px;
-  min-width: 34px;
-  padding: 0 0.35rem;
+  padding: 0;
   transition: color 0.12s, border-color 0.12s;
 }
 .city-collapse:hover { color: var(--accent); border-color: var(--border); }
 .city-collapse:focus-visible { outline: 1px solid var(--accent); outline-offset: 1px; }
 
-.city-count { font-variant-numeric: tabular-nums; opacity: 0.75; }
+/* Venue count — a readout, not a control, so it sits outside both buttons. */
+.city-count {
+  flex-shrink: 0;
+  font-family: 'Space Mono', monospace;
+  font-size: 0.6rem;
+  font-variant-numeric: tabular-nums;
+  color: var(--muted);
+  opacity: 0.75;
+  min-width: 1.4em;
+  text-align: right;
+}
+
 .city-caret { display: inline-block; transition: transform 0.15s ease; }
 .city-group.collapsed .city-caret { transform: rotate(-90deg); }
 
-/* Venues indented under their city, with a rule tying them to the group. */
+/* Venues indented under their city. The rule is positioned to descend from the middle
+   of the 24px caret, so it reads as a tree line rather than an arbitrary margin. */
 .city-venues {
   display: flex;
   flex-direction: column;
   gap: 0.35rem;
-  padding: 0.4rem 0 0.1rem 0.55rem;
-  margin-left: 0.2rem;
+  padding: 0.4rem 0 0.1rem 0.8rem;
+  margin-left: 11px;
   border-left: 1px solid var(--border);
 }
 

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -80,16 +80,18 @@
         <p class="eq-readout" id="eq-readout" aria-live="polite"></p>
       </div>
 
-      <!-- City Filter -->
+      <!-- Cities & Venues.
+           Replaces the former separate "City" chip row and flat "Venues" list: every
+           venue belongs to a city, so the venues now sit under theirs and each city
+           collapses. Rendered together by renderVenueFilters() in js/filters.js.
+           #venue-filters keeps its id because _updateVenueRestoreBtn() appends to it. -->
       <div class="filter-section">
-        <div class="filter-label">City</div>
-        <div class="chip-group" id="city-filters"></div>
-      </div>
-
-      <!-- Venue Filter -->
-      <div class="filter-section">
-        <div class="filter-label">Venues</div>
-        <div class="venue-list" id="venue-filters"></div>
+        <div class="filter-label">Cities &amp; Venues</div>
+        <!-- Cross-cutting chips that aren't a city — currently only Spotify's
+             "★ for you", appended here by js/spotify.js. Collapses to zero height
+             while empty. -->
+        <div class="chip-group quick-filters" id="quick-filters"></div>
+        <div class="city-groups" id="venue-filters"></div>
         <button class="btn-subscribe-venues" onclick="subscribeToVenues()">↗ get a cal for these venues</button>
         <p class="subscribe-hint">new shows will appear automatically!</p>
       </div>

--- a/frontend/js/filters.js
+++ b/frontend/js/filters.js
@@ -19,6 +19,60 @@ let activeFilters = {
 // so we never call setProp on EventImpl objects during filter passes.
 let _allEventsCache = [];
 
+// ── Collapsed city groups ─────────────────────────────────────────────────────
+//
+// Which city groups are folded shut in the sidebar. Purely presentational: collapsing
+// a city must never change which events are shown, or the calendar would silently
+// disagree with the filters the visitor can see. Persisted because every other
+// sidebar toggle is.
+const COLLAPSED_CITIES_KEY = "triangle-shows-collapsed-cities";
+
+function getCollapsedCities() {
+  try { return new Set(JSON.parse(localStorage.getItem(COLLAPSED_CITIES_KEY) || "[]")); }
+  catch { return new Set(); }
+}
+
+function saveCollapsedCities(set) {
+  try { localStorage.setItem(COLLAPSED_CITIES_KEY, JSON.stringify([...set])); }
+  catch { /* private browsing: the fold still works, it just won't persist */ }
+}
+
+// City names go into element ids, so reduce them to something id-safe.
+function _citySlug(city) {
+  return String(city).toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-|-$/g, "");
+}
+
+function toggleCityCollapse(city) {
+  const collapsed = getCollapsedCities();
+  if (collapsed.has(city)) collapsed.delete(city);
+  else                     collapsed.add(city);
+  saveCollapsedCities(collapsed);
+
+  const group = document.querySelector(`.city-group[data-city="${city}"]`);
+  if (!group) return;
+
+  const isCollapsed = collapsed.has(city);
+  group.classList.toggle("collapsed", isCollapsed);
+
+  const btn = group.querySelector(".city-collapse");
+  if (btn) {
+    btn.setAttribute("aria-expanded", isCollapsed ? "false" : "true");
+    btn.setAttribute("aria-label", `${isCollapsed ? "Expand" : "Collapse"} ${city} venues`);
+  }
+  // Deliberately no applyAllFilters() — see the note on COLLAPSED_CITIES_KEY.
+}
+
+// The count on a city header is "venues you can see here", so it has to be refreshed
+// when one is hidden rather than only on a full re-render.
+function _updateCityCounts() {
+  document.querySelectorAll(".city-group").forEach((group) => {
+    const count = group.querySelectorAll(".venue-checkbox").length;
+    const el = group.querySelector(".city-count");
+    if (el) el.textContent = String(count);
+  });
+}
+
+
 // ── Hidden venues ─────────────────────────────────────────────────────────────
 const HIDDEN_VENUES_KEY = "triangle-shows-hidden-venues";
 
@@ -32,7 +86,12 @@ function hideVenue(slug) {
   hidden.add(slug);
   localStorage.setItem(HIDDEN_VENUES_KEY, JSON.stringify([...hidden]));
   const label = document.querySelector(`.venue-checkbox input[data-venue="${slug}"]`)?.closest(".venue-checkbox");
+  const group = label?.closest(".city-group");
   if (label) label.remove();
+  // Drop a city whose last visible venue just went. An empty group still showing a
+  // live filter chip reads as a rendering bug.
+  if (group && !group.querySelector(".venue-checkbox")) group.remove();
+  _updateCityCounts();
   _updateVenueRestoreBtn();
   applyAllFilters();
   updateCityChipStates();
@@ -77,32 +136,22 @@ async function loadVenues(attempt = 0) {
 }
 
 function renderFilters() {
-  renderCityFilters();
+  // Cities and venues render together now — the city rows are the group headers.
   renderVenueFilters();
   setupSearch();
 
   updateCityChipStates();
 }
 
-function renderCityFilters() {
-  const container = document.getElementById("city-filters");
-  const cities = [...new Set(venues.map((v) => v.city))].sort();
-
-  container.innerHTML = cities
-    .map((city) => {
-      const colors = CITY_COLORS[city] || {};
-      const border = colors.border || "var(--dim)";
-      const activeBg = colors.activeBg || "var(--accent-bg)";
-      return `<button class="chip city-chip" data-city="${city}"
-        style="--chip-border: ${border}; --chip-active-bg: ${activeBg}"
-        onclick="toggleCity('${city}')">${city}</button>`;
-    })
-    .join("");
-}
-
+// Render every city as a collapsible group with its venues nested underneath.
+//
+// The city header keeps the `.city-chip` class and `data-city`, and each venue keeps
+// `data-venue-city`, so toggleCity() and updateCityChipStates() work against this
+// markup unchanged — they query by those attributes, not by position.
 function renderVenueFilters() {
   const container = document.getElementById("venue-filters");
   const hidden = getHiddenVenues();
+  const collapsed = getCollapsedCities();
 
   // Preserve which venues are currently checked so restoring a hidden venue
   // doesn't reset other venues' selected/unselected state.
@@ -112,21 +161,51 @@ function renderVenueFilters() {
   });
   const hasExistingState = currentChecked.size > 0;
 
-  container.innerHTML = venues
-    .filter((v) => !hidden.has(v.slug))
-    .map((v) => {
-      // Newly-visible venues (just restored) default to checked.
-      // Existing venues preserve their prior state.
-      const isChecked = !hasExistingState || currentChecked.has(v.slug) || !document.querySelector(`[data-venue="${v.slug}"]`);
+  const shown = venues.filter((v) => !hidden.has(v.slug));
+  // A city with every venue hidden gets no group at all, rather than an empty one.
+  const cities = [...new Set(shown.map((v) => v.city))].sort();
+
+  container.innerHTML = cities
+    .map((city) => {
+      const colors   = CITY_COLORS[city] || {};
+      const border   = colors.border   || "var(--dim)";
+      const activeBg = colors.activeBg || "var(--accent-bg)";
+      const cityVenues  = shown.filter((v) => v.city === city);
+      const isCollapsed = collapsed.has(city);
+      const venuesId    = `city-venues-${_citySlug(city)}`;
+
+      const rows = cityVenues
+        .map((v) => {
+          // Newly-visible venues (just restored) default to checked.
+          // Existing venues preserve their prior state.
+          const isChecked = !hasExistingState || currentChecked.has(v.slug) || !document.querySelector(`[data-venue="${v.slug}"]`);
+          return `
+        <label class="venue-checkbox" data-venue-city="${city}">
+          <input type="checkbox" data-venue="${v.slug}" ${isChecked ? "checked" : ""} onchange="toggleVenue('${v.slug}')">
+          <span class="venue-dot" style="background-color: ${v.color}"></span>
+          <span class="venue-label">${v.name}</span>
+          <button class="venue-hide-btn" data-slug="${v.slug}" tabindex="-1" aria-label="Hide ${v.name}">✕</button>
+        </label>`;
+        })
+        .join("");
+
       return `
-      <label class="venue-checkbox" data-venue-city="${v.city}">
-        <input type="checkbox" data-venue="${v.slug}" ${isChecked ? "checked" : ""} onchange="toggleVenue('${v.slug}')">
-        <span class="venue-dot" style="background-color: ${v.color}"></span>
-        <span class="venue-label">${v.name}</span>
-        <button class="venue-hide-btn" data-slug="${v.slug}" tabindex="-1" aria-label="Hide ${v.name}">✕</button>
-      </label>`;
+      <div class="city-group${isCollapsed ? " collapsed" : ""}" data-city="${city}">
+        <div class="city-group-head">
+          <button class="chip city-chip" data-city="${city}"
+                  style="--chip-border: ${border}; --chip-active-bg: ${activeBg}"
+                  onclick="toggleCity('${city}')">${city}</button>
+          <button class="city-collapse" data-city="${city}"
+                  aria-expanded="${isCollapsed ? "false" : "true"}"
+                  aria-controls="${venuesId}"
+                  aria-label="${isCollapsed ? "Expand" : "Collapse"} ${city} venues"
+                  onclick="toggleCityCollapse('${city}')"><span class="city-count">${cityVenues.length}</span><span class="city-caret" aria-hidden="true">▾</span></button>
+        </div>
+        <div class="city-venues" id="${venuesId}">${rows}</div>
+      </div>`;
     })
     .join("");
+
   container.querySelectorAll(".venue-hide-btn").forEach((btn) => {
     btn.addEventListener("click", function (e) {
       e.preventDefault();

--- a/frontend/js/filters.js
+++ b/frontend/js/filters.js
@@ -27,9 +27,22 @@ let _allEventsCache = [];
 // sidebar toggle is.
 const COLLAPSED_CITIES_KEY = "triangle-shows-collapsed-cities";
 
-function getCollapsedCities() {
-  try { return new Set(JSON.parse(localStorage.getItem(COLLAPSED_CITIES_KEY) || "[]")); }
+// The persisted list, or null when the visitor has never folded anything.
+function _storedCollapsedCities() {
+  const raw = localStorage.getItem(COLLAPSED_CITIES_KEY);
+  if (raw === null) return null;
+  try { return new Set(JSON.parse(raw)); }
   catch { return new Set(); }
+}
+
+// Which cities are folded shut. Everything starts folded: the point of grouping is to
+// shorten the sidebar, and four headers plus twenty-two rows is *longer* than the flat
+// list this replaced. Once the visitor folds or unfolds anything, their explicit choice
+// is stored and used instead.
+function getCollapsedCities() {
+  const stored = _storedCollapsedCities();
+  if (stored) return stored;
+  return new Set(venues.map((v) => v.city));
 }
 
 function saveCollapsedCities(set) {
@@ -56,8 +69,12 @@ function toggleCityCollapse(city) {
 
   const btn = group.querySelector(".city-collapse");
   if (btn) {
+    const n = group.querySelectorAll(".venue-checkbox").length;
     btn.setAttribute("aria-expanded", isCollapsed ? "false" : "true");
-    btn.setAttribute("aria-label", `${isCollapsed ? "Expand" : "Collapse"} ${city} venues`);
+    btn.setAttribute(
+      "aria-label",
+      `${isCollapsed ? "Expand" : "Collapse"} ${city}, ${n} venue${n === 1 ? "" : "s"}`
+    );
   }
   // Deliberately no applyAllFilters() — see the note on COLLAPSED_CITIES_KEY.
 }
@@ -189,17 +206,21 @@ function renderVenueFilters() {
         })
         .join("");
 
+      // Caret first so it reads as the disclosure control for the row, the way a
+      // tree view does. The count is a plain span rather than part of either button —
+      // it's a readout, and putting it inside the caret's hit area implied otherwise.
       return `
       <div class="city-group${isCollapsed ? " collapsed" : ""}" data-city="${city}">
         <div class="city-group-head">
-          <button class="chip city-chip" data-city="${city}"
-                  style="--chip-border: ${border}; --chip-active-bg: ${activeBg}"
-                  onclick="toggleCity('${city}')">${city}</button>
           <button class="city-collapse" data-city="${city}"
                   aria-expanded="${isCollapsed ? "false" : "true"}"
                   aria-controls="${venuesId}"
-                  aria-label="${isCollapsed ? "Expand" : "Collapse"} ${city} venues"
-                  onclick="toggleCityCollapse('${city}')"><span class="city-count">${cityVenues.length}</span><span class="city-caret" aria-hidden="true">▾</span></button>
+                  aria-label="${isCollapsed ? "Expand" : "Collapse"} ${city}, ${cityVenues.length} venue${cityVenues.length === 1 ? "" : "s"}"
+                  onclick="toggleCityCollapse('${city}')"><span class="city-caret" aria-hidden="true">▾</span></button>
+          <button class="chip city-chip" data-city="${city}"
+                  style="--chip-border: ${border}; --chip-active-bg: ${activeBg}"
+                  onclick="toggleCity('${city}')">${city}</button>
+          <span class="city-count" aria-hidden="true">${cityVenues.length}</span>
         </div>
         <div class="city-venues" id="${venuesId}">${rows}</div>
       </div>`;

--- a/frontend/js/spotify.js
+++ b/frontend/js/spotify.js
@@ -197,7 +197,11 @@ function _onSpotifyReady() {
 }
 
 function _renderForYouChip() {
-  const chipGroup = document.getElementById("city-filters");
+  // #quick-filters is the row for chips that aren't a city. It used to be
+  // #city-filters, which no longer exists now that cities are group headers rather
+  // than a flat chip row; the fallback keeps this working against an older index.html.
+  const chipGroup = document.getElementById("quick-filters")
+                 || document.getElementById("city-filters");
   if (!chipGroup || document.getElementById("chip-for-you")) return;
   const chip = document.createElement("button");
   chip.id        = "chip-for-you";


### PR DESCRIPTION
The sidebar had a City chip row and a flat 22-item venue list as two unrelated sections, even though every venue belongs to exactly one city. Cities are now group headers with their venues nested underneath, and each group folds shut.

Live data is four cities: Chapel Hill-Carrboro (4), Durham (8), Raleigh (9), Saxapahaw (1).

## Collapse never touches the filter

This is the load-bearing part. `_getFilteredEvents()` builds its venue map straight from the DOM:

```js
document.querySelectorAll(".venue-checkbox input[type=checkbox]").forEach((cb) => {
  venueMap[cb.dataset.venue] = cb.checked;
});
```

So unmounting a collapsed city's inputs would silently drop those venues from the filter, and the calendar would disagree with a sidebar the visitor cannot see. Instead the venues hide with `display: none`, which keeps them queryable while removing them from layout and tab order — the same thing `.venue-checkbox input { display: none }` two rules below already relied on. `toggleCityCollapse()` also deliberately does not call `applyAllFilters()`.

Verified rather than assumed:

| Check | Result |
|---|---|
| Collapse Durham → checkboxes still found | 8/8 |
| Collapse Durham → still checked | 8/8 |
| Collapse Durham → visible events | 2475, unchanged |
| First visit, all four folded → visible events | 2475, unchanged |
| `toggleCity('Durham')` while folded | solos correctly, 2475 → 880 |

## Existing behaviour is untouched

`toggleCity()` and `updateCityChipStates()` are unchanged. They query by `[data-city]` and `[data-venue-city]`, both of which the new markup keeps, so the existing solo/restore logic survives — including on a folded group.

Also verified: hiding Saxapahaw's only venue removes the group rather than leaving an empty one above a live filter chip; hiding a Durham venue drops its count 8 → 7 and keeps the group; `restore hidden` brings back all 4 groups and 22 checkboxes; fold state survives reload with correct `aria-expanded`.

## A contrast bug found on the way

The caret first used `--dim`, which measures **1.83:1** against `--surface` in dark mode — under the 3:1 an interactive control needs. It's `--muted` now, which clears 3:1 in all ten palette/mode combinations (minimum 3.07 on durham/light). The hit target also went from 22px to 24px.

## Decisions

- **Cities default to folded.** Grouping was meant to shorten the sidebar, and four headers plus 22 rows is longer than the flat list it replaced. Folded, the section is four rows instead of twenty-six, which also brings the live-music toggle above the fold. The default is *computed*, not written — the fallback applies only while the storage key is absent, so a first fold or unfold records an explicit list and is respected from then on.
- **The chip filters, a separate leading caret folds.** One row, two actions that can't steal each other's clicks. The chip fills the row so the whole width is a city filter target.
- **The count is a readout, not a control** — a plain span outside both buttons. It's `aria-hidden` and folded into the caret's label instead ("Expand Durham, 8 venues"), so a screen reader gets the number in context rather than a bare "8".
- **Merged the two sections** into one "Cities & Venues". Keeping a separate chip row would have shown the same control twice.
- **Spotify's "★ for you" chip** moved to a new `#quick-filters` row, since `#city-filters` no longer exists once cities are headers. `spotify.js` keeps a fallback to the old id.
- **Deleted the now-unused `.venue-list` CSS** rather than leaving dead rules.

## Also checked

- Mobile at 390px: no horizontal overflow, row doesn't wrap, caret stays 24×24, order stays caret → chip → count
- `prefers-reduced-motion`: the caret rotation transition is dropped
- Backend suite: **249 passed, 4 skipped** (frontend-only change, but `index.html` is asserted against by the asset-versioning tests from #73)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
