### PR TITLE
Serve Durham site on durm-shows.net and fix iCal subscription

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Triangle Shows aggregates live music listings from 21+ venues across the Triangl
 - **Hide shows** — hide events cluttering your view; restore them any time
 - **Calendar subscription** — add `https://triangle-shows.net/feeds/events.ics` to Apple Calendar, Google Calendar, or Outlook for live updates
 - **Color palettes** — 5 themes (Amber, Phosphor, Midnight, Wisteria, Durham) with light/dark modes
-- **Durham subdomain** — `durm.triangle-shows.net` shows only Durham venues with the Durham Bulls palette
+- **Durham site** — [durm-shows.net](https://durm-shows.net) shows only Durham venues with the Durham Bulls palette. `durm.triangle-shows.net` still works and serves the same thing
 
 ---
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -28,6 +28,10 @@ Browser
   ├── triangle-shows.org ──► Cloudflare ──► 301 redirect ──► triangle-shows.net
   │                          (never reaches an origin server)
   │
+  ├── durm-shows.net ──────┐  (and durm.triangle-shows.net)
+  │                        │   same app, same origin; the Durham variant is chosen
+  │                        │   client-side from the hostname, not by routing
+  │                        ▼
   └── triangle-shows.net ──► Cloudflare DNS (proxied)
                                │
                                ├─ SSL terminated here (Full mode, free managed cert)
@@ -77,10 +81,49 @@ contacted.
 |---|---|---|---|---|
 | triangle-shows.net | CNAME | `@` | the hashed `.run.app` hostname | Yes |
 | triangle-shows.net | CNAME | `www` | the hashed `.run.app` hostname | Yes |
+| triangle-shows.net | CNAME | `durm` | the hashed `.run.app` hostname | Yes |
 | triangle-shows.org | A | `@` | `192.0.2.1` (dummy) | Yes |
+| durm-shows.net | CNAME | `@` | the hashed `.run.app` hostname | Yes |
+| durm-shows.net | CNAME | `www` | the hashed `.run.app` hostname | Yes |
+
+Every hostname that should reach the app needs **two** things, not one: a proxied DNS
+record *and* a Worker route. The record alone gets the request to Cloudflare, where it
+arrives with `Host: durm-shows.net` and Cloud Run answers 404 — the Worker is what rewrites
+the Host header. See "Sites and hostnames" below.
 
 SSL mode is **Full**, with Always Use HTTPS on. Full works because the `.run.app` origin carries
 a valid Google-managed certificate.
+
+### Sites and hostnames
+
+One deployment serves both sites. There is no second service, no second build, and nothing
+host-aware on the backend — the Worker rewrites every incoming Host to the `.run.app` name,
+so FastAPI cannot tell the hostnames apart and does not need to.
+
+The Durham variant is selected **client-side**, by `detectSiteConfig()` in
+`frontend/js/config.js`, from `window.location.hostname`:
+
+| Hostname | Site |
+|---|---|
+| `durm-shows.net`, `www.durm-shows.net` | Durham |
+| `durm.*` (i.e. `durm.triangle-shows.net`) | Durham |
+| `durm-shows.localhost` | Durham — local preview only |
+| anything else | main Triangle site |
+
+That variant filters venues to `SITE_CONFIG.city`, swaps the ASCII title and subtitle, and
+pins the `durham` palette while hiding the palette picker.
+
+**Adding another city site** therefore needs three things and no infrastructure work beyond
+the first two:
+
+1. A proxied DNS record for the hostname, pointing at the hashed `.run.app` name
+2. A Worker route covering `<hostname>/*`, so the Host header gets rewritten
+3. A branch in `detectSiteConfig()` returning that city's config
+
+**Consequence worth remembering:** because selection is client-side and the origin is
+host-blind, a hostname with DNS but no Worker route returns 404 for the whole site, and a
+hostname with both but no `detectSiteConfig()` branch silently serves the *main* Triangle
+site rather than erroring.
 
 ### Origin hostnames
 

--- a/frontend/js/config.js
+++ b/frontend/js/config.js
@@ -5,9 +5,17 @@
 // production instead. Scoped to that exact port on purpose: the docker-compose stack
 // serves the real app on :8000 and must keep talking to its own local API.
 // CORS permits this — allow_origins is "*" with allow_credentials off.
+// Any *.localhost name is covered too, not just "localhost" itself: browsers resolve the
+// whole suffix to loopback, and the Durham variant is previewed at
+// durm-shows.localhost:8080, which would otherwise fall through to its own origin and
+// find no API there.
+const _isLoopbackHost =
+  location.hostname === "localhost" ||
+  location.hostname === "127.0.0.1" ||
+  location.hostname.endsWith(".localhost");
+
 const API_BASE =
-  (location.hostname === "localhost" || location.hostname === "127.0.0.1") &&
-  location.port === "8080"
+  _isLoopbackHost && location.port === "8080"
     ? "https://triangle-shows.net"
     : window.location.origin;
 
@@ -153,10 +161,28 @@ function fitAsciiTitle() {
 document.addEventListener("DOMContentLoaded", fitAsciiTitle);
 window.addEventListener("resize", fitAsciiTitle);
 
-// Per-subdomain site configuration. Detected once at load time from hostname.
-const SITE_CONFIG = (function () {
-  const host = window.location.hostname;
-  if (host.startsWith("durm.")) {
+// Per-site configuration, chosen from the hostname once at load time.
+//
+// The Durham variant answers on two kinds of host: its own domain, durm-shows.net, and
+// the older durm.* subdomain it grew out of. Both are kept working — the subdomain has
+// been linked to and bookmarked, and there is no reason to break it.
+//
+// Hostname detection is factored into a function taking the host explicitly rather than
+// reading window.location directly, so it can be exercised for a host other than the one
+// the page happens to be served from. Without that, the only way to check the Durham
+// variant is to deploy and visit it.
+// durm-shows.localhost is here so the Durham variant can be opened locally. Browsers
+// resolve *.localhost to the loopback address without a hosts-file entry, so
+// http://durm-shows.localhost:8080 reaches the local preview server and picks the variant
+// up from the hostname. Harmless in production: the name is unreachable from anywhere
+// except the machine serving it.
+const DURM_HOSTS = ["durm-shows.net", "www.durm-shows.net", "durm-shows.localhost"];
+
+function detectSiteConfig(host) {
+  host = String(host || "").toLowerCase();
+  // durm-shows.net is matched exactly; durm.* covers the subdomain form. Note these are
+  // genuinely different prefixes — "durm-shows.net" does not start with "durm.".
+  if (host.startsWith("durm.") || DURM_HOSTS.includes(host)) {
     return {
       city:      "Durham",
       title:     "durm-shows",
@@ -166,9 +192,11 @@ const SITE_CONFIG = (function () {
     };
   }
   return { city: null };
-})();
+}
 
-// Apply subdomain-specific title, subtitle, and default palette.
+const SITE_CONFIG = detectSiteConfig(window.location.hostname);
+
+// Apply site-specific title, subtitle, and default palette.
 // Runs after DOM is ready; palette is only defaulted if the user has no saved preference.
 function applySiteConfig() {
   if (!SITE_CONFIG.city) return;

--- a/frontend/js/filters.js
+++ b/frontend/js/filters.js
@@ -306,7 +306,14 @@ function subscribeToVenues() {
   const allCbs  = [...document.querySelectorAll(".venue-checkbox input[type=checkbox]")];
   const checked = allCbs.filter(cb => cb.checked);
   const params = new URLSearchParams();
-  if (checked.length > 0 && checked.length < allCbs.length) {
+
+  // "Everything is ticked, so no filter is needed" holds only on the main site, where the
+  // sidebar lists every venue. On a city-scoped site it lists that city's venues alone, so
+  // omitting the filter subscribes the visitor to the whole Triangle — the opposite of the
+  // page they are looking at. Measured on the Durham site: 8 of 8 ticked produced a bare
+  // /feeds/events.ics and a calendar full of Raleigh and Chapel Hill shows.
+  const cityScoped = typeof SITE_CONFIG === "object" && !!SITE_CONFIG.city;
+  if (checked.length > 0 && (cityScoped || checked.length < allCbs.length)) {
     params.set("venue", checked.map(cb => cb.dataset.venue).join(","));
   }
   // Match the feed to what the visitor is viewing: if they've opted into


### PR DESCRIPTION
This pull request updates the documentation and frontend logic to support a new dedicated Durham site at `durm-shows.net`, in addition to the existing `durm.triangle-shows.net` subdomain. The changes clarify how site variants are selected based on hostname, ensure local preview works for the Durham variant, and fix venue filtering logic for city-specific sites.

**Documentation updates for new Durham site:**

* Updated `README.md` to reference the new Durham site at `durm-shows.net`, noting that the old subdomain still works.
* Expanded `docs/ARCHITECTURE.md` with details on DNS, Cloudflare Worker routing, and client-side site selection for `durm-shows.net` and `durm.triangle-shows.net`. Added a new section explaining how additional city sites can be added and how site selection works. [[1]](diffhunk://#diff-ff21b6b9a3a33e9d9056ac96882cc348d7077612b5931068f7459707b21eb3d1R31-R34) [[2]](diffhunk://#diff-ff21b6b9a3a33e9d9056ac96882cc348d7077612b5931068f7459707b21eb3d1R84-R127)

**Frontend logic improvements:**

* Refactored `frontend/js/config.js` to centralize site detection in a new `detectSiteConfig()` function, supporting both the new Durham domain and subdomain, and enabling local preview at `durm-shows.localhost`. [[1]](diffhunk://#diff-6e31fa5c07bae264f94cb4c098e6f888523f49b030c04d05da630da8cda0e1fbR8-R18) [[2]](diffhunk://#diff-6e31fa5c07bae264f94cb4c098e6f888523f49b030c04d05da630da8cda0e1fbL156-R185) [[3]](diffhunk://#diff-6e31fa5c07bae264f94cb4c098e6f888523f49b030c04d05da630da8cda0e1fbL169-R199)

**Bug fix for venue filtering:**

* Fixed venue subscription logic in `frontend/js/filters.js` to ensure that, on city-specific sites like Durham, subscribing to all venues does not unintentionally include all Triangle venues.