### PR TITLE
Add a "only my shows" toggle, and make the tile icons legible

### DIFF
--- a/frontend/css/styles.css
+++ b/frontend/css/styles.css
@@ -190,28 +190,29 @@ html[data-mode="light"][data-palette="wisteria"] {
   --eq-fav-hover: #12617f;
 }
 
-/* Pressed background for the favourites-only button.
-   Deliberately NOT --eq-fav, though it is the same colour family and follows the same
-   wisteria swap. --eq-fav is tuned as a *graphic* against the 3:1 floor, because it
-   paints equalizer bars. Here it would sit behind 0.62rem uppercase text, which needs
-   4.5:1 — and the light-mode --eq-fav values measure 3.37 to 4.05, so reusing them
-   failed in all five light palettes. These are the same hues taken darker until the
-   button label clears 4.5:1 everywhere (worst case 4.73, durham/light). */
+/* The "strong" favourite colour: same hue family as --eq-fav, taken darker.
+   Used by the favourites-only button's pressed background and by a hearted heart icon
+   on an event tile. Both need something --eq-fav cannot give them, for the same reason:
+   --eq-fav is tuned as a *graphic* sitting on --bg, because it paints equalizer bars.
+   Against a tile (--surface2) or behind button text it is too light — measured at
+   3.37-4.05 behind the button label (needs 4.5) and 2.64-2.96 as a heart on a light
+   tile (needs 3). These values clear both floors everywhere: worst 4.73 for the button
+   label and 3.70 for the heart, both on durham/light. */
 :root {
-  --fav-btn-bg:       #ff8fa8;
-  --fav-btn-bg-hover: #ffb3c4;
+  --fav-strong:       #ff8fa8;
+  --fav-strong-hover: #ffb3c4;
 }
 html[data-mode="light"] {
-  --fav-btn-bg:       #b83a5c;
-  --fav-btn-bg-hover: #9c2a48;
+  --fav-strong:       #b83a5c;
+  --fav-strong-hover: #9c2a48;
 }
 html[data-palette="wisteria"] {
-  --fav-btn-bg:       #8ad5f0;
-  --fav-btn-bg-hover: #b0e6f8;
+  --fav-strong:       #8ad5f0;
+  --fav-strong-hover: #b0e6f8;
 }
 html[data-mode="light"][data-palette="wisteria"] {
-  --fav-btn-bg:       #12617f;
-  --fav-btn-bg-hover: #0d4d66;
+  --fav-strong:       #12617f;
+  --fav-strong-hover: #0d4d66;
 }
 
 /* Durham Bulls light: warm desaturated brown bg, navy text */
@@ -849,7 +850,7 @@ a:hover { color: var(--accent-hover); text-decoration: underline; }
   position: relative;
   display: flex;
   flex-direction: column;
-  padding: 2px 32px 2px 4px; /* right padding reserves space for heart + hide */
+  padding: 2px 44px 2px 4px; /* right padding reserves space for heart + hide */
   overflow: hidden;
 }
 /* Event title.
@@ -885,49 +886,57 @@ a:hover { color: var(--accent-hover); text-decoration: underline; }
   text-overflow: ellipsis;
 }
 
-/* Heart / favorite button — shows on hover, 20% bigger than original */
+/* Heart / favorite button — revealed when the tile is hovered.
+   Colors are palette tokens, not the hardcoded rgba(255,255,255,…) they used to be.
+   That white was correct while tiles were saturated dark fills; once the gutter
+   treatment moved tile text onto --surface2 it became near-invisible in light mode. */
 .ev-heart {
   position: absolute;
   top: 50%;
-  right: 17px;
+  right: 24px;
   transform: translateY(-50%);
   background: none;
   border: none;
   cursor: pointer;
-  font-size: 0.84rem;
+  font-size: 0.95rem;
   line-height: 1;
-  color: rgba(255,255,255,0.5);
-  padding: 1px 2px;
+  color: var(--muted);
+  padding: 2px 3px;
   opacity: 0;
   transition: opacity 0.15s, color 0.12s;
   z-index: 1;
   user-select: none;
 }
 .ev:hover .ev-heart        { opacity: 1; }
-.ev-heart.hearted          { opacity: 1 !important; color: #ff8fa8; }
-.ev-heart:hover            { color: rgba(255,255,255,0.9); }
-.ev-heart.hearted:hover    { color: #ff5580; }
+/* --fav-strong rather than a literal #ff8fa8, and rather than --eq-fav: the token
+   carries the light-mode and wisteria variants, so a hearted show stays visible on warm
+   paper and stops clashing on the pink palette. --eq-fav itself measures only 2.64-2.96
+   against a light tile, because it is tuned to sit on --bg rather than on --surface2. */
+.ev-heart.hearted          { opacity: 1 !important; color: var(--fav-strong); }
+.ev-heart:hover            { color: var(--accent); }
+.ev-heart.hearted:hover    { color: var(--fav-strong-hover); }
 
 /* Hide button — dismiss event until page refresh */
 .ev-hide {
   position: absolute;
   top: 50%;
-  right: 2px;
+  right: 3px;
   transform: translateY(-50%);
   background: none;
   border: none;
   cursor: pointer;
-  font-size: 0.62rem;
+  /* Was 0.62rem — roughly 10px, and the smallest interactive thing on the page. */
+  font-size: 0.78rem;
   line-height: 1;
-  color: rgba(255,255,255,0.4);
-  padding: 1px 2px;
+  color: var(--muted);
+  padding: 2px 3px;
   opacity: 0;
   transition: opacity 0.15s, color 0.12s;
   z-index: 1;
   user-select: none;
 }
 .ev:hover .ev-hide  { opacity: 1; }
-.ev-hide:hover      { color: rgba(255,255,255,0.9); }
+.ev-hide:hover      { color: var(--accent); }
 
 /* Past events — greyed out */
 .fc-event.ev-past { opacity: 0.45; }
@@ -1181,14 +1190,14 @@ a:hover { color: var(--accent-hover); text-decoration: underline; }
    button in the heart pink rather than another accent outline, which also stops it
    reading as "hovered". */
 .btn-favorites-only.active {
-  background: var(--fav-btn-bg);
-  border-color: var(--fav-btn-bg);
+  background: var(--fav-strong);
+  border-color: var(--fav-strong);
   color: var(--bg);
   opacity: 1;
 }
 .btn-favorites-only.active:hover {
-  background: var(--fav-btn-bg-hover);
-  border-color: var(--fav-btn-bg-hover);
+  background: var(--fav-strong-hover);
+  border-color: var(--fav-strong-hover);
   color: var(--bg);
 }
 .btn-favorites-only:focus-visible,
@@ -1275,8 +1284,10 @@ a:hover { color: var(--accent-hover); text-decoration: underline; }
 
   /* List view: clip overflow on mobile; title fills all available width */
   .fc { overflow: hidden; }
-  /* Reduce ev right padding on mobile */
-  .ev { padding-right: 20px; }
+  /* Mobile reserves less than desktop, but 20px was under the icons' own width even
+     before they grew — and on mobile they are permanently visible rather than
+     hover-revealed, so a title running underneath them is guaranteed, not occasional. */
+  .ev { padding-right: 40px; }
 
   /* Ko-fi: hide from header, show at bottom of sidebar */
   .app-header .kofi-wrap { display: none; }
@@ -1300,8 +1311,8 @@ a:hover { color: var(--accent-hover); text-decoration: underline; }
   .palette-btn { width: 26px; height: 26px; }
 
   /* Heart + hide: always slightly visible on mobile (no real hover) */
-  .ev-heart { opacity: 0.4; font-size: 0.84rem; }
-  .ev-hide  { opacity: 0.3; }
+  .ev-heart { opacity: 0.75; font-size: 0.95rem; }
+  .ev-hide  { opacity: 0.6;  font-size: 0.78rem; }
   .venue-hide-btn { opacity: 0.3; }
 
   /* Bottom bar: left edge on mobile (sidebar is hidden) */
@@ -1319,9 +1330,10 @@ html[data-mode="light"] .modal-overlay {
 /* Light mode: list view needs dark text (events have no colored bg in list view) */
 html[data-mode="light"] .fc-list-event .ev-title { color: var(--text); }
 html[data-mode="light"] .fc-list-event .ev-venue { color: var(--muted); }
-html[data-mode="light"] .fc-list-event .ev-heart { color: rgba(0,0,0,0.35); }
-html[data-mode="light"] .fc-list-event .ev-hide  { color: rgba(0,0,0,0.25); }
-html[data-mode="light"] .venue-hide-btn          { color: rgba(0,0,0,0.35); }
+/* The .ev-heart / .ev-hide light-mode overrides that were here are gone: they existed
+   only to undo a hardcoded white base, and the base is now --muted, which is already
+   palette- and mode-correct. */
+html[data-mode="light"] .venue-hide-btn          { color: var(--muted); }
 
 /* Light mode needs nothing special for daygrid events now. The block that used to live
    here put them on --surface2 and colored the title with the venue color, to rescue the
@@ -1479,10 +1491,10 @@ html[data-mode="light"] .fc .fc-list-event .ev {
 .fc .fc-daygrid-event:hover {
   background-color: color-mix(in srgb, var(--venue-color, var(--accent)) 14%, var(--surface2)) !important;
 }
-.fc .fc-daygrid-event .ev-heart,
-.fc .fc-daygrid-event .ev-hide {
-  color: var(--dim);
-}
+/* No daygrid-specific colour for the icons any more. This block set them to --dim,
+   which measures 1.83:1 against --surface2 in dark mode -- under the 3:1 an interactive
+   control needs, and the reason they were hard to read on hover. The base .ev-heart /
+   .ev-hide rules now use --muted, which works in both modes. */
 
 /* The list view's own dot is drawn by FullCalendar from the event's border color, which
    is the unbrightened seed value -- same invisibility problem on a dark surface. */

--- a/frontend/css/styles.css
+++ b/frontend/css/styles.css
@@ -190,6 +190,30 @@ html[data-mode="light"][data-palette="wisteria"] {
   --eq-fav-hover: #12617f;
 }
 
+/* Pressed background for the favourites-only button.
+   Deliberately NOT --eq-fav, though it is the same colour family and follows the same
+   wisteria swap. --eq-fav is tuned as a *graphic* against the 3:1 floor, because it
+   paints equalizer bars. Here it would sit behind 0.62rem uppercase text, which needs
+   4.5:1 — and the light-mode --eq-fav values measure 3.37 to 4.05, so reusing them
+   failed in all five light palettes. These are the same hues taken darker until the
+   button label clears 4.5:1 everywhere (worst case 4.73, durham/light). */
+:root {
+  --fav-btn-bg:       #ff8fa8;
+  --fav-btn-bg-hover: #ffb3c4;
+}
+html[data-mode="light"] {
+  --fav-btn-bg:       #b83a5c;
+  --fav-btn-bg-hover: #9c2a48;
+}
+html[data-palette="wisteria"] {
+  --fav-btn-bg:       #8ad5f0;
+  --fav-btn-bg-hover: #b0e6f8;
+}
+html[data-mode="light"][data-palette="wisteria"] {
+  --fav-btn-bg:       #12617f;
+  --fav-btn-bg-hover: #0d4d66;
+}
+
 /* Durham Bulls light: warm desaturated brown bg, navy text */
 html[data-mode="light"][data-palette="durham"] {
   --bg:           #f5ece0;
@@ -1122,6 +1146,7 @@ a:hover { color: var(--accent-hover); text-decoration: underline; }
   transform: translateY(0);
 }
 
+.btn-favorites-only,
 .btn-download-shows,
 .btn-restore-hidden {
   display: inline-block;
@@ -1139,6 +1164,7 @@ a:hover { color: var(--accent-hover); text-decoration: underline; }
   transition: background 0.15s, color 0.15s;
   opacity: 0.72;
 }
+.btn-favorites-only:hover,
 .btn-download-shows:hover,
 .btn-restore-hidden:hover {
   background: var(--accent);
@@ -1147,6 +1173,30 @@ a:hover { color: var(--accent-hover); text-decoration: underline; }
 }
 /* Restore button: slightly subdued by default */
 .btn-restore-hidden { opacity: 0.55; }
+
+/* Favourites-only toggle.
+   The other two buttons are actions — press and something happens. This one is a mode,
+   and the pressed state has to be unmistakable: a filtered calendar that looks
+   unfiltered is the failure worth designing against. So the active state is a filled
+   button in the heart pink rather than another accent outline, which also stops it
+   reading as "hovered". */
+.btn-favorites-only.active {
+  background: var(--fav-btn-bg);
+  border-color: var(--fav-btn-bg);
+  color: var(--bg);
+  opacity: 1;
+}
+.btn-favorites-only.active:hover {
+  background: var(--fav-btn-bg-hover);
+  border-color: var(--fav-btn-bg-hover);
+  color: var(--bg);
+}
+.btn-favorites-only:focus-visible,
+.btn-download-shows:focus-visible,
+.btn-restore-hidden:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
 
 /* First-appear bounce for the buttons */
 .favorites-bar.visible .btn-download-shows,

--- a/frontend/css/styles.css
+++ b/frontend/css/styles.css
@@ -853,6 +853,20 @@ a:hover { color: var(--accent-hover); text-decoration: underline; }
   padding: 2px 44px 2px 4px; /* right padding reserves space for heart + hide */
   overflow: hidden;
 }
+
+/* Only reserve room for the icons while they are actually on screen.
+   The icons are absolutely positioned, so changing this padding re-ellipsizes the title
+   without resizing the tile — nothing around it moves, the text just gets shorter. That
+   buys back roughly a character and a half in every month cell for the 99% of the time
+   the pointer is elsewhere.
+   Gated on (hover: hover) rather than a width: on touch devices the icons are permanently
+   visible, so the reserve has to be permanent too, and there is no hover to restore it.
+   Selector carries .fc to reach (0,2,0), so it wins over the width-based .ev override in
+   the responsive block below regardless of source order. */
+@media (hover: hover) {
+  .fc .ev          { padding-right: 6px; }
+  .fc .ev:hover    { padding-right: 44px; }
+}
 /* Event title.
    Was Space Mono 700 at 12px, which is the readability complaint that started this branch.
    Bold works against a monospace at this size: Space Mono's counters are tight to begin
@@ -1284,10 +1298,10 @@ a:hover { color: var(--accent-hover); text-decoration: underline; }
 
   /* List view: clip overflow on mobile; title fills all available width */
   .fc { overflow: hidden; }
-  /* Mobile reserves less than desktop, but 20px was under the icons' own width even
-     before they grew — and on mobile they are permanently visible rather than
-     hover-revealed, so a title running underneath them is guaranteed, not occasional. */
-  .ev { padding-right: 40px; }
+  /* List view keeps the reserve: the icons are permanently visible here (no hover to
+     reveal them), and titles wrap rather than truncate, so the reserve costs a little
+     line width and never hides text. 20px used to be under the icons' own width. */
+  .fc-list-event .ev { padding-right: 40px; }
 
   /* Ko-fi: hide from header, show at bottom of sidebar */
   .app-header .kofi-wrap { display: none; }
@@ -1317,6 +1331,19 @@ a:hover { color: var(--accent-hover); text-decoration: underline; }
 
   /* Bottom bar: left edge on mobile (sidebar is hidden) */
   .favorites-bar { left: 0.75rem; }
+}
+
+/* Month view on a phone: drop the icons entirely.
+   A day cell is ~52px there and a tile ~47px, so two permanently-visible controls plus
+   a title does not fit — measured, the title was allotted 0px and the tile rendered as
+   nothing but a heart and a cross. The month grid on a phone is a density overview;
+   hearting and hiding belong to the list view, which is the default at that width
+   anyway. Also gated on (hover: none) so a merely narrow desktop window keeps its
+   hover-revealed icons instead of losing them. */
+@media (max-width: 768px) and (hover: none) {
+  .fc-daygrid-event .ev-heart,
+  .fc-daygrid-event .ev-hide { display: none; }
+  .fc-daygrid-event .ev { padding-right: 4px; }
 }
 
 /* Light mode: darken the modal overlay slightly less */

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -155,6 +155,10 @@
 
   <!-- Bottom-left utility bar: appears when shows are hearted or hidden -->
   <div class="favorites-bar" id="favorites-bar">
+    <!-- A view toggle, so it sits above the export action. aria-pressed rather than a
+         plain button: it has an on/off state, and the label alone doesn't convey which. -->
+    <button class="btn-favorites-only" id="btn-favorites-only" aria-pressed="false"
+            onclick="toggleFavoritesOnly()">♡ only my shows</button>
     <button class="btn-download-shows" onclick="downloadFavorites()">↓ download my shows</button>
     <button class="btn-restore-hidden" id="btn-restore-hidden" onclick="restoreHidden()">↺ restore hidden</button>
   </div>

--- a/frontend/js/favorites.js
+++ b/frontend/js/favorites.js
@@ -22,9 +22,18 @@ function toggleFavorite(eventId, eventData) {
   saveFavorites(favs);
   _refreshHeartUI(eventId, !!favs[eventId]);
   updateBottomBar();
-  // Repaint the equalizer so the hearted portion of each bar tracks the change
-  // immediately, rather than waiting for the next calendar refetch.
-  if (window.Equalizer && typeof window.Equalizer.refresh === "function") {
+
+  const favOnly = typeof activeFilters === "object" && !!activeFilters.favoritesOnly;
+  if (favOnly && typeof applyAllFilters === "function") {
+    // In the favourites-only view this heart changes which events belong on screen, so
+    // the calendar has to be re-filtered — otherwise an un-hearted show just sits there.
+    // The re-filter feeds the equalizer with the new visible set on its way through
+    // app.js, so refreshing the equalizer here first would only render a set that is
+    // about to be replaced.
+    applyAllFilters();
+  } else if (window.Equalizer && typeof window.Equalizer.refresh === "function") {
+    // Outside that view the visible set is unchanged and only the hearted portion of
+    // each bar needs repainting, which is far cheaper than a full re-filter.
     window.Equalizer.refresh();
   }
 }
@@ -94,13 +103,29 @@ function updateBottomBar() {
 
   const favCount = Object.keys(getFavorites()).length;
   const hidCount = Object.keys(getHidden()).length;
+  const favOnly  = typeof activeFilters === "object" && !!activeFilters.favoritesOnly;
 
-  bar.classList.toggle("visible", favCount > 0 || hidCount > 0);
+  // `|| favOnly` is load-bearing. This bar holds the only control for the
+  // favourites-only view, so it has to stay up while that view is on — including after
+  // the last favourite is un-hearted. Without it, removing your final show hides the
+  // bar and strands you on a filtered, empty calendar with nothing to switch off.
+  bar.classList.toggle("visible", favCount > 0 || hidCount > 0 || favOnly);
 
   const dlBtn = bar.querySelector(".btn-download-shows");
   if (dlBtn) {
     dlBtn.style.display = favCount > 0 ? "" : "none";
     dlBtn.textContent   = `↓ download my shows (${favCount})`;
+  }
+
+  const onlyBtn = document.getElementById("btn-favorites-only");
+  if (onlyBtn) {
+    // Same reasoning as the bar itself: stays visible while the view is on even at
+    // zero favourites, so it can always be turned back off.
+    onlyBtn.style.display = favCount > 0 || favOnly ? "" : "none";
+    // The count explains an empty calendar at a glance — "(0)" is why nothing is here.
+    onlyBtn.textContent = `${favOnly ? "♥" : "♡"} only my shows (${favCount})`;
+    onlyBtn.classList.toggle("active", favOnly);
+    onlyBtn.setAttribute("aria-pressed", favOnly ? "true" : "false");
   }
 
   const restoreBtn = document.getElementById("btn-restore-hidden");

--- a/frontend/js/favorites.js
+++ b/frontend/js/favorites.js
@@ -10,8 +10,25 @@ function getFavorites() {
   try { return JSON.parse(localStorage.getItem(FAVORITES_KEY) || "{}"); }
   catch { return {}; }
 }
+// Returns false when the store refused the write, so callers can avoid showing a heart
+// that was never saved.
+//
+// getFavorites() already tolerates unreadable storage; this side did not, so a throw
+// propagated straight out of toggleFavorite() and skipped the UI update, leaving the
+// heart, the bar and the equalizer disagreeing with each other.
+//
+// Capacity is not the likely trigger. Measured against all 2771 events currently in the
+// database, a stored favourite averages 247 bytes, so a 5 MB origin quota holds roughly
+// 21,000 of them and hearting literally every event would use about 13%. What does throw
+// regardless of size is a private-browsing window or a browser set to block site data.
 function saveFavorites(favs) {
-  localStorage.setItem(FAVORITES_KEY, JSON.stringify(favs));
+  try {
+    localStorage.setItem(FAVORITES_KEY, JSON.stringify(favs));
+    return true;
+  } catch (err) {
+    console.warn("Could not save favorites — storage refused the write:", err);
+    return false;
+  }
 }
 function isFavorited(eventId) { return !!getFavorites()[eventId]; }
 
@@ -19,7 +36,9 @@ function toggleFavorite(eventId, eventData) {
   const favs = getFavorites();
   if (favs[eventId]) { delete favs[eventId]; }
   else               { favs[eventId] = eventData; }
-  saveFavorites(favs);
+  // Bail before touching the UI if the write failed, so the heart never claims a
+  // favourite that was not stored.
+  if (!saveFavorites(favs)) return;
   _refreshHeartUI(eventId, !!favs[eventId]);
   updateBottomBar();
 

--- a/frontend/js/filters.js
+++ b/frontend/js/filters.js
@@ -12,6 +12,12 @@ let activeFilters = {
   search: "",
   forYou: false,
   includeNonMusic: localStorage.getItem(INCLUDE_NON_MUSIC_KEY) === "1",
+  // Deliberately NOT persisted, unlike includeNonMusic. That one is a standing
+  // preference ("I want to see trivia nights"); this is a transient "just show me
+  // mine" view. A view filter that survives a reload is how someone concludes the
+  // calendar is broken — they come back to a near-empty month and have no memory of
+  // switching anything on.
+  favoritesOnly: false,
 };
 
 // Cache of all events from the API (plain JS objects). Populated once on initial
@@ -278,6 +284,14 @@ function toggleForYou() {
 
 // Toggle whether non-live-music events (karaoke/trivia/theme nights/etc.) are shown.
 // Choice is persisted so it sticks across visits. Default (chip inactive) hides them.
+// Show only hearted shows. The button lives in the bottom-left favourites bar, so
+// updateBottomBar() is refreshed here to keep its label and pressed state in sync.
+function toggleFavoritesOnly() {
+  activeFilters.favoritesOnly = !activeFilters.favoritesOnly;
+  if (typeof updateBottomBar === "function") updateBottomBar();
+  applyAllFilters();
+}
+
 function toggleNonMusic() {
   activeFilters.includeNonMusic = !activeFilters.includeNonMusic;
   localStorage.setItem(INCLUDE_NON_MUSIC_KEY, activeFilters.includeNonMusic ? "1" : "0");
@@ -312,10 +326,28 @@ function _checkEventVisible(ev, venueMap) {
   // wouldn't be in venueMap and would otherwise pass through unchecked.
   if (SITE_CONFIG.city && props.venue_city !== SITE_CONFIG.city) return false;
 
+  const hearted = typeof isFavorited === "function" && isFavorited(ev.id);
+
+  // Favourites-only view. Composes with the venue and search filters below rather than
+  // overriding them, because those are explicit choices — unticking a venue should keep
+  // working even if you hearted something there.
+  if (activeFilters.favoritesOnly && !hearted) return false;
+
   // Non-live-music events (karaoke, trivia, theme nights, recurring series) are
   // hidden unless the visitor opts in via the toggle. Only an explicit `false`
   // hides — missing/true always shows, so unclassified data is never dropped.
-  if (!activeFilters.includeNonMusic && props.is_live_music === false) return false;
+  //
+  // Inside the favourites-only view a hearted show is exempt: the flag is the
+  // classifier's guess, and someone who deliberately hearted a karaoke night has
+  // overruled it. Without this the button could read "only my shows (5)" beside a
+  // calendar showing two — the kind of quiet disagreement that reads as a bug.
+  //
+  // Scoped to that view on purpose. Outside it the toggle keeps meaning "hide this
+  // category", so the normal calendar behaves exactly as before.
+  const exemptAsFavorite = activeFilters.favoritesOnly && hearted;
+  if (!activeFilters.includeNonMusic && props.is_live_music === false && !exemptAsFavorite) {
+    return false;
+  }
 
   // "For you" mode: show only Spotify-matched events, ignoring venue filters.
   if (activeFilters.forYou) {


### PR DESCRIPTION
Adds the "only my shows" toggle to the bottom-left favourites bar, and fixes three things about the heart and hide icons that surfaced while building it.

Four commits, each standalone — the last three can be dropped independently if you'd rather land just the feature.

## The toggle

It hovers in with the bar exactly as "download my shows" does. A mode rather than an action, so it takes `aria-pressed` and a **filled** pressed state instead of another accent outline — a filtered calendar that looks unfiltered is the failure worth designing against.

**The stranding case is the part worth reviewing.** This bar holds the view's only control, and it only renders when something is hearted or hidden. Un-hearting your last show would therefore hide the bar *and* the toggle, leaving you on an empty filtered calendar with no way out. The bar now stays up while the view is on regardless of count, and the label reads `♥ only my shows (0)` — which doubles as the explanation for the empty calendar, so no separate empty state is needed.

**Not persisted**, unlike `includeNonMusic`. That one is a standing preference; this is a transient "just show me mine" view, and a view filter that survives a reload is how someone returns to a near-empty month and concludes the site is broken.

**A hearted show is exempt from the live-music filter inside this view only.** Without it the button could read "only my shows (5)" beside a calendar showing two — that flag is the classifier's guess and an explicit heart overrules it. Scoped to the view deliberately: elsewhere the toggle keeps meaning "hide this category" and the normal calendar is unchanged.

Verified against the real filter path (not the pure function): 2475 events → 5 with only hearted rendered, the equalizer following (103 shows → "5 shows · 5 hearted"), un-hearting one dropping it immediately, un-hearting all leaving 0 events with the bar and button still reachable, and turning off restoring both the calendar and the original bars.

## Icons: bigger, and legible

Heart 13.4px → **15.2px**, hide ✕ 9.9px → **12.5px** (it had been the smallest interactive thing on the page).

Size was only half of it. The daygrid override added with the gutter treatment set both icons to `--dim`, which measures **1.83:1** against the tile in dark mode — under the 3:1 an interactive control needs, and the same mistake already fixed on the city caret. That block is gone; the base rules use `--muted` at **4.07:1**, so no daygrid-specific colour is needed at all.

The base colours were also hardcoded `rgba(255,255,255,…)`. Correct while tiles were saturated fills, but the gutter treatment moved tile text onto `--surface2` and the light-mode overrides that compensated were removed with the fill — so they were near-invisible in light mode regardless of hover. All palette tokens now.

A hearted heart takes `--fav-strong`, not `--eq-fav`. `--eq-fav` looks like the obvious token and is wrong: it's tuned to sit on `--bg` for the equalizer bars and measures 2.64–2.96 as a heart on a light tile. `--fav-btn-bg` was already the darker variant of that hue, so it's renamed `--fav-strong` and serves both the button's pressed background and this icon. Both clear their floors in all twenty palette/mode/state combinations — worst 4.73 for the button label, 3.70 for the heart.

## Titles get the full width until the icons appear

The icons are absolutely positioned, so the padding keeping a title off them only needs to exist while they're visible. On a pointer device it's now `6px` at rest and `44px` on hover, which re-ellipsizes the title without resizing the tile — nothing moves, the text just shortens.

Measured at 1100px: **91px / ~11 characters at rest** vs 53px / 6 while hovered. About five more characters whenever the pointer is elsewhere.

Gated on `(hover: hover)` rather than a width, since the real axis is whether hover exists. That raised the touch question, and checking found one case already fine and one genuinely broken:

- **Fine:** list view is the phone default and titles *wrap* there. A 119-character title renders over four lines, fully visible; the 40px reserve costs a little line width and hides no text. List view keeps it.
- **Broken:** month view on a phone. A day cell is 52px and a tile 47px, so the reserve left the title **0px** — the tile rendered as nothing but a heart and a cross. Icons are dropped in that combination and the reserve drops to 4px, giving ~4 characters. Cramped, but that's the limit of a seven-column grid at 390px, and hearting belongs to the list view there anyway.

## A storage bug, answering a question that came up

`saveFavorites()` called `localStorage.setItem` with no guard while `getFavorites()` has had a `try/catch` all along. A refused write threw straight out of `toggleFavorite()` and skipped everything after it, leaving the heart, the bar and the equalizer disagreeing about whether the show was saved.

Capacity is not the trigger, and it's worth recording since the question prompted this: it's **localStorage, not a cookie**. Measured across all 2771 events in the database, a stored favourite averages **247 bytes** (median 249, max 496) — so a 5 MB origin quota holds roughly **21,000** favourites, and hearting every event in the database would use about **13%** of it. A 4 KB cookie would hold about 16. What does throw regardless of size is a private-browsing window or a browser set to block site data.

`hideEvent()` and `restoreHidden()` have the same unguarded shape; left alone to keep the commit to the path this feature exercises.

## Notes

- Rebased onto `69f1427` after the button-text and footer-credit commits landed; `index.html` merged cleanly and both survive verbatim.
- Backend suite green: **249 passed, 4 skipped**.
- **One thing not empirically tested:** the mobile month-view rule carries `(hover: none)` alongside the width so a merely *narrow desktop window* keeps its hover-revealed icons. The preview tool couples widths under 768px to touch emulation, so `hover: hover` never reports true down there. Correct by construction, but worth narrowing a real browser window to confirm.
- Separately noticed and **not** fixed here: `applyAllFilters()` guards on a pending `requestAnimationFrame`, and rAF never fires in a non-compositing tab — so `_filterRafId` stays set and every later filter call returns early. It self-heals on foreground, so users mostly won't see it, but it makes filtering unreliable in a background tab. Pre-existing; happy to fix separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
