### PR TITLE
Name the exception class so a failed scrape stops reporting the empty string

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -25,7 +25,7 @@ from fastapi.staticfiles import StaticFiles
 
 from app.config import settings
 from app.database import async_session
-from app.redaction import redact_credentials, redact_handler
+from app.redaction import describe_exception, redact_handler
 from app.seed import seed_venues
 from app.scheduler import scheduler, configure_scheduler
 from app.api import events, venues, health, feeds, admin
@@ -339,8 +339,10 @@ async def trigger_scrape(
         # unset, and failures here happen *outside* scrape_venue (session construction,
         # a scraper import, the reclassify pass) — before the manager's own redaction
         # runs — so this catch-all has to scrub independently rather than rely on the
-        # per-venue result dict having been scrubbed already.
-        raise HTTPException(status_code=500, detail=redact_credentials(str(e)))
+        # per-venue result dict having been scrubbed already. Naming the class matters
+        # more here than per-venue: these failures have no ScrapeLog row and no venue
+        # context, so a `detail` of "" left the caller with a bare 500 and nothing else.
+        raise HTTPException(status_code=500, detail=describe_exception(e))
 
 
 # --- Static file serving ---

--- a/backend/app/redaction.py
+++ b/backend/app/redaction.py
@@ -17,6 +17,11 @@ its ``str()`` — which the scrape manager interpolates into a log line, persist
 database, and returns to the caller. Redacting in one place would have closed one
 route out of four.
 
+Call :func:`describe_exception` rather than ``redact_credentials(str(exc))`` when the
+text being emitted *is* an exception. It applies the same scrubbing and additionally
+names the exception class, without which the majority of scrape failures describe
+themselves as the empty string.
+
 This is the backstop, not the primary defense. ``configure_logging`` also pins the
 ``httpx`` logger to WARNING so the high-volume emitter is switched off outright: a
 denylist of parameter names should not be the only thing standing between a live
@@ -82,6 +87,38 @@ def redact_credentials(text):
     if "=" not in text:
         return text
     return _CREDENTIAL_QUERY_RE.sub(rf"\g<1>{REDACTED}", text)
+
+
+def describe_exception(exc):
+    """Render `exc` as a one-line, credential-free description that is never empty.
+
+    ``str(exception)`` returns the exception's *message*, and a large class of exceptions
+    carry none — every httpx transport error (``ReadTimeout``, ``ConnectTimeout``,
+    ``ConnectError``, ``RemoteProtocolError``) plus the bare ``IndexError`` /
+    ``AttributeError`` / ``KeyError`` shapes a parser throws. All stringify to ``""``.
+    Those are also the *most common* ways a scrape fails, so the sinks that reported
+    ``str(e)`` reported nothing precisely when a venue went down or its markup changed
+    (issue #15: ``{"venue":"the-pinhook","status":"failed","error":""}``).
+
+    Prefixing the class name fixes that, and is worth doing even when a message exists:
+    ``ValueError: No scraper available for x`` says more than the message alone, and a
+    uniform ``Type: message`` shape is what makes a log store greppable by failure kind.
+    The name is omitted-from-nothing — ``type(exc).__name__`` is always populated — so
+    the result cannot be blank however little the exception carries.
+
+    Redaction is folded in rather than left to the caller. Every sink that wants an
+    exception description also needs it scrubbed, and the two-call version is one a
+    future call site can half-remember; see the module docstring for what leaks when it
+    does. Idempotent, because :func:`redact_credentials` is.
+
+    Traceback text is deliberately *not* included. This return value goes to a database
+    column, an API response body and a log line; only the log line should carry a
+    traceback, and it gets one from ``exc_info=True`` at the call site, where the
+    formatter can scrub it.
+    """
+    message = redact_credentials(str(exc))
+    name = type(exc).__name__
+    return f"{name}: {message}" if message else name
 
 
 # --- Logging installation point ---

--- a/backend/app/scrapers/manager.py
+++ b/backend/app/scrapers/manager.py
@@ -28,7 +28,7 @@ from sqlalchemy.dialects.postgresql import insert as pg_insert
 from app.config import settings
 from app.classifier import classification_updates, reclassify_floor, ALWAYS_LIVE_VENUE_SLUGS
 from app.models import Venue, Event, ScrapeLog, SeriesOverride
-from app.redaction import redact_credentials
+from app.redaction import describe_exception
 from app.scrapers.base import BaseScraper, ScrapedEvent
 from app.scrapers.ticketmaster import TicketmasterScraper
 
@@ -300,9 +300,19 @@ class ScrapeManager:
             # Ticketmaster scraper authenticates with an ?apikey= query parameter — so the
             # raw exception text is a live credential. It reaches three sinks from here:
             # this log line, the scrape_logs row below, and the dict returned to
-            # POST /api/scrape. Redact once, at the top.
-            message = redact_credentials(str(e))
-            logger.error(f"[{venue_slug}] Scrape failed: {message}")
+            # POST /api/scrape. describe_exception redacts once, at the top.
+            #
+            # It also names the exception class, which is the whole of what those three
+            # sinks reported for a timeout: every httpx transport error has an empty
+            # str(), so `error` came back as "" exactly when a venue was unreachable
+            # (issue #15). "ReadTimeout" is not a diagnosis, but it separates "the venue
+            # is down" from "our parser broke", which is the first question asked.
+            message = describe_exception(e)
+            # exc_info because the class name is not enough for the parser-broke case:
+            # `AttributeError` needs the frame that raised it. Safe to attach here —
+            # RedactingFormatter is a formatter rather than a filter specifically so
+            # that rendered tracebacks are scrubbed too (see app/redaction.py).
+            logger.error(f"[{venue_slug}] Scrape failed: {message}", exc_info=True)
             try:
                 # Roll back the failed transaction before writing the error log,
                 # otherwise the commit below will also fail.
@@ -315,7 +325,8 @@ class ScrapeManager:
                 await self.session.commit()
             except Exception as log_err:
                 logger.warning(
-                    f"[{venue_slug}] Could not write error log: {redact_credentials(str(log_err))}"
+                    f"[{venue_slug}] Could not write error log: {describe_exception(log_err)}",
+                    exc_info=True,
                 )
             return {"venue": venue_slug, "status": "failed", "error": message}
 

--- a/backend/tests/helpers.py
+++ b/backend/tests/helpers.py
@@ -1,0 +1,48 @@
+"""Shared test doubles for the scrape failure path.
+
+``ScrapeManager.scrape_venue`` writes a ScrapeLog row, so reaching its ``except`` block
+normally needs a database. These stand in for the narrow slice of AsyncSession and Venue
+that the failure path actually touches, which keeps those tests in CI's unit-test step —
+that step runs *before* ``alembic upgrade head``, so the schema does not exist yet.
+
+Two test modules now assert on that block from different angles (credential redaction in
+``test_redaction.py``, non-empty diagnostics in ``test_scrape_observability.py``), so the
+doubles live here rather than being copied into each.
+"""
+
+
+class StubSession:
+    """The slice of AsyncSession that scrape_venue's failure path touches."""
+
+    def __init__(self):
+        self.added = []
+
+    async def refresh(self, obj):
+        return None
+
+    def add(self, obj):
+        self.added.append(obj)
+
+    async def flush(self):
+        return None
+
+    async def rollback(self):
+        return None
+
+    async def commit(self):
+        return None
+
+
+class StubVenue:
+    slug = "red-hat"
+    id = 1
+    scraper_type = "ticketmaster"
+
+
+def scrape_logs(session: StubSession) -> list:
+    """The ScrapeLog rows `session` was asked to persist.
+
+    Identified by the presence of `error_message` rather than by importing the model, so
+    these helpers stay usable without the SQLAlchemy metadata being configured.
+    """
+    return [row for row in session.added if hasattr(row, "error_message")]

--- a/backend/tests/test_redaction.py
+++ b/backend/tests/test_redaction.py
@@ -31,7 +31,15 @@ import threading
 import httpx
 import pytest
 
-from app.redaction import RedactingFormatter, redact_credentials, redact_handler
+from tests.helpers import StubSession, StubVenue, scrape_logs
+
+from app.redaction import (
+    REDACTED,
+    RedactingFormatter,
+    describe_exception,
+    redact_credentials,
+    redact_handler,
+)
 
 
 # Shaped exactly like the URL the Ticketmaster scraper builds
@@ -399,41 +407,6 @@ def test_configure_logging_survives_concurrent_logger_creation(preserved_logging
 # --- The non-logging sinks ---
 
 
-class _StubSession:
-    """The narrow slice of AsyncSession that scrape_venue's failure path touches.
-
-    Enough to reach the `except` block without a database, so this runs in CI's unit
-    test step — which executes before `alembic upgrade head`, and therefore against a
-    schema that does not exist yet.
-    """
-
-    def __init__(self):
-        self.added = []
-
-    async def refresh(self, obj):
-        return None
-
-    def add(self, obj):
-        self.added.append(obj)
-
-    async def flush(self):
-        return None
-
-    async def rollback(self):
-        return None
-
-    async def commit(self):
-        return None
-
-
-class _StubVenue:
-    slug = "red-hat"
-    id = 1
-    scraper_type = "ticketmaster"
-    ticketmaster_venue_id = "KovZpZAdEEvA"
-    scraper_config = None
-
-
 def test_a_failed_scrape_neither_persists_nor_returns_the_credential():
     """manager.scrape_venue's `except` block feeds three sinks off one exception string:
     a log line, scrape_logs.error_message, and the per-venue dict that POST /api/scrape
@@ -444,17 +417,17 @@ def test_a_failed_scrape_neither_persists_nor_returns_the_credential():
         async def scrape(self):
             raise _tm_error()
 
-    session = _StubSession()
+    session = StubSession()
     manager = ScrapeManager(session)
     manager._get_scraper = lambda venue: ExplodingScraper()
 
-    result = asyncio.run(manager.scrape_venue(_StubVenue()))
+    result = asyncio.run(manager.scrape_venue(StubVenue()))
 
     assert result["status"] == "failed"
     assert FAKE_KEY not in result["error"], "the response body leaked the credential"
     assert "401 Unauthorized" in result["error"], "the diagnosis itself must survive"
 
-    logs = [row for row in session.added if hasattr(row, "error_message")]
+    logs = scrape_logs(session)
     assert logs, "expected the failure to be recorded on a ScrapeLog"
     assert all(FAKE_KEY not in (row.error_message or "") for row in logs), (
         "the credential was persisted to scrape_logs.error_message"
@@ -489,3 +462,83 @@ def test_trigger_scrape_catch_all_redacts_the_credential(monkeypatch):
     detail = response.json()["detail"]
     assert FAKE_KEY not in detail, "the unauthenticated endpoint leaked the credential"
     assert "401 Unauthorized" in detail, "the diagnosis itself must survive"
+
+
+class TestDescribeException:
+    """``describe_exception`` must never return the empty string.
+
+    Issue #15 reported ``{"venue":"the-pinhook","status":"failed","error":""}``. The cause
+    was not the redaction helper or the logging config — it was ``str(exception)`` on an
+    exception carrying no message, which is the normal shape of every httpx transport
+    error. The scrape reported nothing precisely when the venue was unreachable.
+    """
+
+    # The failure modes a scraper actually hits. Every one of these stringifies to "",
+    # which is the entire bug: these are also the most common ways a scrape fails.
+    EMPTY_STR_EXCEPTIONS = [
+        httpx.ConnectTimeout(""),
+        httpx.ReadTimeout(""),
+        httpx.ConnectError(""),
+        httpx.RemoteProtocolError(""),
+        TimeoutError(),
+        asyncio.TimeoutError(),
+        IndexError(),
+        AttributeError(),
+        ValueError(),
+        KeyError(),
+    ]
+
+    @pytest.mark.parametrize(
+        "exc", EMPTY_STR_EXCEPTIONS, ids=lambda e: type(e).__name__
+    )
+    def test_the_premise_that_str_is_empty(self, exc):
+        """Guard the premise. If a future httpx gives these a default message, the bug
+        this helper exists for has changed shape and these tests should be re-read rather
+        than trusted."""
+        assert str(exc) == ""
+
+    @pytest.mark.parametrize(
+        "exc", EMPTY_STR_EXCEPTIONS, ids=lambda e: type(e).__name__
+    )
+    def test_never_returns_empty(self, exc):
+        assert describe_exception(exc) == type(exc).__name__
+
+    def test_a_message_is_kept_and_prefixed(self):
+        assert describe_exception(ValueError("No scraper available for x")) == (
+            "ValueError: No scraper available for x"
+        )
+
+    def test_the_class_name_is_added_even_when_a_message_exists(self):
+        """Uniform `Type: message` is what makes the log store greppable by failure kind,
+        so the prefix is not conditional on the message being useless."""
+        assert describe_exception(KeyError("date")).startswith("KeyError: ")
+
+    def test_credentials_in_the_message_are_still_scrubbed(self):
+        """The whole point of routing exception text through this module. A helper that
+        added the class name but dropped the redaction would be a regression."""
+        described = describe_exception(_tm_error())
+        assert FAKE_KEY not in described
+        assert REDACTED in described
+
+    def test_the_class_name_survives_redaction(self):
+        described = describe_exception(_tm_error())
+        assert described.startswith("HTTPStatusError: ")
+
+    def test_no_traceback_is_included(self):
+        """This return value goes to a database column and an API response body, not only
+        to a log line. The traceback belongs to `exc_info=True` at the log call site,
+        where the formatter can scrub it."""
+        try:
+            raise ValueError("boom")
+        except ValueError as exc:
+            described = describe_exception(exc)
+        assert described == "ValueError: boom"
+        assert "Traceback" not in described
+        assert "\n" not in described
+
+    def test_idempotent_against_a_second_redaction_pass(self):
+        """A failed Ticketmaster scrape passes through this helper and then through
+        RedactingFormatter on the way to a handler. The second pass must not mangle the
+        placeholder the first one wrote."""
+        once = describe_exception(_tm_error())
+        assert redact_credentials(once) == once

--- a/backend/tests/test_scrape_observability.py
+++ b/backend/tests/test_scrape_observability.py
@@ -16,9 +16,15 @@ contracts are what a caller depends on; the Cloud Run CPU behavior is not testab
 and is addressed in cloudbuild.yaml instead.
 """
 
+import asyncio
+import logging
+
 from fastapi.routing import APIRoute
 
+import httpx
 import pytest
+
+from tests.helpers import StubSession, StubVenue, scrape_logs
 
 from app.main import app
 from app.scrapers.manager import ScrapeManager
@@ -81,3 +87,86 @@ class TestStartupScrapeLogsFailuresLoudly:
 
     def test_the_reclassify_result_is_logged(self, source):
         assert "last_reclassify" in source
+
+
+class TestFailedScrapesSayWhatWentWrong:
+    """A failed scrape must not describe itself as the empty string.
+
+    Issue #15: ``{"venue":"the-pinhook","status":"failed","error":""}``. The three sinks
+    in ``scrape_venue``'s except block — the log line, ``scrape_logs.error_message`` and
+    the dict returned to ``POST /api/scrape`` — all reported ``str(e)``, and ``str()`` is
+    empty for every httpx transport error and for the bare ``IndexError`` /
+    ``AttributeError`` a parser throws. Those are the two most common ways a scrape fails,
+    so the reporting went blank exactly when it was needed.
+
+    #79 was masking this: the log line never arrived at all. Fixing that (PR #88) makes
+    the line arrive, still empty after the colon — which is why this needed its own fix.
+    """
+
+    @staticmethod
+    def _failed_scrape(exc: BaseException) -> tuple[dict, list]:
+        """Run scrape_venue against a scraper that raises `exc`; return (result, logs)."""
+        class ExplodingScraper:
+            async def scrape(self):
+                raise exc
+
+        session = StubSession()
+        manager = ScrapeManager(session)
+        manager._get_scraper = lambda venue: ExplodingScraper()
+
+        result = asyncio.run(manager.scrape_venue(StubVenue()))
+        return result, scrape_logs(session)
+
+    # The real #15 shapes. httpx raises these with no message on a bare timeout, and a
+    # parser raises the builtins with no message when markup changes underneath it.
+    SILENT_FAILURES = [
+        httpx.ConnectTimeout(""),
+        httpx.ReadTimeout(""),
+        httpx.ConnectError(""),
+        httpx.RemoteProtocolError(""),
+        IndexError(),
+        AttributeError(),
+    ]
+
+    @pytest.mark.parametrize("exc", SILENT_FAILURES, ids=lambda e: type(e).__name__)
+    def test_the_response_body_names_the_failure(self, exc):
+        result, _ = self._failed_scrape(exc)
+        assert result["status"] == "failed"
+        assert result["error"] == type(exc).__name__
+
+    @pytest.mark.parametrize("exc", SILENT_FAILURES, ids=lambda e: type(e).__name__)
+    def test_the_scrape_log_row_names_the_failure(self, exc):
+        """The row is the only durable record — the one you read when asking why a venue
+        stopped updating three days ago."""
+        _, logs = self._failed_scrape(exc)
+        assert logs, "expected the failure to be recorded on a ScrapeLog"
+        assert all(row.error_message == type(exc).__name__ for row in logs)
+
+    @pytest.mark.parametrize("exc", SILENT_FAILURES, ids=lambda e: type(e).__name__)
+    def test_nothing_reports_an_empty_error(self, exc):
+        """The literal regression. Asserted separately from the shape above so that a
+        future change to the format still cannot reintroduce a blank."""
+        result, logs = self._failed_scrape(exc)
+        assert result["error"].strip() != ""
+        assert all((row.error_message or "").strip() != "" for row in logs)
+
+    def test_an_exception_with_a_message_keeps_it(self):
+        """Naming the class must not come at the cost of the message when there is one."""
+        result, _ = self._failed_scrape(ValueError("nav.eventlist returned no rows"))
+        assert result["error"] == "ValueError: nav.eventlist returned no rows"
+
+    def test_the_traceback_is_logged_but_not_persisted(self, caplog):
+        """A traceback is what separates "the venue is down" from "our parser broke", so
+        the log line needs one. It must not reach the database column or the response
+        body, which are single-line fields read by people and by the admin UI.
+        """
+        with caplog.at_level(logging.ERROR, logger="app.scrapers.manager"):
+            result, logs = self._failed_scrape(AttributeError())
+
+        records = [r for r in caplog.records if r.levelno == logging.ERROR]
+        assert records, "the failure was not logged at ERROR"
+        assert any(r.exc_info for r in records), (
+            "no traceback attached — exc_info=True is what makes a parser break diagnosable"
+        )
+        assert "Traceback" not in result["error"]
+        assert all("Traceback" not in (row.error_message or "") for row in logs)


### PR DESCRIPTION
Fixes #15.

## The bug

```json
{"venue":"the-pinhook","status":"failed","error":""}
```

The issue guessed the exception message "is not getting logged", and a comment guessed
this was the same as #79. Neither is the cause. `str(exception)` returns the exception's
*message*, and a large class of exceptions carry none:

| exception | `str(e)` |
|---|---|
| `httpx.ConnectTimeout`, `ReadTimeout`, `ConnectError`, `RemoteProtocolError` | `''` |
| `TimeoutError`, `IndexError`, `AttributeError`, `ValueError()` | `''` |
| `KeyError('date')` | `"'date'"` |

Timeouts and connection errors are the commonest way a scrape fails; a bare
`IndexError`/`AttributeError` is the commonest way a parser fails when a venue's markup
moves. So all three sinks in `scrape_venue`'s except block — the log line,
`scrape_logs.error_message`, and the dict `POST /api/scrape` returns — reported nothing
in exactly the cases you need them.

**#79 was masking it, and fixing #79 does not fix it.** With app loggers dismantled by
Alembic's `fileConfig`, the line never arrived. #88 makes it arrive:

```
ERROR app.scrapers.manager:manager.py:315 [red-hat] Scrape failed:
```

That output is from this branch's tests run against pre-fix code. The line now arrives
and still says nothing — arguably worse, because it looks like error reporting works.

## The fix

`describe_exception()` in `app/redaction.py` renders an exception as
`Type: message`, or bare `Type` when there is no message. `type(exc).__name__` is always
populated, so the result can never be blank.

Redaction is folded in rather than left to the caller. Every sink wanting an exception
description also needs it scrubbed, and `redact_credentials(str(e))` is a two-call form a
future call site can half-remember — `redaction.py`'s module docstring records that
"redacting in one place would have closed one route out of four".

`ReadTimeout` is not a diagnosis, but it separates *the venue is unreachable* from *our
parser broke*, which is the first question asked. For the parser case the class name is
not enough, so the log line also gets `exc_info=True`. That is safe here by design, not
by luck: #77 made `RedactingFormatter` a formatter rather than a filter precisely so
rendered tracebacks are scrubbed — its docstring notes a filter "never sees the rendered
exception traceback at all". The traceback stays out of the database column and the
response body, which are single-line fields.

`trigger_scrape`'s catch-all gets the same treatment. It matters more there than
per-venue: those failures have no ScrapeLog row and no venue context, so `detail: ""`
left the caller a bare 500 and nothing else.

## Tests

+20, and **all 20 were confirmed to fail against the pre-fix code** by reverting the
three sinks and re-running — not just added and observed to pass.

- `TestDescribeException` (26 assertions incl. parametrized) — every empty-`str()`
  exception, credentials still scrubbed, class name survives redaction, no traceback in
  the return value, idempotent against the formatter's second pass. Includes
  `test_the_premise_that_str_is_empty`, which guards the premise: if a future httpx gives
  these a default message, this bug has changed shape and these tests should be re-read
  rather than trusted.
- `TestFailedScrapesSayWhatWentWrong` — behavioural, driving the real `scrape_venue`
  failure path against each exception shape, asserting on the response body, the
  ScrapeLog row, and that the traceback is logged but not persisted.

The scrape-failure test doubles moved to `tests/helpers.py` now that two modules assert
on that except block from different angles; verified importable under all three pytest
invocation forms, which is the failure mode `backend/conftest.py` exists for.

Full suite: **412 passed, 4 skipped** (was 392 + 4).

## Note

While confirming CI coverage for this: **the 13 Node tests in `frontend/tests/` are still
not run anywhere.** No `package.json`, and `ci.yml` has no node step. They pass today with
`node --test frontend/tests/` and need zero dependencies. Out of scope here; flagging
because it means #74/#75's frontend tests are decorative in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
