### PR TITLE
Stop Alembic's fileConfig from dismantling app logging

### DIFF
--- a/backend/alembic/env.py
+++ b/backend/alembic/env.py
@@ -9,6 +9,7 @@ Requires: DATABASE_URL env var (falls back to alembic.ini), app.database.Base,
 
 # --- Imports ---
 
+import logging
 import os
 import sys
 from logging.config import fileConfig
@@ -34,8 +35,27 @@ if db_url:
     db_url = db_url.replace("ssl=require", "sslmode=require")
     config.set_main_option("sqlalchemy.url", db_url)
 
-# Configure logging from alembic.ini if a config file is present
-if config.config_file_name is not None:
+# Configure logging from alembic.ini — but only when nothing has configured it already.
+#
+# main.py applies migrations from inside its lifespan handler, which runs this file in the
+# app's own process. fileConfig defaults to disable_existing_loggers=True, so an
+# unconditional call here disabled every app.* logger and replaced root's handlers with
+# alembic.ini's. Two things broke, both silently:
+#
+#   * Nothing logged after migrations was emitted — no "Migrations applied", no
+#     per-request lines, and not one ERROR-severity entry across a period containing
+#     hundreds of HTTP 500s. That is issue #79, and it is why those 500s have no
+#     traceback to diagnose.
+#   * Root's handlers lost the redact_handler wrapper from #77, reopening the
+#     Ticketmaster credential sink for anything logging through root. #77's docstring
+#     names this residue exactly: "handlers installed *after* this runs are not
+#     covered".
+#
+# A root logger with handlers means somebody has already configured logging deliberately
+# — under the alembic CLI it has none, so the ini still applies there, which is the case
+# this call exists for. main.py additionally re-applies its own configuration after
+# migrations, so the fix does not depend on this check alone being right.
+if config.config_file_name is not None and not logging.getLogger().handlers:
     fileConfig(config.config_file_name)
 
 # Point Alembic at the full set of ORM models so it can diff against the live schema

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -81,6 +81,13 @@ def configure_logging() -> None:
     bet — if a future dependency installs a handler lazily, call this again once it has.
     """
     logging.basicConfig(level=getattr(logging, settings.LOG_LEVEL), format=LOG_FORMAT)
+    # basicConfig is a no-op once root has a handler, so on any call after the first it
+    # sets neither handler nor level. The level has to be asserted separately for a repeat
+    # call to mean anything: applying migrations in-process runs alembic.ini through
+    # fileConfig, which pins [logger_root] to WARN, and app.* loggers inherit from root.
+    # Without this line a post-migration configure_logging() leaves every INFO line
+    # suppressed while looking like it had restored things.
+    logging.getLogger().setLevel(getattr(logging, settings.LOG_LEVEL))
 
     # Snapshot the registry before walking it. loggerDict is the live dict that
     # logging.getLogger() inserts into, and the filter below runs Python between
@@ -151,6 +158,13 @@ async def lifespan(app: FastAPI):
 
     # Apply any pending Alembic migrations — creates tables on fresh DBs, updates schema on existing ones
     await asyncio.to_thread(_run_migrations)
+    # Re-apply logging after migrations. alembic/env.py declines to reconfigure logging
+    # when the app has already done so, but Alembic is exactly the "dependency that
+    # installs a handler lazily" this function's own docstring warns about, and calling it
+    # again is the remedy it prescribes. Idempotent (the redaction wrap never nests), and
+    # it means log visibility and credential redaction do not both hinge on that single
+    # check in env.py staying correct.
+    configure_logging()
     logger.info("Migrations applied")
 
     # Seed venues

--- a/backend/tests/test_logging_survives_migrations.py
+++ b/backend/tests/test_logging_survives_migrations.py
@@ -1,0 +1,148 @@
+"""
+Tests that running Alembic in-process does not dismantle the app's logging.
+
+main.py applies migrations from inside the lifespan handler, which executes
+alembic/env.py in this same process. env.py configures logging from alembic.ini, and
+`logging.config.fileConfig` defaults to ``disable_existing_loggers=True`` — so that call
+used to disable every ``app.*`` logger and replace root's handlers. The observable
+result in production was that everything logged before migrations reached Cloud Logging
+and nothing logged after them ever did: no "Migrations applied", no per-request lines,
+and — across a period containing hundreds of HTTP 500s — not one entry at ERROR
+severity.
+
+Two properties are pinned here, because the same call broke two unrelated things:
+
+* ``app.*`` loggers stay enabled and keep their level, so anything logged after
+  migrations is still emitted at all (issue #79).
+* Root's handlers stay wrapped by ``redact_handler``, so the Ticketmaster credential
+  redaction added in #77 keeps applying. ``fileConfig`` installs alembic.ini's own
+  ``StreamHandler`` on root; an unwrapped handler is a reopened sink. #77's docstring
+  names this exact residue — "handlers installed *after* this runs are not covered" —
+  and Alembic is a dependency that installs one lazily.
+
+The hostile call is reproduced against the real ``backend/alembic.ini`` rather than a
+fixture, so a change to that file's logger sections is caught here.
+"""
+
+import logging
+import logging.config
+from pathlib import Path
+
+import pytest
+
+from app.main import configure_logging
+from app.redaction import RedactingFormatter
+
+
+ALEMBIC_INI = Path(__file__).resolve().parents[1] / "alembic.ini"
+
+
+def _root_handlers_are_wrapped() -> bool:
+    """True when every handler on root carries #77's redaction wrapper.
+
+    redact_handler wraps by swapping in a RedactingFormatter and returns None, so the
+    presence of that formatter is the only readable signal — which is also exactly what
+    redact_handler itself checks to stay idempotent.
+    """
+    root = logging.getLogger()
+    if not root.handlers:
+        return False
+    return all(isinstance(h.formatter, RedactingFormatter) for h in root.handlers)
+
+
+@pytest.fixture
+def restore_logging():
+    """Snapshot and restore global logging state, so these tests cannot leak."""
+    root = logging.getLogger()
+    saved_handlers = list(root.handlers)
+    saved_level = root.level
+    saved_disabled = {
+        name: getattr(obj, "disabled", None)
+        for name, obj in logging.root.manager.loggerDict.items()
+        if isinstance(obj, logging.Logger)
+    }
+    yield
+    root.handlers = saved_handlers
+    root.setLevel(saved_level)
+    for name, was_disabled in saved_disabled.items():
+        obj = logging.root.manager.loggerDict.get(name)
+        if isinstance(obj, logging.Logger) and was_disabled is not None:
+            obj.disabled = was_disabled
+
+
+class TestAlembicIniIsStillHostile:
+    """Guards the premise. If alembic.ini stops disabling loggers on its own, the
+    assertions below would pass for the wrong reason and this file would be testing
+    nothing."""
+
+    def test_ini_exists(self):
+        assert ALEMBIC_INI.is_file(), f"expected {ALEMBIC_INI}"
+
+    def test_raw_fileconfig_still_disables_app_loggers(self, restore_logging):
+        """The unguarded call, as env.py used to make it."""
+        configure_logging()
+        app_logger = logging.getLogger("app.main")
+        assert not app_logger.disabled
+
+        logging.config.fileConfig(str(ALEMBIC_INI))
+
+        assert app_logger.disabled, (
+            "alembic.ini no longer disables existing loggers — the guard in "
+            "alembic/env.py may now be unnecessary, but check before removing it"
+        )
+
+
+class TestLoggingSurvivesAnInProcessMigration:
+    def test_app_loggers_stay_enabled_and_leveled(self, restore_logging):
+        """#79: the lines after 'Migrations applied' have to be emitted at all."""
+        configure_logging()
+        logging.config.fileConfig(str(ALEMBIC_INI), disable_existing_loggers=False)
+        configure_logging()  # what main.py now does after _run_migrations()
+
+        app_logger = logging.getLogger("app.main")
+        assert not app_logger.disabled
+        assert app_logger.getEffectiveLevel() <= logging.INFO, (
+            "alembic.ini pins [logger_root] to WARN; app loggers inherit from root, so "
+            "re-enabling them is not enough on its own"
+        )
+
+    def test_root_handlers_are_re_wrapped_for_redaction(self, restore_logging):
+        """#77: alembic.ini installs its own StreamHandler on root. Unwrapped, that is a
+        credential sink that reopened silently after startup."""
+        configure_logging()
+        assert _root_handlers_are_wrapped()
+
+        logging.config.fileConfig(str(ALEMBIC_INI), disable_existing_loggers=False)
+        configure_logging()
+
+        assert _root_handlers_are_wrapped(), (
+            "root carries a handler that redact_handler has not wrapped"
+        )
+
+    def test_a_record_logged_after_migrations_reaches_a_handler(self, restore_logging):
+        """End to end rather than by attribute: the point is that the record arrives.
+
+        Deliberately not caplog. fileConfig replaces root's handlers, which removes the
+        one caplog installed — so caplog reports nothing even when the record is being
+        emitted perfectly well to stderr. That false negative is worth naming: it is the
+        same shape as the original bug, a sink disappearing rather than a record going
+        missing.
+        """
+        configure_logging()
+        logging.config.fileConfig(str(ALEMBIC_INI), disable_existing_loggers=False)
+        configure_logging()
+
+        seen = []
+
+        class Capture(logging.Handler):
+            def emit(self, record):
+                seen.append(self.format(record))
+
+        sink = Capture()
+        logging.getLogger().addHandler(sink)
+        try:
+            logging.getLogger("app.main").info("Migrations applied")
+        finally:
+            logging.getLogger().removeHandler(sink)
+
+        assert any("Migrations applied" in line for line in seen)


### PR DESCRIPTION
Closes #79.

Everything logged before migrations reached Cloud Logging; nothing logged after them ever did. Three days of production logs held 163 application entries, **all of them startup lines**, and not one entry at ERROR severity across a period containing hundreds of HTTP 500s.

## Cause

`backend/alembic/env.py:39`:

```python
fileConfig(config.config_file_name)   # disable_existing_loggers defaults to True
```

`main.py` applies migrations from inside its lifespan handler, **in-process**, so that call disabled every `app.*` logger the moment migrations ran. `alembic.ini` compounds it two ways: `[logger_root] level = WARN`, which `app.*` loggers inherit, and `handlers = console`, which replaces root's handlers with its own.

The cut-off in the real logs matched line for line:

| Log line | Emitted | Arrived |
|---|---|---|
| `INFO: Uvicorn running on …` | before lifespan | yes |
| `app.main: Starting Triangle Shows API...` | before migrations | yes |
| `app.tokens: [tokens] …` ×2 | before migrations | yes |
| `alembic.runtime.migration: …` ×2 | Alembic's own logger | yes |
| **`Migrations applied`** | the very next line | **no** |
| **`Venues seeded`** | after | **no** |
| **any per-request line** | request time | **no** |
| **`INFO: Application startup complete.`** | uvicorn | **no** — its logger was disabled too |

## Fix

`env.py` configures logging from the ini **only when nothing has configured it already**. Under the standalone `alembic` CLI root has no handlers, so the ini still applies there — which is the case that call exists for. `main.py` additionally re-applies `configure_logging()` after migrations, so neither log visibility nor credential redaction depends on that one check staying correct.

That second call needed a fix inside `configure_logging()` to mean anything. **`logging.basicConfig` is a no-op once root has a handler**, so on a repeat call it sets neither handler nor level, and root stayed at the `WARN` alembic.ini had left. The level is now asserted separately:

```python
logging.getLogger().setLevel(getattr(logging, settings.LOG_LEVEL))
```

Mutation-checked: removing that single line turns two of these tests red.

## It also restores a security property #77 had just added

`configure_logging()` wraps every handler with `redact_handler` so the Ticketmaster credential cannot reach a log sink. Its docstring names the residue exactly:

> Residue worth knowing: handlers installed *after* this runs are not covered… if a future dependency installs a handler lazily, call this again once it has.

**Alembic is that dependency.** `fileConfig` installed an unwrapped `StreamHandler` on root after import, reopening the sink for anything logging through root. Pinned by `test_root_handlers_are_re_wrapped_for_redaction`.

## Verified against a real boot

The issue asked specifically not to trust a clean console. So this was checked by booting the app under docker-compose against real Postgres, not by asserting on logger attributes:

```
[INFO] app.main: Starting Triangle Shows API...
[INFO] alembic.runtime.migration: Running upgrade 0004 -> 0005, ...
[INFO] app.main: Migrations applied            <-- previously absent
[INFO] app.seed: Seed complete: 22 new, 0 updated venues   <-- previously absent
[INFO] app.main: Venues seeded                 <-- previously absent
INFO:     Application startup complete.        <-- previously absent
```

and a triggered scrape now emits every per-venue line from `app.scrapers.*`, which is the request-time path that had gone silent:

```
[INFO] app.scrapers.rhp_events: [RHP] Found 54 events for cats-cradle
[INFO] app.scrapers.manager: [cats-cradle] Scrape complete: 54 found, 54 created, ...
```

Alembic's own lines now carry the app's timestamped format rather than the ini's bare one, so boot output is consistent.

## Tests

Five, against the **real** `backend/alembic.ini` rather than a fixture, so a change to its logger sections is caught here. `TestAlembicIniIsStillHostile` guards the premise — if the ini stops disabling loggers, the others would pass for the wrong reason and it says so in the failure message.

One test deliberately avoids `caplog`: `fileConfig` removes the handler caplog installs, so caplog reports nothing even while the record is emitted perfectly to stderr. That false negative is the same shape as the original bug — a sink disappearing rather than a record going missing — and is worth naming rather than working around silently.

Backend suite: **324 passed, 4 skipped**.

## A correction to the record

`reclassify_all()` **contains no logger call.** The long-standing note that its `Reclassified` line never reaches Cloud Logging was misattributed — there is no such line. The count travels in `POST /api/scrape`'s response body, which is why that response was described as the reliable signal.

PR #59's body and the comment in `cloudbuild.yaml` are wrong on two counts: this logging did not work, and the specific line they name does not exist. Worth correcting when someone next touches either.

## Why this matters beyond tidiness

#78 (cold-start 500s, ~96/day, silently stopping scheduled scrapes) is characterised from the outside but undiagnosed, because the exception has nowhere to go. This is the prerequisite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
