### PR TITLE
CSS + JS versioning; venue nesting; "my shows only" toggle; minor text adjustments

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -12,7 +12,9 @@ asyncpg-compatible PostgreSQL; Alembic migrations in backend/alembic/.
 # --- Imports ---
 import asyncio
 import logging
+import os
 from contextlib import asynccontextmanager
+from functools import lru_cache
 from pathlib import Path
 from typing import Optional
 
@@ -264,8 +266,92 @@ frontend_candidates = [
     Path(__file__).parent.parent.parent / "frontend",  # local dev
     Path("/frontend"),  # Docker
 ]
-for frontend_dir in frontend_candidates:
-    if frontend_dir.exists():
-        # Mounted last so API routes take priority over the catch-all html=True handler
-        app.mount("/", StaticFiles(directory=str(frontend_dir), html=True), name="frontend")
+
+_frontend_dir: Optional[Path] = None
+for candidate in frontend_candidates:
+    if candidate.exists():
+        _frontend_dir = candidate
         break
+
+
+# --- Asset versioning on index.html ---
+#
+# index.html references /css/*.css and /js/*.js at fixed URLs. Cloudflare caches those at
+# the edge for hours on the free plan, while index.html itself is never edge-cached
+# (cf-cache-status: DYNAMIC). After a deploy that combination serves *new* HTML against
+# *old* assets, which is worse than serving an entirely stale page: on the 2026-08-28
+# release the new markup loaded a new equalizer.js against a styles.css that had no rules
+# for it, and visitors got a row of unstyled buttons in the sidebar.
+#
+# Substituting {{ASSET_VERSION}} with the commit SHA gives every deploy fresh asset URLs,
+# so the edge treats them as new objects and there is nothing left to purge by hand.
+#
+# Done at request time from the env var rather than by rewriting the file at image build:
+# GIT_COMMIT is already in the container (cloudbuild.yaml passes it as a build arg,
+# Dockerfile promotes it to ENV, health.py reads it), and this way the checked-in
+# index.html stays a file that runs as-is in local dev.
+
+ASSET_VERSION_PLACEHOLDER = "{{ASSET_VERSION}}"
+
+
+def _asset_version() -> str:
+    """Cache-busting token for static asset URLs.
+
+    The commit SHA in production. Unset locally and in CI, where "dev" is correct: there is
+    no CDN in front of either, and the browser revalidates against the local server.
+    """
+    return os.environ.get("GIT_COMMIT", "dev")[:12]
+
+
+@lru_cache(maxsize=1)
+def _index_html() -> Optional[str]:
+    """index.html with the asset version substituted, read once per container.
+
+    Cached because neither the file nor GIT_COMMIT changes within the life of a container.
+    Returns None when there is no frontend directory, which is the case in the API-only
+    test runs -- the caller then falls through to a 404 rather than raising.
+    """
+    if _frontend_dir is None:
+        return None
+
+    index_path = _frontend_dir / "index.html"
+    if not index_path.is_file():
+        return None
+
+    html = index_path.read_text(encoding="utf-8")
+    return html.replace(ASSET_VERSION_PLACEHOLDER, _asset_version())
+
+
+@app.get("/", include_in_schema=False)
+@app.get("/index.html", include_in_schema=False)
+async def serve_index():
+    """Serve the templated index.html.
+
+    Registered before the StaticFiles mount below, which would otherwise answer "/" with
+    the raw file and leave the placeholder in the markup.
+
+    no-store rather than a short max-age: this document is what names the versioned asset
+    URLs, so a cached copy of it defeats the whole mechanism by continuing to point at the
+    previous deploy's files.
+    """
+    from fastapi.responses import HTMLResponse, PlainTextResponse
+
+    html = _index_html()
+    if html is None:
+        return PlainTextResponse("Frontend not available", status_code=404)
+
+    return HTMLResponse(
+        html,
+        headers={
+            "Cache-Control": "no-store, must-revalidate",
+            # Surfaces which build a page came from without opening devtools, which is how
+            # the stale-asset problem went unnoticed for as long as it did.
+            "X-Asset-Version": _asset_version(),
+        },
+    )
+
+
+if _frontend_dir is not None:
+    # Mounted last so API routes and serve_index above take priority over the catch-all
+    # html=True handler.
+    app.mount("/", StaticFiles(directory=str(_frontend_dir), html=True), name="frontend")

--- a/backend/tests/test_asset_versioning.py
+++ b/backend/tests/test_asset_versioning.py
@@ -1,0 +1,145 @@
+"""
+Tests for the versioned asset URLs on index.html.
+
+What this protects. index.html references /css and /js at fixed URLs, and Cloudflare caches
+those at the edge for hours while never caching index.html itself. After a deploy that
+serves new HTML against old assets, which is worse than serving a wholly stale page: on the
+2026-08-28 release the new markup loaded a new equalizer.js against a styles.css with no
+rules for it, and the sidebar rendered as unstyled buttons. Appending ?v=<commit sha> makes
+every deploy a new URL at the edge.
+
+The mechanism has two halves and a test that only checks one of them passes for the wrong
+reason, so both are pinned:
+
+  1. The response contains no unsubstituted placeholder. On its own this also passes if
+     index.html simply never had a placeholder in it.
+  2. The file on disk still contains the placeholder, and the response carries a real
+     version token in its place.
+
+The CDN assertion is here because the substitution is a string replace over the whole
+document: a broader pattern that caught the FullCalendar or Google Fonts URLs would append
+a query string to a third-party request, which is both wrong and hard to notice.
+"""
+
+import re
+
+import pytest
+from fastapi.testclient import TestClient
+
+from app.main import (
+    ASSET_VERSION_PLACEHOLDER,
+    _asset_version,
+    _frontend_dir,
+    _index_html,
+    app,
+)
+
+
+needs_frontend = pytest.mark.skipif(
+    _frontend_dir is None, reason="no frontend directory in this checkout"
+)
+
+
+@pytest.fixture
+def client():
+    return TestClient(app)
+
+
+@pytest.fixture
+def index_body(client):
+    response = client.get("/")
+    assert response.status_code == 200, "index.html is not being served at /"
+    return response.text
+
+
+@needs_frontend
+class TestPlaceholderIsSubstituted:
+    def test_no_placeholder_survives_into_the_response(self, index_body):
+        assert ASSET_VERSION_PLACEHOLDER not in index_body
+
+    def test_the_source_file_really_does_contain_the_placeholder(self):
+        """Guards against the first assertion passing because nothing needed substituting.
+
+        If someone removes the placeholders from index.html, the whole mechanism silently
+        stops working while every other test here still passes.
+        """
+        raw = (_frontend_dir / "index.html").read_text(encoding="utf-8")
+        assert ASSET_VERSION_PLACEHOLDER in raw
+
+    def test_local_assets_carry_the_version_token(self, index_body):
+        version = _asset_version()
+        assert f"/css/styles.css?v={version}" in index_body
+        for script in ("app.js", "config.js", "design.js", "equalizer.js"):
+            assert f"/js/{script}?v={version}" in index_body
+
+    def test_every_local_asset_is_versioned_not_just_some(self, index_body):
+        """A partially versioned page is the exact failure being fixed: the mixed state,
+        where some files come from the new deploy and some from cache."""
+        unversioned = re.findall(r'(?:href|src)="(/(?:css|js)/[^"?]+\.(?:css|js))"', index_body)
+        assert unversioned == [], f"local assets missing ?v=: {unversioned}"
+
+
+@needs_frontend
+class TestThirdPartyUrlsAreUntouched:
+    def test_cdn_and_font_urls_have_no_version_query(self, index_body):
+        for host in ("cdn.jsdelivr.net", "fonts.googleapis.com", "fonts.gstatic.com"):
+            for url in re.findall(rf'"(https://{re.escape(host)}[^"]*)"', index_body):
+                assert "?v=" not in url, f"third-party URL was versioned: {url}"
+
+
+@needs_frontend
+class TestTheDocumentItselfIsNotCached:
+    def test_cache_control_forbids_storing_the_html(self, client):
+        """The load-bearing header. This document is what names the versioned asset URLs,
+        so a cached copy keeps pointing at the previous deploy's files and the versioning
+        buys nothing."""
+        cache_control = client.get("/").headers.get("cache-control", "")
+        assert "no-store" in cache_control
+
+    def test_index_html_path_behaves_like_the_root(self, client):
+        """Both routes exist, so a link to /index.html cannot bypass the substitution and
+        get the raw file from the StaticFiles mount."""
+        response = client.get("/index.html")
+        assert response.status_code == 200
+        assert ASSET_VERSION_PLACEHOLDER not in response.text
+        assert "no-store" in response.headers.get("cache-control", "")
+
+
+class TestVersionToken:
+    def test_falls_back_to_dev_when_git_commit_is_unset(self, monkeypatch):
+        """Local dev and CI have no GIT_COMMIT, and must still serve a usable page."""
+        monkeypatch.delenv("GIT_COMMIT", raising=False)
+        assert _asset_version() == "dev"
+
+    def test_uses_the_commit_sha_when_present(self, monkeypatch):
+        monkeypatch.setenv("GIT_COMMIT", "0123456789abcdef0123456789abcdef01234567")
+        assert _asset_version() == "0123456789ab"
+
+    def test_token_is_url_safe(self, monkeypatch):
+        """It goes straight into a query string, so anything needing escaping would produce
+        a subtly wrong URL rather than an error."""
+        monkeypatch.setenv("GIT_COMMIT", "06bdf7f132dc5fec7d541ce40e353d69a2784966")
+        assert re.fullmatch(r"[A-Za-z0-9._-]+", _asset_version())
+
+    def test_changing_the_sha_changes_the_asset_urls(self, monkeypatch):
+        """The property the whole fix depends on: a new deploy must produce new URLs.
+
+        _index_html is lru_cached, since neither the file nor the SHA changes within a
+        container's life, so the cache is cleared here to exercise a fresh render.
+        """
+        if _frontend_dir is None:
+            pytest.skip("no frontend directory in this checkout")
+
+        monkeypatch.setenv("GIT_COMMIT", "a" * 40)
+        _index_html.cache_clear()
+        first = _index_html()
+
+        monkeypatch.setenv("GIT_COMMIT", "b" * 40)
+        _index_html.cache_clear()
+        second = _index_html()
+
+        assert first != second
+        assert "?v=" + "a" * 12 in first
+        assert "?v=" + "b" * 12 in second
+
+        _index_html.cache_clear()

--- a/frontend/css/styles.css
+++ b/frontend/css/styles.css
@@ -515,11 +515,71 @@ a:hover { color: var(--accent-hover); text-decoration: underline; }
   opacity: 0.45;
 }
 
-/* Venue list (rendered by JS as .venue-checkbox labels) */
-.venue-list {
+/* ── Cities & venues ───────────────────────────────────────────────────────────
+   Venues nest under a collapsible city header. Replaces the former flat .venue-list
+   and the separate city chip row. */
+
+.city-groups { display: flex; flex-direction: column; gap: 0.6rem; }
+
+/* Row for non-city chips (Spotify's "★ for you"). Takes no space while empty, so an
+   unconnected visitor sees no gap. */
+.quick-filters:not(:empty) { margin-bottom: 0.6rem; }
+
+.city-group-head { display: flex; align-items: stretch; gap: 0.3rem; }
+/* The chip fills the row so the whole width is a city filter target, and the caret
+   stays a separate, smaller hit area — one row, two distinct actions. */
+.city-group-head .city-chip { flex: 1 1 auto; text-align: left; }
+
+.city-collapse {
+  flex-shrink: 0;
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 0.3rem;
+  background: none;
+  border: 1px solid transparent;
+  border-radius: 1px;
+  cursor: pointer;
+  /* --muted, not --dim. This is the control the whole feature hangs on, and --dim
+     measures 1.83:1 against --surface in dark mode — under the 3:1 an interactive
+     element needs. --dim is fine for inert decoration, not for this. */
+  color: var(--muted);
+  font-family: 'Space Mono', monospace;
+  font-size: 0.6rem;
+  /* min-height carries the hit target to 24px; padding alone left it at 22. */
+  min-height: 24px;
+  min-width: 34px;
+  padding: 0 0.35rem;
+  transition: color 0.12s, border-color 0.12s;
+}
+.city-collapse:hover { color: var(--accent); border-color: var(--border); }
+.city-collapse:focus-visible { outline: 1px solid var(--accent); outline-offset: 1px; }
+
+.city-count { font-variant-numeric: tabular-nums; opacity: 0.75; }
+.city-caret { display: inline-block; transition: transform 0.15s ease; }
+.city-group.collapsed .city-caret { transform: rotate(-90deg); }
+
+/* Venues indented under their city, with a rule tying them to the group. */
+.city-venues {
   display: flex;
   flex-direction: column;
   gap: 0.35rem;
+  padding: 0.4rem 0 0.1rem 0.55rem;
+  margin-left: 0.2rem;
+  border-left: 1px solid var(--border);
+}
+
+/* Collapse uses display:none deliberately, and the inputs must stay in the DOM.
+   _getFilteredEvents() builds its venue map with
+   querySelectorAll(".venue-checkbox input[type=checkbox]"), so unmounting a collapsed
+   city would silently drop its venues from the filter — the calendar would disagree
+   with a sidebar the visitor cannot see. display:none keeps them queryable while
+   removing them from layout and from the tab order, which is the same thing
+   `.venue-checkbox input { display: none }` already relies on further down. */
+.city-group.collapsed .city-venues { display: none; }
+
+@media (prefers-reduced-motion: reduce) {
+  .city-caret { transition: none; }
 }
 
 .venue-checkbox {

--- a/frontend/css/styles.css
+++ b/frontend/css/styles.css
@@ -525,17 +525,18 @@ a:hover { color: var(--accent-hover); text-decoration: underline; }
    unconnected visitor sees no gap. */
 .quick-filters:not(:empty) { margin-bottom: 0.6rem; }
 
-.city-group-head { display: flex; align-items: stretch; gap: 0.3rem; }
-/* The chip fills the row so the whole width is a city filter target, and the caret
-   stays a separate, smaller hit area — one row, two distinct actions. */
+.city-group-head { display: flex; align-items: center; gap: 0.3rem; }
+/* The chip fills the row so the whole width is a city filter target, with the caret a
+   separate leading hit area — one row, two distinct actions that can't steal each
+   other's clicks. */
 .city-group-head .city-chip { flex: 1 1 auto; text-align: left; }
 
+/* Disclosure caret, leading the row like a tree view. */
 .city-collapse {
   flex-shrink: 0;
   display: flex;
   align-items: center;
-  justify-content: flex-end;
-  gap: 0.3rem;
+  justify-content: center;
   background: none;
   border: 1px solid transparent;
   border-radius: 1px;
@@ -544,28 +545,41 @@ a:hover { color: var(--accent-hover); text-decoration: underline; }
      measures 1.83:1 against --surface in dark mode — under the 3:1 an interactive
      element needs. --dim is fine for inert decoration, not for this. */
   color: var(--muted);
-  font-family: 'Space Mono', monospace;
-  font-size: 0.6rem;
-  /* min-height carries the hit target to 24px; padding alone left it at 22. */
+  /* 0.6rem was legible only if you already knew it was there. */
+  font-size: 0.95rem;
+  line-height: 1;
+  /* Square, and at the 24px hit-target minimum. */
+  width: 24px;
   min-height: 24px;
-  min-width: 34px;
-  padding: 0 0.35rem;
+  padding: 0;
   transition: color 0.12s, border-color 0.12s;
 }
 .city-collapse:hover { color: var(--accent); border-color: var(--border); }
 .city-collapse:focus-visible { outline: 1px solid var(--accent); outline-offset: 1px; }
 
-.city-count { font-variant-numeric: tabular-nums; opacity: 0.75; }
+/* Venue count — a readout, not a control, so it sits outside both buttons. */
+.city-count {
+  flex-shrink: 0;
+  font-family: 'Space Mono', monospace;
+  font-size: 0.6rem;
+  font-variant-numeric: tabular-nums;
+  color: var(--muted);
+  opacity: 0.75;
+  min-width: 1.4em;
+  text-align: right;
+}
+
 .city-caret { display: inline-block; transition: transform 0.15s ease; }
 .city-group.collapsed .city-caret { transform: rotate(-90deg); }
 
-/* Venues indented under their city, with a rule tying them to the group. */
+/* Venues indented under their city. The rule is positioned to descend from the middle
+   of the 24px caret, so it reads as a tree line rather than an arbitrary margin. */
 .city-venues {
   display: flex;
   flex-direction: column;
   gap: 0.35rem;
-  padding: 0.4rem 0 0.1rem 0.55rem;
-  margin-left: 0.2rem;
+  padding: 0.4rem 0 0.1rem 0.8rem;
+  margin-left: 11px;
   border-left: 1px solid var(--border);
 }
 

--- a/frontend/css/styles.css
+++ b/frontend/css/styles.css
@@ -190,28 +190,29 @@ html[data-mode="light"][data-palette="wisteria"] {
   --eq-fav-hover: #12617f;
 }
 
-/* Pressed background for the favourites-only button.
-   Deliberately NOT --eq-fav, though it is the same colour family and follows the same
-   wisteria swap. --eq-fav is tuned as a *graphic* against the 3:1 floor, because it
-   paints equalizer bars. Here it would sit behind 0.62rem uppercase text, which needs
-   4.5:1 — and the light-mode --eq-fav values measure 3.37 to 4.05, so reusing them
-   failed in all five light palettes. These are the same hues taken darker until the
-   button label clears 4.5:1 everywhere (worst case 4.73, durham/light). */
+/* The "strong" favourite colour: same hue family as --eq-fav, taken darker.
+   Used by the favourites-only button's pressed background and by a hearted heart icon
+   on an event tile. Both need something --eq-fav cannot give them, for the same reason:
+   --eq-fav is tuned as a *graphic* sitting on --bg, because it paints equalizer bars.
+   Against a tile (--surface2) or behind button text it is too light — measured at
+   3.37-4.05 behind the button label (needs 4.5) and 2.64-2.96 as a heart on a light
+   tile (needs 3). These values clear both floors everywhere: worst 4.73 for the button
+   label and 3.70 for the heart, both on durham/light. */
 :root {
-  --fav-btn-bg:       #ff8fa8;
-  --fav-btn-bg-hover: #ffb3c4;
+  --fav-strong:       #ff8fa8;
+  --fav-strong-hover: #ffb3c4;
 }
 html[data-mode="light"] {
-  --fav-btn-bg:       #b83a5c;
-  --fav-btn-bg-hover: #9c2a48;
+  --fav-strong:       #b83a5c;
+  --fav-strong-hover: #9c2a48;
 }
 html[data-palette="wisteria"] {
-  --fav-btn-bg:       #8ad5f0;
-  --fav-btn-bg-hover: #b0e6f8;
+  --fav-strong:       #8ad5f0;
+  --fav-strong-hover: #b0e6f8;
 }
 html[data-mode="light"][data-palette="wisteria"] {
-  --fav-btn-bg:       #12617f;
-  --fav-btn-bg-hover: #0d4d66;
+  --fav-strong:       #12617f;
+  --fav-strong-hover: #0d4d66;
 }
 
 /* Durham Bulls light: warm desaturated brown bg, navy text */
@@ -849,7 +850,7 @@ a:hover { color: var(--accent-hover); text-decoration: underline; }
   position: relative;
   display: flex;
   flex-direction: column;
-  padding: 2px 32px 2px 4px; /* right padding reserves space for heart + hide */
+  padding: 2px 44px 2px 4px; /* right padding reserves space for heart + hide */
   overflow: hidden;
 }
 /* Event title.
@@ -885,49 +886,57 @@ a:hover { color: var(--accent-hover); text-decoration: underline; }
   text-overflow: ellipsis;
 }
 
-/* Heart / favorite button — shows on hover, 20% bigger than original */
+/* Heart / favorite button — revealed when the tile is hovered.
+   Colors are palette tokens, not the hardcoded rgba(255,255,255,…) they used to be.
+   That white was correct while tiles were saturated dark fills; once the gutter
+   treatment moved tile text onto --surface2 it became near-invisible in light mode. */
 .ev-heart {
   position: absolute;
   top: 50%;
-  right: 17px;
+  right: 24px;
   transform: translateY(-50%);
   background: none;
   border: none;
   cursor: pointer;
-  font-size: 0.84rem;
+  font-size: 0.95rem;
   line-height: 1;
-  color: rgba(255,255,255,0.5);
-  padding: 1px 2px;
+  color: var(--muted);
+  padding: 2px 3px;
   opacity: 0;
   transition: opacity 0.15s, color 0.12s;
   z-index: 1;
   user-select: none;
 }
 .ev:hover .ev-heart        { opacity: 1; }
-.ev-heart.hearted          { opacity: 1 !important; color: #ff8fa8; }
-.ev-heart:hover            { color: rgba(255,255,255,0.9); }
-.ev-heart.hearted:hover    { color: #ff5580; }
+/* --fav-strong rather than a literal #ff8fa8, and rather than --eq-fav: the token
+   carries the light-mode and wisteria variants, so a hearted show stays visible on warm
+   paper and stops clashing on the pink palette. --eq-fav itself measures only 2.64-2.96
+   against a light tile, because it is tuned to sit on --bg rather than on --surface2. */
+.ev-heart.hearted          { opacity: 1 !important; color: var(--fav-strong); }
+.ev-heart:hover            { color: var(--accent); }
+.ev-heart.hearted:hover    { color: var(--fav-strong-hover); }
 
 /* Hide button — dismiss event until page refresh */
 .ev-hide {
   position: absolute;
   top: 50%;
-  right: 2px;
+  right: 3px;
   transform: translateY(-50%);
   background: none;
   border: none;
   cursor: pointer;
-  font-size: 0.62rem;
+  /* Was 0.62rem — roughly 10px, and the smallest interactive thing on the page. */
+  font-size: 0.78rem;
   line-height: 1;
-  color: rgba(255,255,255,0.4);
-  padding: 1px 2px;
+  color: var(--muted);
+  padding: 2px 3px;
   opacity: 0;
   transition: opacity 0.15s, color 0.12s;
   z-index: 1;
   user-select: none;
 }
 .ev:hover .ev-hide  { opacity: 1; }
-.ev-hide:hover      { color: rgba(255,255,255,0.9); }
+.ev-hide:hover      { color: var(--accent); }
 
 /* Past events — greyed out */
 .fc-event.ev-past { opacity: 0.45; }
@@ -1181,14 +1190,14 @@ a:hover { color: var(--accent-hover); text-decoration: underline; }
    button in the heart pink rather than another accent outline, which also stops it
    reading as "hovered". */
 .btn-favorites-only.active {
-  background: var(--fav-btn-bg);
-  border-color: var(--fav-btn-bg);
+  background: var(--fav-strong);
+  border-color: var(--fav-strong);
   color: var(--bg);
   opacity: 1;
 }
 .btn-favorites-only.active:hover {
-  background: var(--fav-btn-bg-hover);
-  border-color: var(--fav-btn-bg-hover);
+  background: var(--fav-strong-hover);
+  border-color: var(--fav-strong-hover);
   color: var(--bg);
 }
 .btn-favorites-only:focus-visible,
@@ -1275,8 +1284,10 @@ a:hover { color: var(--accent-hover); text-decoration: underline; }
 
   /* List view: clip overflow on mobile; title fills all available width */
   .fc { overflow: hidden; }
-  /* Reduce ev right padding on mobile */
-  .ev { padding-right: 20px; }
+  /* Mobile reserves less than desktop, but 20px was under the icons' own width even
+     before they grew — and on mobile they are permanently visible rather than
+     hover-revealed, so a title running underneath them is guaranteed, not occasional. */
+  .ev { padding-right: 40px; }
 
   /* Ko-fi: hide from header, show at bottom of sidebar */
   .app-header .kofi-wrap { display: none; }
@@ -1300,8 +1311,8 @@ a:hover { color: var(--accent-hover); text-decoration: underline; }
   .palette-btn { width: 26px; height: 26px; }
 
   /* Heart + hide: always slightly visible on mobile (no real hover) */
-  .ev-heart { opacity: 0.4; font-size: 0.84rem; }
-  .ev-hide  { opacity: 0.3; }
+  .ev-heart { opacity: 0.75; font-size: 0.95rem; }
+  .ev-hide  { opacity: 0.6;  font-size: 0.78rem; }
   .venue-hide-btn { opacity: 0.3; }
 
   /* Bottom bar: left edge on mobile (sidebar is hidden) */
@@ -1319,9 +1330,10 @@ html[data-mode="light"] .modal-overlay {
 /* Light mode: list view needs dark text (events have no colored bg in list view) */
 html[data-mode="light"] .fc-list-event .ev-title { color: var(--text); }
 html[data-mode="light"] .fc-list-event .ev-venue { color: var(--muted); }
-html[data-mode="light"] .fc-list-event .ev-heart { color: rgba(0,0,0,0.35); }
-html[data-mode="light"] .fc-list-event .ev-hide  { color: rgba(0,0,0,0.25); }
-html[data-mode="light"] .venue-hide-btn          { color: rgba(0,0,0,0.35); }
+/* The .ev-heart / .ev-hide light-mode overrides that were here are gone: they existed
+   only to undo a hardcoded white base, and the base is now --muted, which is already
+   palette- and mode-correct. */
+html[data-mode="light"] .venue-hide-btn          { color: var(--muted); }
 
 /* Light mode needs nothing special for daygrid events now. The block that used to live
    here put them on --surface2 and colored the title with the venue color, to rescue the
@@ -1479,10 +1491,10 @@ html[data-mode="light"] .fc .fc-list-event .ev {
 .fc .fc-daygrid-event:hover {
   background-color: color-mix(in srgb, var(--venue-color, var(--accent)) 14%, var(--surface2)) !important;
 }
-.fc .fc-daygrid-event .ev-heart,
-.fc .fc-daygrid-event .ev-hide {
-  color: var(--dim);
-}
+/* No daygrid-specific colour for the icons any more. This block set them to --dim,
+   which measures 1.83:1 against --surface2 in dark mode -- under the 3:1 an interactive
+   control needs, and the reason they were hard to read on hover. The base .ev-heart /
+   .ev-hide rules now use --muted, which works in both modes. */
 
 /* The list view's own dot is drawn by FullCalendar from the event's border color, which
    is the unbrightened seed value -- same invisibility problem on a dark surface. */

--- a/frontend/css/styles.css
+++ b/frontend/css/styles.css
@@ -190,6 +190,30 @@ html[data-mode="light"][data-palette="wisteria"] {
   --eq-fav-hover: #12617f;
 }
 
+/* Pressed background for the favourites-only button.
+   Deliberately NOT --eq-fav, though it is the same colour family and follows the same
+   wisteria swap. --eq-fav is tuned as a *graphic* against the 3:1 floor, because it
+   paints equalizer bars. Here it would sit behind 0.62rem uppercase text, which needs
+   4.5:1 — and the light-mode --eq-fav values measure 3.37 to 4.05, so reusing them
+   failed in all five light palettes. These are the same hues taken darker until the
+   button label clears 4.5:1 everywhere (worst case 4.73, durham/light). */
+:root {
+  --fav-btn-bg:       #ff8fa8;
+  --fav-btn-bg-hover: #ffb3c4;
+}
+html[data-mode="light"] {
+  --fav-btn-bg:       #b83a5c;
+  --fav-btn-bg-hover: #9c2a48;
+}
+html[data-palette="wisteria"] {
+  --fav-btn-bg:       #8ad5f0;
+  --fav-btn-bg-hover: #b0e6f8;
+}
+html[data-mode="light"][data-palette="wisteria"] {
+  --fav-btn-bg:       #12617f;
+  --fav-btn-bg-hover: #0d4d66;
+}
+
 /* Durham Bulls light: warm desaturated brown bg, navy text */
 html[data-mode="light"][data-palette="durham"] {
   --bg:           #f5ece0;
@@ -1122,6 +1146,7 @@ a:hover { color: var(--accent-hover); text-decoration: underline; }
   transform: translateY(0);
 }
 
+.btn-favorites-only,
 .btn-download-shows,
 .btn-restore-hidden {
   display: inline-block;
@@ -1139,6 +1164,7 @@ a:hover { color: var(--accent-hover); text-decoration: underline; }
   transition: background 0.15s, color 0.15s;
   opacity: 0.72;
 }
+.btn-favorites-only:hover,
 .btn-download-shows:hover,
 .btn-restore-hidden:hover {
   background: var(--accent);
@@ -1147,6 +1173,30 @@ a:hover { color: var(--accent-hover); text-decoration: underline; }
 }
 /* Restore button: slightly subdued by default */
 .btn-restore-hidden { opacity: 0.55; }
+
+/* Favourites-only toggle.
+   The other two buttons are actions — press and something happens. This one is a mode,
+   and the pressed state has to be unmistakable: a filtered calendar that looks
+   unfiltered is the failure worth designing against. So the active state is a filled
+   button in the heart pink rather than another accent outline, which also stops it
+   reading as "hovered". */
+.btn-favorites-only.active {
+  background: var(--fav-btn-bg);
+  border-color: var(--fav-btn-bg);
+  color: var(--bg);
+  opacity: 1;
+}
+.btn-favorites-only.active:hover {
+  background: var(--fav-btn-bg-hover);
+  border-color: var(--fav-btn-bg-hover);
+  color: var(--bg);
+}
+.btn-favorites-only:focus-visible,
+.btn-download-shows:focus-visible,
+.btn-restore-hidden:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
 
 /* First-appear bounce for the buttons */
 .favorites-bar.visible .btn-download-shows,

--- a/frontend/css/styles.css
+++ b/frontend/css/styles.css
@@ -853,6 +853,20 @@ a:hover { color: var(--accent-hover); text-decoration: underline; }
   padding: 2px 44px 2px 4px; /* right padding reserves space for heart + hide */
   overflow: hidden;
 }
+
+/* Only reserve room for the icons while they are actually on screen.
+   The icons are absolutely positioned, so changing this padding re-ellipsizes the title
+   without resizing the tile — nothing around it moves, the text just gets shorter. That
+   buys back roughly a character and a half in every month cell for the 99% of the time
+   the pointer is elsewhere.
+   Gated on (hover: hover) rather than a width: on touch devices the icons are permanently
+   visible, so the reserve has to be permanent too, and there is no hover to restore it.
+   Selector carries .fc to reach (0,2,0), so it wins over the width-based .ev override in
+   the responsive block below regardless of source order. */
+@media (hover: hover) {
+  .fc .ev          { padding-right: 6px; }
+  .fc .ev:hover    { padding-right: 44px; }
+}
 /* Event title.
    Was Space Mono 700 at 12px, which is the readability complaint that started this branch.
    Bold works against a monospace at this size: Space Mono's counters are tight to begin
@@ -1284,10 +1298,10 @@ a:hover { color: var(--accent-hover); text-decoration: underline; }
 
   /* List view: clip overflow on mobile; title fills all available width */
   .fc { overflow: hidden; }
-  /* Mobile reserves less than desktop, but 20px was under the icons' own width even
-     before they grew — and on mobile they are permanently visible rather than
-     hover-revealed, so a title running underneath them is guaranteed, not occasional. */
-  .ev { padding-right: 40px; }
+  /* List view keeps the reserve: the icons are permanently visible here (no hover to
+     reveal them), and titles wrap rather than truncate, so the reserve costs a little
+     line width and never hides text. 20px used to be under the icons' own width. */
+  .fc-list-event .ev { padding-right: 40px; }
 
   /* Ko-fi: hide from header, show at bottom of sidebar */
   .app-header .kofi-wrap { display: none; }
@@ -1317,6 +1331,19 @@ a:hover { color: var(--accent-hover); text-decoration: underline; }
 
   /* Bottom bar: left edge on mobile (sidebar is hidden) */
   .favorites-bar { left: 0.75rem; }
+}
+
+/* Month view on a phone: drop the icons entirely.
+   A day cell is ~52px there and a tile ~47px, so two permanently-visible controls plus
+   a title does not fit — measured, the title was allotted 0px and the tile rendered as
+   nothing but a heart and a cross. The month grid on a phone is a density overview;
+   hearting and hiding belong to the list view, which is the default at that width
+   anyway. Also gated on (hover: none) so a merely narrow desktop window keeps its
+   hover-revealed icons instead of losing them. */
+@media (max-width: 768px) and (hover: none) {
+  .fc-daygrid-event .ev-heart,
+  .fc-daygrid-event .ev-hide { display: none; }
+  .fc-daygrid-event .ev { padding-right: 4px; }
 }
 
 /* Light mode: darken the modal overlay slightly less */

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -149,7 +149,7 @@
     <!-- Calendar -->
     <main class="calendar-container">
       <div id="calendar"></div>
-      <footer class="site-credit">made by <a href="http://bsky.app/profile/tyfi.bsky.social" target="_blank" rel="noopener">@tyfi</a>. it's on <a href="https://github.com/triangle-shows/triangle-shows" target="_blank" rel="noopener">github</a>.</footer>
+      <footer class="site-credit">made by <a href="http://bsky.app/profile/tyfi.bsky.social" target="_blank" rel="noopener">@tyfi</a> and the gang at <a href="https://github.com/triangle-shows" target="_blank" rel="noopener">triangle-shows</a>. it's on <a href="https://github.com/triangle-shows/triangle-shows" target="_blank" rel="noopener">github</a>.</footer>
     </main>
   </div>
 

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -16,7 +16,7 @@
        week ruler; loaded so pixel treatments can be tried elsewhere without a round trip. -->
   <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:ital,wght@0,400;0,500;0,600;1,400&family=Orbitron:wght@900&family=Silkscreen:wght@400;700&family=Space+Mono:ital,wght@0,400;0,700;1,400;1,700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/fullcalendar@6.1.15/index.global.min.css">
-  <link rel="stylesheet" href="/css/styles.css">
+  <link rel="stylesheet" href="/css/styles.css?v={{ASSET_VERSION}}">
 
   <!-- Google Analytics -->
   <script async src="https://www.googletagmanager.com/gtag/js?id=G-S37F3PHK0R"></script>
@@ -168,12 +168,12 @@
   <script defer src="https://cdn.jsdelivr.net/npm/fullcalendar@6.1.15/index.global.min.js"></script>
 
   <!-- App JS -->
-  <script defer src="/js/design.js"></script>
-  <script defer src="/js/equalizer.js"></script>
-  <script defer src="/js/config.js"></script>
-  <script defer src="/js/filters.js"></script>
-  <script defer src="/js/modal.js"></script>
-  <script defer src="/js/favorites.js"></script>
-  <script defer src="/js/app.js"></script>
+  <script defer src="/js/design.js?v={{ASSET_VERSION}}"></script>
+  <script defer src="/js/equalizer.js?v={{ASSET_VERSION}}"></script>
+  <script defer src="/js/config.js?v={{ASSET_VERSION}}"></script>
+  <script defer src="/js/filters.js?v={{ASSET_VERSION}}"></script>
+  <script defer src="/js/modal.js?v={{ASSET_VERSION}}"></script>
+  <script defer src="/js/favorites.js?v={{ASSET_VERSION}}"></script>
+  <script defer src="/js/app.js?v={{ASSET_VERSION}}"></script>
 </body>
 </html>

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -100,7 +100,7 @@
       <div class="filter-section">
         <div class="filter-label">Show</div>
         <div class="chip-group">
-          <button class="chip" id="chip-non-music" onclick="toggleNonMusic()">include non-live music</button>
+          <button class="chip" id="chip-non-music" onclick="toggleNonMusic()">include non-live shows</button>
         </div>
         <p class="subscribe-hint">karaoke, trivia, theme nights &amp; other recurring events are hidden by default</p>
       </div>

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -155,6 +155,10 @@
 
   <!-- Bottom-left utility bar: appears when shows are hearted or hidden -->
   <div class="favorites-bar" id="favorites-bar">
+    <!-- A view toggle, so it sits above the export action. aria-pressed rather than a
+         plain button: it has an on/off state, and the label alone doesn't convey which. -->
+    <button class="btn-favorites-only" id="btn-favorites-only" aria-pressed="false"
+            onclick="toggleFavoritesOnly()">♡ only my shows</button>
     <button class="btn-download-shows" onclick="downloadFavorites()">↓ download my shows</button>
     <button class="btn-restore-hidden" id="btn-restore-hidden" onclick="restoreHidden()">↺ restore hidden</button>
   </div>

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -80,16 +80,18 @@
         <p class="eq-readout" id="eq-readout" aria-live="polite"></p>
       </div>
 
-      <!-- City Filter -->
+      <!-- Cities & Venues.
+           Replaces the former separate "City" chip row and flat "Venues" list: every
+           venue belongs to a city, so the venues now sit under theirs and each city
+           collapses. Rendered together by renderVenueFilters() in js/filters.js.
+           #venue-filters keeps its id because _updateVenueRestoreBtn() appends to it. -->
       <div class="filter-section">
-        <div class="filter-label">City</div>
-        <div class="chip-group" id="city-filters"></div>
-      </div>
-
-      <!-- Venue Filter -->
-      <div class="filter-section">
-        <div class="filter-label">Venues</div>
-        <div class="venue-list" id="venue-filters"></div>
+        <div class="filter-label">Cities &amp; Venues</div>
+        <!-- Cross-cutting chips that aren't a city — currently only Spotify's
+             "★ for you", appended here by js/spotify.js. Collapses to zero height
+             while empty. -->
+        <div class="chip-group quick-filters" id="quick-filters"></div>
+        <div class="city-groups" id="venue-filters"></div>
         <button class="btn-subscribe-venues" onclick="subscribeToVenues()">↗ get a cal for these venues</button>
         <p class="subscribe-hint">new shows will appear automatically!</p>
       </div>

--- a/frontend/js/favorites.js
+++ b/frontend/js/favorites.js
@@ -22,9 +22,18 @@ function toggleFavorite(eventId, eventData) {
   saveFavorites(favs);
   _refreshHeartUI(eventId, !!favs[eventId]);
   updateBottomBar();
-  // Repaint the equalizer so the hearted portion of each bar tracks the change
-  // immediately, rather than waiting for the next calendar refetch.
-  if (window.Equalizer && typeof window.Equalizer.refresh === "function") {
+
+  const favOnly = typeof activeFilters === "object" && !!activeFilters.favoritesOnly;
+  if (favOnly && typeof applyAllFilters === "function") {
+    // In the favourites-only view this heart changes which events belong on screen, so
+    // the calendar has to be re-filtered — otherwise an un-hearted show just sits there.
+    // The re-filter feeds the equalizer with the new visible set on its way through
+    // app.js, so refreshing the equalizer here first would only render a set that is
+    // about to be replaced.
+    applyAllFilters();
+  } else if (window.Equalizer && typeof window.Equalizer.refresh === "function") {
+    // Outside that view the visible set is unchanged and only the hearted portion of
+    // each bar needs repainting, which is far cheaper than a full re-filter.
     window.Equalizer.refresh();
   }
 }
@@ -94,13 +103,29 @@ function updateBottomBar() {
 
   const favCount = Object.keys(getFavorites()).length;
   const hidCount = Object.keys(getHidden()).length;
+  const favOnly  = typeof activeFilters === "object" && !!activeFilters.favoritesOnly;
 
-  bar.classList.toggle("visible", favCount > 0 || hidCount > 0);
+  // `|| favOnly` is load-bearing. This bar holds the only control for the
+  // favourites-only view, so it has to stay up while that view is on — including after
+  // the last favourite is un-hearted. Without it, removing your final show hides the
+  // bar and strands you on a filtered, empty calendar with nothing to switch off.
+  bar.classList.toggle("visible", favCount > 0 || hidCount > 0 || favOnly);
 
   const dlBtn = bar.querySelector(".btn-download-shows");
   if (dlBtn) {
     dlBtn.style.display = favCount > 0 ? "" : "none";
     dlBtn.textContent   = `↓ download my shows (${favCount})`;
+  }
+
+  const onlyBtn = document.getElementById("btn-favorites-only");
+  if (onlyBtn) {
+    // Same reasoning as the bar itself: stays visible while the view is on even at
+    // zero favourites, so it can always be turned back off.
+    onlyBtn.style.display = favCount > 0 || favOnly ? "" : "none";
+    // The count explains an empty calendar at a glance — "(0)" is why nothing is here.
+    onlyBtn.textContent = `${favOnly ? "♥" : "♡"} only my shows (${favCount})`;
+    onlyBtn.classList.toggle("active", favOnly);
+    onlyBtn.setAttribute("aria-pressed", favOnly ? "true" : "false");
   }
 
   const restoreBtn = document.getElementById("btn-restore-hidden");

--- a/frontend/js/favorites.js
+++ b/frontend/js/favorites.js
@@ -10,8 +10,25 @@ function getFavorites() {
   try { return JSON.parse(localStorage.getItem(FAVORITES_KEY) || "{}"); }
   catch { return {}; }
 }
+// Returns false when the store refused the write, so callers can avoid showing a heart
+// that was never saved.
+//
+// getFavorites() already tolerates unreadable storage; this side did not, so a throw
+// propagated straight out of toggleFavorite() and skipped the UI update, leaving the
+// heart, the bar and the equalizer disagreeing with each other.
+//
+// Capacity is not the likely trigger. Measured against all 2771 events currently in the
+// database, a stored favourite averages 247 bytes, so a 5 MB origin quota holds roughly
+// 21,000 of them and hearting literally every event would use about 13%. What does throw
+// regardless of size is a private-browsing window or a browser set to block site data.
 function saveFavorites(favs) {
-  localStorage.setItem(FAVORITES_KEY, JSON.stringify(favs));
+  try {
+    localStorage.setItem(FAVORITES_KEY, JSON.stringify(favs));
+    return true;
+  } catch (err) {
+    console.warn("Could not save favorites — storage refused the write:", err);
+    return false;
+  }
 }
 function isFavorited(eventId) { return !!getFavorites()[eventId]; }
 
@@ -19,7 +36,9 @@ function toggleFavorite(eventId, eventData) {
   const favs = getFavorites();
   if (favs[eventId]) { delete favs[eventId]; }
   else               { favs[eventId] = eventData; }
-  saveFavorites(favs);
+  // Bail before touching the UI if the write failed, so the heart never claims a
+  // favourite that was not stored.
+  if (!saveFavorites(favs)) return;
   _refreshHeartUI(eventId, !!favs[eventId]);
   updateBottomBar();
 

--- a/frontend/js/filters.js
+++ b/frontend/js/filters.js
@@ -12,6 +12,12 @@ let activeFilters = {
   search: "",
   forYou: false,
   includeNonMusic: localStorage.getItem(INCLUDE_NON_MUSIC_KEY) === "1",
+  // Deliberately NOT persisted, unlike includeNonMusic. That one is a standing
+  // preference ("I want to see trivia nights"); this is a transient "just show me
+  // mine" view. A view filter that survives a reload is how someone concludes the
+  // calendar is broken — they come back to a near-empty month and have no memory of
+  // switching anything on.
+  favoritesOnly: false,
 };
 
 // Cache of all events from the API (plain JS objects). Populated once on initial
@@ -278,6 +284,14 @@ function toggleForYou() {
 
 // Toggle whether non-live-music events (karaoke/trivia/theme nights/etc.) are shown.
 // Choice is persisted so it sticks across visits. Default (chip inactive) hides them.
+// Show only hearted shows. The button lives in the bottom-left favourites bar, so
+// updateBottomBar() is refreshed here to keep its label and pressed state in sync.
+function toggleFavoritesOnly() {
+  activeFilters.favoritesOnly = !activeFilters.favoritesOnly;
+  if (typeof updateBottomBar === "function") updateBottomBar();
+  applyAllFilters();
+}
+
 function toggleNonMusic() {
   activeFilters.includeNonMusic = !activeFilters.includeNonMusic;
   localStorage.setItem(INCLUDE_NON_MUSIC_KEY, activeFilters.includeNonMusic ? "1" : "0");
@@ -312,10 +326,28 @@ function _checkEventVisible(ev, venueMap) {
   // wouldn't be in venueMap and would otherwise pass through unchecked.
   if (SITE_CONFIG.city && props.venue_city !== SITE_CONFIG.city) return false;
 
+  const hearted = typeof isFavorited === "function" && isFavorited(ev.id);
+
+  // Favourites-only view. Composes with the venue and search filters below rather than
+  // overriding them, because those are explicit choices — unticking a venue should keep
+  // working even if you hearted something there.
+  if (activeFilters.favoritesOnly && !hearted) return false;
+
   // Non-live-music events (karaoke, trivia, theme nights, recurring series) are
   // hidden unless the visitor opts in via the toggle. Only an explicit `false`
   // hides — missing/true always shows, so unclassified data is never dropped.
-  if (!activeFilters.includeNonMusic && props.is_live_music === false) return false;
+  //
+  // Inside the favourites-only view a hearted show is exempt: the flag is the
+  // classifier's guess, and someone who deliberately hearted a karaoke night has
+  // overruled it. Without this the button could read "only my shows (5)" beside a
+  // calendar showing two — the kind of quiet disagreement that reads as a bug.
+  //
+  // Scoped to that view on purpose. Outside it the toggle keeps meaning "hide this
+  // category", so the normal calendar behaves exactly as before.
+  const exemptAsFavorite = activeFilters.favoritesOnly && hearted;
+  if (!activeFilters.includeNonMusic && props.is_live_music === false && !exemptAsFavorite) {
+    return false;
+  }
 
   // "For you" mode: show only Spotify-matched events, ignoring venue filters.
   if (activeFilters.forYou) {

--- a/frontend/js/filters.js
+++ b/frontend/js/filters.js
@@ -19,6 +19,60 @@ let activeFilters = {
 // so we never call setProp on EventImpl objects during filter passes.
 let _allEventsCache = [];
 
+// ── Collapsed city groups ─────────────────────────────────────────────────────
+//
+// Which city groups are folded shut in the sidebar. Purely presentational: collapsing
+// a city must never change which events are shown, or the calendar would silently
+// disagree with the filters the visitor can see. Persisted because every other
+// sidebar toggle is.
+const COLLAPSED_CITIES_KEY = "triangle-shows-collapsed-cities";
+
+function getCollapsedCities() {
+  try { return new Set(JSON.parse(localStorage.getItem(COLLAPSED_CITIES_KEY) || "[]")); }
+  catch { return new Set(); }
+}
+
+function saveCollapsedCities(set) {
+  try { localStorage.setItem(COLLAPSED_CITIES_KEY, JSON.stringify([...set])); }
+  catch { /* private browsing: the fold still works, it just won't persist */ }
+}
+
+// City names go into element ids, so reduce them to something id-safe.
+function _citySlug(city) {
+  return String(city).toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-|-$/g, "");
+}
+
+function toggleCityCollapse(city) {
+  const collapsed = getCollapsedCities();
+  if (collapsed.has(city)) collapsed.delete(city);
+  else                     collapsed.add(city);
+  saveCollapsedCities(collapsed);
+
+  const group = document.querySelector(`.city-group[data-city="${city}"]`);
+  if (!group) return;
+
+  const isCollapsed = collapsed.has(city);
+  group.classList.toggle("collapsed", isCollapsed);
+
+  const btn = group.querySelector(".city-collapse");
+  if (btn) {
+    btn.setAttribute("aria-expanded", isCollapsed ? "false" : "true");
+    btn.setAttribute("aria-label", `${isCollapsed ? "Expand" : "Collapse"} ${city} venues`);
+  }
+  // Deliberately no applyAllFilters() — see the note on COLLAPSED_CITIES_KEY.
+}
+
+// The count on a city header is "venues you can see here", so it has to be refreshed
+// when one is hidden rather than only on a full re-render.
+function _updateCityCounts() {
+  document.querySelectorAll(".city-group").forEach((group) => {
+    const count = group.querySelectorAll(".venue-checkbox").length;
+    const el = group.querySelector(".city-count");
+    if (el) el.textContent = String(count);
+  });
+}
+
+
 // ── Hidden venues ─────────────────────────────────────────────────────────────
 const HIDDEN_VENUES_KEY = "triangle-shows-hidden-venues";
 
@@ -32,7 +86,12 @@ function hideVenue(slug) {
   hidden.add(slug);
   localStorage.setItem(HIDDEN_VENUES_KEY, JSON.stringify([...hidden]));
   const label = document.querySelector(`.venue-checkbox input[data-venue="${slug}"]`)?.closest(".venue-checkbox");
+  const group = label?.closest(".city-group");
   if (label) label.remove();
+  // Drop a city whose last visible venue just went. An empty group still showing a
+  // live filter chip reads as a rendering bug.
+  if (group && !group.querySelector(".venue-checkbox")) group.remove();
+  _updateCityCounts();
   _updateVenueRestoreBtn();
   applyAllFilters();
   updateCityChipStates();
@@ -77,32 +136,22 @@ async function loadVenues(attempt = 0) {
 }
 
 function renderFilters() {
-  renderCityFilters();
+  // Cities and venues render together now — the city rows are the group headers.
   renderVenueFilters();
   setupSearch();
 
   updateCityChipStates();
 }
 
-function renderCityFilters() {
-  const container = document.getElementById("city-filters");
-  const cities = [...new Set(venues.map((v) => v.city))].sort();
-
-  container.innerHTML = cities
-    .map((city) => {
-      const colors = CITY_COLORS[city] || {};
-      const border = colors.border || "var(--dim)";
-      const activeBg = colors.activeBg || "var(--accent-bg)";
-      return `<button class="chip city-chip" data-city="${city}"
-        style="--chip-border: ${border}; --chip-active-bg: ${activeBg}"
-        onclick="toggleCity('${city}')">${city}</button>`;
-    })
-    .join("");
-}
-
+// Render every city as a collapsible group with its venues nested underneath.
+//
+// The city header keeps the `.city-chip` class and `data-city`, and each venue keeps
+// `data-venue-city`, so toggleCity() and updateCityChipStates() work against this
+// markup unchanged — they query by those attributes, not by position.
 function renderVenueFilters() {
   const container = document.getElementById("venue-filters");
   const hidden = getHiddenVenues();
+  const collapsed = getCollapsedCities();
 
   // Preserve which venues are currently checked so restoring a hidden venue
   // doesn't reset other venues' selected/unselected state.
@@ -112,21 +161,51 @@ function renderVenueFilters() {
   });
   const hasExistingState = currentChecked.size > 0;
 
-  container.innerHTML = venues
-    .filter((v) => !hidden.has(v.slug))
-    .map((v) => {
-      // Newly-visible venues (just restored) default to checked.
-      // Existing venues preserve their prior state.
-      const isChecked = !hasExistingState || currentChecked.has(v.slug) || !document.querySelector(`[data-venue="${v.slug}"]`);
+  const shown = venues.filter((v) => !hidden.has(v.slug));
+  // A city with every venue hidden gets no group at all, rather than an empty one.
+  const cities = [...new Set(shown.map((v) => v.city))].sort();
+
+  container.innerHTML = cities
+    .map((city) => {
+      const colors   = CITY_COLORS[city] || {};
+      const border   = colors.border   || "var(--dim)";
+      const activeBg = colors.activeBg || "var(--accent-bg)";
+      const cityVenues  = shown.filter((v) => v.city === city);
+      const isCollapsed = collapsed.has(city);
+      const venuesId    = `city-venues-${_citySlug(city)}`;
+
+      const rows = cityVenues
+        .map((v) => {
+          // Newly-visible venues (just restored) default to checked.
+          // Existing venues preserve their prior state.
+          const isChecked = !hasExistingState || currentChecked.has(v.slug) || !document.querySelector(`[data-venue="${v.slug}"]`);
+          return `
+        <label class="venue-checkbox" data-venue-city="${city}">
+          <input type="checkbox" data-venue="${v.slug}" ${isChecked ? "checked" : ""} onchange="toggleVenue('${v.slug}')">
+          <span class="venue-dot" style="background-color: ${v.color}"></span>
+          <span class="venue-label">${v.name}</span>
+          <button class="venue-hide-btn" data-slug="${v.slug}" tabindex="-1" aria-label="Hide ${v.name}">✕</button>
+        </label>`;
+        })
+        .join("");
+
       return `
-      <label class="venue-checkbox" data-venue-city="${v.city}">
-        <input type="checkbox" data-venue="${v.slug}" ${isChecked ? "checked" : ""} onchange="toggleVenue('${v.slug}')">
-        <span class="venue-dot" style="background-color: ${v.color}"></span>
-        <span class="venue-label">${v.name}</span>
-        <button class="venue-hide-btn" data-slug="${v.slug}" tabindex="-1" aria-label="Hide ${v.name}">✕</button>
-      </label>`;
+      <div class="city-group${isCollapsed ? " collapsed" : ""}" data-city="${city}">
+        <div class="city-group-head">
+          <button class="chip city-chip" data-city="${city}"
+                  style="--chip-border: ${border}; --chip-active-bg: ${activeBg}"
+                  onclick="toggleCity('${city}')">${city}</button>
+          <button class="city-collapse" data-city="${city}"
+                  aria-expanded="${isCollapsed ? "false" : "true"}"
+                  aria-controls="${venuesId}"
+                  aria-label="${isCollapsed ? "Expand" : "Collapse"} ${city} venues"
+                  onclick="toggleCityCollapse('${city}')"><span class="city-count">${cityVenues.length}</span><span class="city-caret" aria-hidden="true">▾</span></button>
+        </div>
+        <div class="city-venues" id="${venuesId}">${rows}</div>
+      </div>`;
     })
     .join("");
+
   container.querySelectorAll(".venue-hide-btn").forEach((btn) => {
     btn.addEventListener("click", function (e) {
       e.preventDefault();

--- a/frontend/js/filters.js
+++ b/frontend/js/filters.js
@@ -27,9 +27,22 @@ let _allEventsCache = [];
 // sidebar toggle is.
 const COLLAPSED_CITIES_KEY = "triangle-shows-collapsed-cities";
 
-function getCollapsedCities() {
-  try { return new Set(JSON.parse(localStorage.getItem(COLLAPSED_CITIES_KEY) || "[]")); }
+// The persisted list, or null when the visitor has never folded anything.
+function _storedCollapsedCities() {
+  const raw = localStorage.getItem(COLLAPSED_CITIES_KEY);
+  if (raw === null) return null;
+  try { return new Set(JSON.parse(raw)); }
   catch { return new Set(); }
+}
+
+// Which cities are folded shut. Everything starts folded: the point of grouping is to
+// shorten the sidebar, and four headers plus twenty-two rows is *longer* than the flat
+// list this replaced. Once the visitor folds or unfolds anything, their explicit choice
+// is stored and used instead.
+function getCollapsedCities() {
+  const stored = _storedCollapsedCities();
+  if (stored) return stored;
+  return new Set(venues.map((v) => v.city));
 }
 
 function saveCollapsedCities(set) {
@@ -56,8 +69,12 @@ function toggleCityCollapse(city) {
 
   const btn = group.querySelector(".city-collapse");
   if (btn) {
+    const n = group.querySelectorAll(".venue-checkbox").length;
     btn.setAttribute("aria-expanded", isCollapsed ? "false" : "true");
-    btn.setAttribute("aria-label", `${isCollapsed ? "Expand" : "Collapse"} ${city} venues`);
+    btn.setAttribute(
+      "aria-label",
+      `${isCollapsed ? "Expand" : "Collapse"} ${city}, ${n} venue${n === 1 ? "" : "s"}`
+    );
   }
   // Deliberately no applyAllFilters() — see the note on COLLAPSED_CITIES_KEY.
 }
@@ -189,17 +206,21 @@ function renderVenueFilters() {
         })
         .join("");
 
+      // Caret first so it reads as the disclosure control for the row, the way a
+      // tree view does. The count is a plain span rather than part of either button —
+      // it's a readout, and putting it inside the caret's hit area implied otherwise.
       return `
       <div class="city-group${isCollapsed ? " collapsed" : ""}" data-city="${city}">
         <div class="city-group-head">
-          <button class="chip city-chip" data-city="${city}"
-                  style="--chip-border: ${border}; --chip-active-bg: ${activeBg}"
-                  onclick="toggleCity('${city}')">${city}</button>
           <button class="city-collapse" data-city="${city}"
                   aria-expanded="${isCollapsed ? "false" : "true"}"
                   aria-controls="${venuesId}"
-                  aria-label="${isCollapsed ? "Expand" : "Collapse"} ${city} venues"
-                  onclick="toggleCityCollapse('${city}')"><span class="city-count">${cityVenues.length}</span><span class="city-caret" aria-hidden="true">▾</span></button>
+                  aria-label="${isCollapsed ? "Expand" : "Collapse"} ${city}, ${cityVenues.length} venue${cityVenues.length === 1 ? "" : "s"}"
+                  onclick="toggleCityCollapse('${city}')"><span class="city-caret" aria-hidden="true">▾</span></button>
+          <button class="chip city-chip" data-city="${city}"
+                  style="--chip-border: ${border}; --chip-active-bg: ${activeBg}"
+                  onclick="toggleCity('${city}')">${city}</button>
+          <span class="city-count" aria-hidden="true">${cityVenues.length}</span>
         </div>
         <div class="city-venues" id="${venuesId}">${rows}</div>
       </div>`;

--- a/frontend/js/spotify.js
+++ b/frontend/js/spotify.js
@@ -197,7 +197,11 @@ function _onSpotifyReady() {
 }
 
 function _renderForYouChip() {
-  const chipGroup = document.getElementById("city-filters");
+  // #quick-filters is the row for chips that aren't a city. It used to be
+  // #city-filters, which no longer exists now that cities are group headers rather
+  // than a flat chip row; the fallback keeps this working against an older index.html.
+  const chipGroup = document.getElementById("quick-filters")
+                 || document.getElementById("city-filters");
   if (!chipGroup || document.getElementById("chip-for-you")) return;
   const chip = document.createElement("button");
   chip.id        = "chip-for-you";


### PR DESCRIPTION
Merges in:

- 
- A few very minor text adjustments to index.html (changed credits, non-live button shifted from "music" to "shows")
- Pulled in #73 : Versioning of CSS and JS URLs so we don't get crashes on mixed caching
- Pulled in #80 : Nesting venues within cities in the sidebar
- Pulled in #81 : Added a toggle to filter everything except users' favorited shows