### PR TITLE
Run the frontend tests in CI, and fail loudly if they stop being discovered

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,43 @@ on:
   pull_request:
 
 jobs:
+  frontend-tests:
+    name: Frontend unit tests
+    runs-on: ubuntu-latest
+
+    # A separate job rather than a step in smoke-test below. These tests need neither
+    # Postgres nor Python, so folding them in would make them queue behind a database
+    # container and a pip install for no reason, and a failure would report under a name
+    # ("Migrations + API smoke test") that says nothing about what broke. As their own
+    # job they run in parallel, so total wall-clock does not grow.
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          # No cache: key, and no `npm ci` step, because there is no package.json. The
+          # tests import only node:test, node:assert, node:fs, node:path and node:vm —
+          # all built in. Keeping them dependency-free is deliberate (see the header of
+          # frontend/tests/favorites.test.js), so there is nothing to install or cache.
+
+      - name: Run frontend unit tests
+        run: |
+          # `node --test <dir>` exits 0 when it matches no files. So renaming this
+          # directory, or renaming a file off the *.test.js pattern, would leave this job
+          # green having executed nothing — which is the same silent-gap failure this job
+          # exists to close: the tests added in #74 and #75 sat unrun for weeks because
+          # CI was Python-only, and nothing reported their absence. Assert discovery
+          # explicitly so that gap cannot reopen quietly.
+          shopt -s nullglob
+          files=(frontend/tests/*.test.js)
+          if [ ${#files[@]} -eq 0 ]; then
+            echo "::error::No test files matched frontend/tests/*.test.js — the tests were not run."
+            exit 1
+          fi
+          echo "Discovered ${#files[@]} test file(s): ${files[*]}"
+          node --test --test-reporter=spec frontend/tests/
+
   smoke-test:
     name: Migrations + API smoke test
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -56,6 +56,34 @@ See [SELF-HOSTING.md](docs/SELF-HOSTING.md) for setup instructions.
 
 ---
 
+## Running the tests
+
+Two suites, and CI runs both on every pull request.
+
+**Backend** — pytest, from `backend/`:
+
+```bash
+python -m pytest tests -q
+```
+
+A handful of migration tests need a reachable PostgreSQL server and skip cleanly without
+one, so a local run with no database still passes. CI stands up a Postgres service
+container, so they do run there.
+
+**Frontend** — Node's built-in test runner, from the repo root:
+
+```bash
+node --test frontend/tests/
+```
+
+No `package.json`, no `npm install`, no dependencies: these use only `node:test`,
+`node:assert`, `node:fs`, `node:path` and `node:vm`. Requires Node 18 or newer. Keeping
+them dependency-free is deliberate — a browser-less runner that needs no toolchain is
+what makes it reasonable to test plain `<script>` files at all, by evaluating them in a
+`vm` context with only the globals they actually touch.
+
+---
+
 ## Project structure
 
 ```
@@ -78,6 +106,7 @@ frontend/
     config.js       # Color palettes, API base URL, site config
     modal.js        # Event detail modal
     favorites.js    # Heart, hide, restore, and export logic
+  tests/            # Node built-in test runner, no dependencies
 tools/              # Dev utilities (see below)
   mockups/          # Static HTML design explorations
 docs/               # Architecture and self-hosting guides


### PR DESCRIPTION
The 13 Node tests added by #74 and #75 **have never run anywhere.** There is no
`package.json`, and `ci.yml` was Python-only, so nothing executed them and nothing
reported their absence — they passed review, landed, and became decorative.

They pass today, unchanged:

```
ℹ tests 13
ℹ pass 13
ℹ fail 0
```

## Shape

A separate job, not a step in `smoke-test`. These tests need neither Postgres nor Python,
so folding them in would queue them behind a database container and a `pip install` for no
reason, and a failure would report under a name — "Migrations + API smoke test" — that says
nothing about what broke. As their own job they run in parallel, so total wall-clock does
not grow.

No `package.json`, no install step, no cache. The tests import only `node:test`,
`node:assert`, `node:fs`, `node:path` and `node:vm`. Staying dependency-free is what makes
it reasonable to test plain `<script>` files at all — they get evaluated in a `vm` context
seeded with just the globals they touch — so there is deliberately nothing to install.

## The discovery guard is the part worth reviewing

**`node --test <dir>` exits 0 when it matches no files.** Verified rather than assumed, by
pointing it at an empty directory:

```
# pass 0
# fail 0
exit code: 0
```

So renaming `frontend/tests/`, or renaming a file off the `*.test.js` pattern, would leave
this job **green having executed nothing** — reopening the exact silent gap this job closes,
in the form that looks most like success. Hence the explicit assertion that at least one
file matched, with a `::error::` annotation when it doesn't. Confirmed to exit 1 against a
non-existent directory:

```
::error::No test files matched frontend/tests/*.test.js — the tests were not run.
exit code: 1
```

## Also

- A **"Running the tests"** section in the README, which documented neither suite. It notes
  that the Postgres-dependent migration tests skip cleanly without a local database, which
  is otherwise a surprise.
- `frontend/tests/` added to the project-structure listing.
- Node pinned to `20`, matching the version these were verified against; the runner needs
  18+.
- `--test-reporter=spec` so the Actions log is readable rather than raw TAP.

No branch protection on `main`, so the new check needs no required-status configuration —
worth knowing if that changes later, since it would then need adding by name.

## Verification

- workflow YAML parses; two jobs resolve as expected
- the run step was executed verbatim in bash locally: 13 pass, exit 0
- the guard was executed against a missing directory: exit 1 with the annotation

🤖 Generated with [Claude Code](https://claude.com/claude-code)
