### PR TITLE
Serve the Durham site on durm-shows.net, and fix its iCal subscription

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Triangle Shows aggregates live music listings from 21+ venues across the Triangl
 - **Hide shows** — hide events cluttering your view; restore them any time
 - **Calendar subscription** — add `https://triangle-shows.net/feeds/events.ics` to Apple Calendar, Google Calendar, or Outlook for live updates
 - **Color palettes** — 5 themes (Amber, Phosphor, Midnight, Wisteria, Durham) with light/dark modes
-- **Durham subdomain** — `durm.triangle-shows.net` shows only Durham venues with the Durham Bulls palette
+- **Durham site** — [durm-shows.net](https://durm-shows.net) shows only Durham venues with the Durham Bulls palette. `durm.triangle-shows.net` still works and serves the same thing
 
 ---
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -28,6 +28,10 @@ Browser
   ├── triangle-shows.org ──► Cloudflare ──► 301 redirect ──► triangle-shows.net
   │                          (never reaches an origin server)
   │
+  ├── durm-shows.net ──────┐  (and durm.triangle-shows.net)
+  │                        │   same app, same origin; the Durham variant is chosen
+  │                        │   client-side from the hostname, not by routing
+  │                        ▼
   └── triangle-shows.net ──► Cloudflare DNS (proxied)
                                │
                                ├─ SSL terminated here (Full mode, free managed cert)
@@ -77,10 +81,49 @@ contacted.
 |---|---|---|---|---|
 | triangle-shows.net | CNAME | `@` | the hashed `.run.app` hostname | Yes |
 | triangle-shows.net | CNAME | `www` | the hashed `.run.app` hostname | Yes |
+| triangle-shows.net | CNAME | `durm` | the hashed `.run.app` hostname | Yes |
 | triangle-shows.org | A | `@` | `192.0.2.1` (dummy) | Yes |
+| durm-shows.net | CNAME | `@` | the hashed `.run.app` hostname | Yes |
+| durm-shows.net | CNAME | `www` | the hashed `.run.app` hostname | Yes |
+
+Every hostname that should reach the app needs **two** things, not one: a proxied DNS
+record *and* a Worker route. The record alone gets the request to Cloudflare, where it
+arrives with `Host: durm-shows.net` and Cloud Run answers 404 — the Worker is what rewrites
+the Host header. See "Sites and hostnames" below.
 
 SSL mode is **Full**, with Always Use HTTPS on. Full works because the `.run.app` origin carries
 a valid Google-managed certificate.
+
+### Sites and hostnames
+
+One deployment serves both sites. There is no second service, no second build, and nothing
+host-aware on the backend — the Worker rewrites every incoming Host to the `.run.app` name,
+so FastAPI cannot tell the hostnames apart and does not need to.
+
+The Durham variant is selected **client-side**, by `detectSiteConfig()` in
+`frontend/js/config.js`, from `window.location.hostname`:
+
+| Hostname | Site |
+|---|---|
+| `durm-shows.net`, `www.durm-shows.net` | Durham |
+| `durm.*` (i.e. `durm.triangle-shows.net`) | Durham |
+| `durm-shows.localhost` | Durham — local preview only |
+| anything else | main Triangle site |
+
+That variant filters venues to `SITE_CONFIG.city`, swaps the ASCII title and subtitle, and
+pins the `durham` palette while hiding the palette picker.
+
+**Adding another city site** therefore needs three things and no infrastructure work beyond
+the first two:
+
+1. A proxied DNS record for the hostname, pointing at the hashed `.run.app` name
+2. A Worker route covering `<hostname>/*`, so the Host header gets rewritten
+3. A branch in `detectSiteConfig()` returning that city's config
+
+**Consequence worth remembering:** because selection is client-side and the origin is
+host-blind, a hostname with DNS but no Worker route returns 404 for the whole site, and a
+hostname with both but no `detectSiteConfig()` branch silently serves the *main* Triangle
+site rather than erroring.
 
 ### Origin hostnames
 

--- a/frontend/js/config.js
+++ b/frontend/js/config.js
@@ -5,9 +5,17 @@
 // production instead. Scoped to that exact port on purpose: the docker-compose stack
 // serves the real app on :8000 and must keep talking to its own local API.
 // CORS permits this — allow_origins is "*" with allow_credentials off.
+// Any *.localhost name is covered too, not just "localhost" itself: browsers resolve the
+// whole suffix to loopback, and the Durham variant is previewed at
+// durm-shows.localhost:8080, which would otherwise fall through to its own origin and
+// find no API there.
+const _isLoopbackHost =
+  location.hostname === "localhost" ||
+  location.hostname === "127.0.0.1" ||
+  location.hostname.endsWith(".localhost");
+
 const API_BASE =
-  (location.hostname === "localhost" || location.hostname === "127.0.0.1") &&
-  location.port === "8080"
+  _isLoopbackHost && location.port === "8080"
     ? "https://triangle-shows.net"
     : window.location.origin;
 
@@ -153,10 +161,28 @@ function fitAsciiTitle() {
 document.addEventListener("DOMContentLoaded", fitAsciiTitle);
 window.addEventListener("resize", fitAsciiTitle);
 
-// Per-subdomain site configuration. Detected once at load time from hostname.
-const SITE_CONFIG = (function () {
-  const host = window.location.hostname;
-  if (host.startsWith("durm.")) {
+// Per-site configuration, chosen from the hostname once at load time.
+//
+// The Durham variant answers on two kinds of host: its own domain, durm-shows.net, and
+// the older durm.* subdomain it grew out of. Both are kept working — the subdomain has
+// been linked to and bookmarked, and there is no reason to break it.
+//
+// Hostname detection is factored into a function taking the host explicitly rather than
+// reading window.location directly, so it can be exercised for a host other than the one
+// the page happens to be served from. Without that, the only way to check the Durham
+// variant is to deploy and visit it.
+// durm-shows.localhost is here so the Durham variant can be opened locally. Browsers
+// resolve *.localhost to the loopback address without a hosts-file entry, so
+// http://durm-shows.localhost:8080 reaches the local preview server and picks the variant
+// up from the hostname. Harmless in production: the name is unreachable from anywhere
+// except the machine serving it.
+const DURM_HOSTS = ["durm-shows.net", "www.durm-shows.net", "durm-shows.localhost"];
+
+function detectSiteConfig(host) {
+  host = String(host || "").toLowerCase();
+  // durm-shows.net is matched exactly; durm.* covers the subdomain form. Note these are
+  // genuinely different prefixes — "durm-shows.net" does not start with "durm.".
+  if (host.startsWith("durm.") || DURM_HOSTS.includes(host)) {
     return {
       city:      "Durham",
       title:     "durm-shows",
@@ -166,9 +192,11 @@ const SITE_CONFIG = (function () {
     };
   }
   return { city: null };
-})();
+}
 
-// Apply subdomain-specific title, subtitle, and default palette.
+const SITE_CONFIG = detectSiteConfig(window.location.hostname);
+
+// Apply site-specific title, subtitle, and default palette.
 // Runs after DOM is ready; palette is only defaulted if the user has no saved preference.
 function applySiteConfig() {
   if (!SITE_CONFIG.city) return;

--- a/frontend/js/filters.js
+++ b/frontend/js/filters.js
@@ -306,7 +306,14 @@ function subscribeToVenues() {
   const allCbs  = [...document.querySelectorAll(".venue-checkbox input[type=checkbox]")];
   const checked = allCbs.filter(cb => cb.checked);
   const params = new URLSearchParams();
-  if (checked.length > 0 && checked.length < allCbs.length) {
+
+  // "Everything is ticked, so no filter is needed" holds only on the main site, where the
+  // sidebar lists every venue. On a city-scoped site it lists that city's venues alone, so
+  // omitting the filter subscribes the visitor to the whole Triangle — the opposite of the
+  // page they are looking at. Measured on the Durham site: 8 of 8 ticked produced a bare
+  // /feeds/events.ics and a calendar full of Raleigh and Chapel Hill shows.
+  const cityScoped = typeof SITE_CONFIG === "object" && !!SITE_CONFIG.city;
+  if (checked.length > 0 && (cityScoped || checked.length < allCbs.length)) {
     params.set("venue", checked.map(cb => cb.dataset.venue).join(","));
   }
   // Match the feed to what the visitor is viewing: if they've opted into


### PR DESCRIPTION
The Durham variant answers on its own domain now, not only the durm.* subdomain it grew out of. Both keep working: the subdomain has been linked to and bookmarked, and there is no reason to break it.

Hostname detection moves into detectSiteConfig(host), taking the host as an argument rather than reading window.location inside an IIFE. That makes it checkable for a host other than the one the page is served from -- previously the only way to exercise the Durham branch was to deploy and visit it. Verified across twelve hostnames, including that durm-shows.net.evil.com and notdurm-shows.net both fall through to the main site: durm-shows.net is matched exactly and durm.* by prefix, and they are genuinely different prefixes since "durm-shows.net" does not begin with "durm.".

durm-shows.localhost is recognised as well, so the variant can be opened locally -- browsers resolve *.localhost to loopback with no hosts-file entry. The API escape hatch in config.js widens from the two literal loopback names to any *.localhost, or the Durham preview would fall through to its own origin and find no API there. Confirmed locally: durm-shows.localhost:8080 renders the durm-shows title, the Durham Bulls palette with the picker hidden, one city group, eight venues, and 882 events all in Durham.

Fixes a real bug that a dedicated domain makes much more visible. subscribeToVenues() skipped the venue filter whenever every checkbox was ticked, on the reasoning that "everything selected" means "no filter needed". That holds on the main site, where the sidebar lists all 22 venues. On a city-scoped site it lists eight, so 8-of-8 produced a bare /feeds/events.ics -- and someone subscribing from the Durham site got a calendar full of Raleigh and Chapel Hill shows. The filter is now always emitted when SITE_CONFIG.city is set.

ARCHITECTURE.md gains a "Sites and hostnames" section, because the model is not obvious from the code: one deployment serves both sites, the Worker rewrites every Host to the .run.app name so the backend cannot tell them apart, and the variant is chosen entirely client-side. It also records the two consequences worth knowing -- a hostname with DNS but no Worker route 404s the whole site, and one with both but no detectSiteConfig() branch silently serves the main site instead of erroring.