### PR TITLE
Admin duplicate flagging: review queue, fold action, and read-path exclusions

### DIFF
--- a/backend/app/admin_ui.py
+++ b/backend/app/admin_ui.py
@@ -133,7 +133,12 @@ ADMIN_HTML = """<!doctype html>
            border-radius:2px; font-size:0.72rem; margin-top:1rem; color:#b8b6b3; }
   .hidden { display:none; }
   /* --- Duplicate review (#63) --- */
-  .b.dupe { background:#3d2033; color:#e08ac8; }
+  /* text-transform:none, unlike every other badge. This is the only badge whose text
+     contains user data — the surviving listing's name — and act names are often
+     deliberately cased ("MF DOOM", "girl in red", "SOPHIE"). Uppercasing them throws that
+     away and reads as shouting. The badge keeps its pill and colour, so the inconsistency
+     is a casing difference in exchange for not mangling a band's name. */
+  .b.dupe { background:#3d2033; color:#e08ac8; text-transform:none; }
   /* One card per candidate cluster. A card rather than more table rows because the unit
      of decision is the cluster, not the row: the admin picks a winner from a small set,
      and a bordered group makes the boundary of that choice unambiguous. */
@@ -154,10 +159,10 @@ ADMIN_HTML = """<!doctype html>
   .crow button.keep { border-color:#2f5c40; color:#7fd69a; }
   .crow button.keep:hover { background:#1f3d2a; }
   .crow button:hover { border-color:var(--accent); color:var(--accent); }
-  /* A folded row is indented under the cluster and dimmed, so "hidden from the public
+  /* A hidden row is indented under the cluster and dimmed, so "hidden from the public
      calendar" reads visually rather than needing the badge to be parsed. */
-  .crow.folded { padding-left:1.7rem; border-left:2px solid #3d2033; background:#121215; }
-  .crow.folded .ct { color:#8a8a8e; }
+  .crow.hiddenrow { padding-left:1.7rem; border-left:2px solid #3d2033; background:#121215; }
+  .crow.hiddenrow .ct { color:#8a8a8e; }
   #dupes .empty { border:1px solid #2a2a2e; border-radius:2px; background:#141417; }
   #err { color:#e0625f; font-size:0.75rem; margin:0 0 0.7rem; min-height:1em; }
 </style>
@@ -244,16 +249,20 @@ ADMIN_HTML = """<!doctype html>
       <p><b>Two different shows on one night is normal</b> — an early and a late set, a
       support show in the back room. Those will appear here and you should leave them. The
       list isn't a to-do list you can empty; it's the set of nights worth a glance.</p>
-      <p><b>keep this one</b> is pressed on the listing you want to survive; everything else
-      on that night folds into it. You press the row you're keeping, not the ones you're
-      hiding, so there's no way to get the direction backwards.</p>
-      <p>Folding <b>hides, it doesn't delete</b>. The row stays in the database pointing at
-      the one you kept, disappears from the public calendar and the subscription feed, and
-      can be brought back with <b>unfold</b> — here, or from the review queue where it shows
-      a pink badge. If you later delete the listing you kept, anything folded into it comes
-      back automatically rather than staying hidden behind a row that no longer exists.</p>
-      <p>The scraper won't undo your decision either: a folded row is protected from the
-      pass that deletes listings a venue has stopped advertising.</p>
+      <p><b>keep this one</b> is pressed on the listing you want to survive; every other
+      listing on that night is then hidden as a duplicate of it. You press the row you're
+      keeping, not the ones you're hiding, so there's no way to get the direction
+      backwards.</p>
+      <p>This <b>hides, it doesn't delete</b>. The hidden row stays in the database,
+      recorded as a duplicate of the one you kept. It disappears from the public calendar
+      and the subscription feed, but stays visible to you — here, and in the review queue
+      with a pink <b>duplicate of "…"</b> badge naming the listing that won. <b>not a
+      duplicate</b> brings it straight back.</p>
+      <p>Nothing else can strand it, either. If you later delete the listing you kept, the
+      hidden ones reappear on the calendar by themselves rather than staying hidden behind
+      a row that no longer exists. And the scraper won't undo your decision: a row you've
+      hidden is protected from the pass that deletes listings a venue has stopped
+      advertising.</p>
     </div>
     <table id="queueTable">
       <thead><tr><th>date</th><th>event</th><th>status</th><th>actions</th></tr></thead>
@@ -292,14 +301,23 @@ ADMIN_HTML = """<!doctype html>
   }
 
   function badge(ev) {
-    // The duplicate badge leads. A folded row is hidden from the public calendar
-    // whatever its live-music verdict says, so showing the verdict first would describe
-    // a row by a flag that currently has no effect.
+    // The duplicate badge leads. A hidden row is out of the public calendar whatever its
+    // live-music verdict says, so showing the verdict first would describe a row by a flag
+    // that currently has no effect.
+    //
+    // Named, not numbered: "duplicate of Sub Rosa" is something an admin can recognise;
+    // "duplicate of 41" is not. The name can be missing if the survivor was deleted
+    // between the two queries, so fall back rather than printing "undefined".
     let dupe = '';
     if (ev.duplicate_of_id) {
-      dupe = '<span class="b dupe">duplicate of ' + ev.duplicate_of_id + '</span> ';
+      const of = ev.duplicate_of_name
+        ? 'duplicate of "' + esc(ev.duplicate_of_name) + '"'
+        : 'hidden as a duplicate';
+      dupe = '<span class="b dupe">' + of + '</span> ';
     } else if (ev.hidden_duplicate_count) {
-      dupe = '<span class="b dupe">' + ev.hidden_duplicate_count + ' folded in</span> ';
+      const n = ev.hidden_duplicate_count;
+      dupe = '<span class="b dupe">' + n + ' hidden duplicate' + (n === 1 ? '' : 's') +
+             '</span> ';
     }
     if (ev.is_manual_override)
       return dupe + '<span class="b manual">manual: ' + (ev.is_live_music ? 'live' : 'non-live') + '</span>';
@@ -318,11 +336,16 @@ ADMIN_HTML = """<!doctype html>
   }
 
   function actions(ev) {
-    // A folded row gets one action and no others. Its classification is moot while it is
+    // A hidden row gets one action and no others. Its classification is moot while it is
     // hidden, and offering "mark live" on a row nobody can see invites the admin to spend
     // a decision on something with no effect.
+    //
+    // "not a duplicate" says what clicking it asserts. "unfold" only meant anything to a
+    // reader who already knew the folding metaphor — and that metaphor was wrong anyway:
+    // it implies the two rows were combined, when nothing is combined and the row is only
+    // hidden with a pointer to the survivor.
     if (ev.duplicate_of_id) {
-      return '<button onclick="unfold(' + ev.id + ')">unfold</button>';
+      return '<button onclick="unfold(' + ev.id + ')">not a duplicate</button>';
     }
     let a = approveAction(ev, false, 1) + ' ';
     if (ev.is_manual_override) {
@@ -502,19 +525,23 @@ ADMIN_HTML = """<!doctype html>
 
   function clusterRow(ev, survivors) {
     if (ev.duplicate_of_id) {
-      return '<div class="crow folded">' +
+      const of = ev.duplicate_of_name
+        ? 'duplicate of "' + esc(ev.duplicate_of_name) + '"'
+        : 'hidden as a duplicate';
+      return '<div class="crow hiddenrow">' +
         '<span class="ct">' + esc(ev.name) + '</span>' + timeLabel(ev) +
-        '<span class="b dupe">folded into ' + ev.duplicate_of_id + '</span>' +
-        '<button onclick="unfold(' + ev.id + ')">unfold</button></div>';
+        '<span class="b dupe">' + of + '</span>' +
+        '<button onclick="unfold(' + ev.id + ')">not a duplicate</button></div>';
     }
-    // "keep this one" acts on the row the admin wants to survive, and folds every other
-    // unfolded row in the cluster into it. Acting on the winner rather than the loser is
+    // "keep this one" acts on the row the admin wants to survive, and hides every other
+    // visible row in the cluster as a duplicate of it. Acting on the winner rather than
+    // the loser is
     // deliberate: a "mark as duplicate" button sits on the row that loses and forces the
     // admin to reason about the other row while clicking this one, which is how the wrong
     // row gets hidden.
     const others = survivors.filter((s) => s !== ev.id);
     const n = others.length;
-    const label = n === 1 ? 'keep this one' : 'keep this one (folds ' + n + ')';
+    const label = n === 1 ? 'keep this one' : 'keep this one (hides ' + n + ')';
     return '<div class="crow">' +
       '<span class="ct">' + esc(ev.name) + '</span>' + timeLabel(ev) +
       (ev.is_manually_created ? '<span class="b manual">hand-added</span>' : '') +
@@ -581,7 +608,7 @@ ADMIN_HTML = """<!doctype html>
     const n = duplicateIds.length;
     if (!confirm('Hide ' + n + ' other listing' + (n === 1 ? '' : 's') +
                  ' on this night, keeping the one you chose?\\n\\n' +
-                 'They stay in the database and can be unfolded here at any time.')) return;
+                 'They stay in the database, and you can restore any of them here at any time.')) return;
     await foldAction(() => api('/admin/api/events/' + survivorId + '/absorb',
               { method: 'POST', body: JSON.stringify({ duplicate_ids: duplicateIds }) }));
   }

--- a/backend/app/admin_ui.py
+++ b/backend/app/admin_ui.py
@@ -132,6 +132,34 @@ ADMIN_HTML = """<!doctype html>
   #rules { white-space:pre-wrap; background:#17171a; border:1px solid #2a2a2e; padding:0.8rem;
            border-radius:2px; font-size:0.72rem; margin-top:1rem; color:#b8b6b3; }
   .hidden { display:none; }
+  /* --- Duplicate review (#63) --- */
+  .b.dupe { background:#3d2033; color:#e08ac8; }
+  /* One card per candidate cluster. A card rather than more table rows because the unit
+     of decision is the cluster, not the row: the admin picks a winner from a small set,
+     and a bordered group makes the boundary of that choice unambiguous. */
+  .cluster { border:1px solid #2a2a2e; border-radius:2px; margin-bottom:0.7rem; background:#141417; }
+  .cluster > .chead { display:flex; align-items:baseline; gap:0.6rem; flex-wrap:wrap;
+           padding:0.5rem 0.7rem; border-bottom:1px solid #1e1e22; }
+  .cluster > .chead .cv { color:#e8e6e3; font-weight:700; }
+  .cluster > .chead .cd { color:#a8a6a3; }
+  .cluster > .chead .sp { flex:1; }
+  .score { color:#8a8a8e; font-size:0.68rem; text-transform:uppercase; letter-spacing:0.06em; }
+  .crow { display:flex; align-items:baseline; gap:0.6rem; flex-wrap:wrap; padding:0.45rem 0.7rem;
+          border-bottom:1px solid #1a1a1e; }
+  .crow:last-child { border-bottom:none; }
+  .crow .ct { flex:1; min-width:12rem; color:#e8e6e3; }
+  .crow .cm { color:#8a8a8e; font-size:0.72rem; }
+  .crow button { font-family:inherit; font-size:0.68rem; padding:0.22rem 0.5rem;
+          border:1px solid #3a3a3e; background:transparent; color:#c8c6c3; cursor:pointer; border-radius:2px; }
+  .crow button.keep { border-color:#2f5c40; color:#7fd69a; }
+  .crow button.keep:hover { background:#1f3d2a; }
+  .crow button:hover { border-color:var(--accent); color:var(--accent); }
+  /* A folded row is indented under the cluster and dimmed, so "hidden from the public
+     calendar" reads visually rather than needing the badge to be parsed. */
+  .crow.folded { padding-left:1.7rem; border-left:2px solid #3d2033; background:#121215; }
+  .crow.folded .ct { color:#8a8a8e; }
+  #dupes .empty { border:1px solid #2a2a2e; border-radius:2px; background:#141417; }
+  #err { color:#e0625f; font-size:0.75rem; margin:0 0 0.7rem; min-height:1em; }
 </style>
 </head><body>
   <header>
@@ -143,6 +171,10 @@ ADMIN_HTML = """<!doctype html>
   </header>
   <main>
     <div class="controls">
+      <button class="fbtn on" data-v="queue" onclick="setView('queue')">review queue</button>
+      <button class="fbtn" data-v="duplicates" onclick="setView('duplicates')">duplicates</button>
+    </div>
+    <div class="controls" id="queueControls">
       <button class="fbtn on" data-f="non_live" onclick="setFilter('non_live')">non-live</button>
       <button class="fbtn" data-f="live" onclick="setFilter('live')">live</button>
       <button class="fbtn" data-f="all" onclick="setFilter('all')">all</button>
@@ -152,6 +184,11 @@ ADMIN_HTML = """<!doctype html>
       <input id="search" placeholder="search name / artist...">
       <span id="count"></span>
     </div>
+    <div class="controls hidden" id="dupeControls">
+      <button class="fbtn tog on" id="dupeFutureBtn" aria-pressed="true" onclick="toggleDupeFuture()">future dates only</button>
+      <span id="dupeCount"></span>
+    </div>
+    <p id="err"></p>
     <pre id="rules" class="hidden"></pre>
     <div id="help" class="hidden">
       <h2>What this page is for</h2>
@@ -197,21 +234,56 @@ ADMIN_HTML = """<!doctype html>
       <p><b>detection rules</b> lists the automatic criteria: keyword matches, and how many
       repeats at one venue count as a recurring series. Anything auto-flagged shows its
       reason next to the badge.</p>
+
+      <h2>Duplicates</h2>
+      <p>The <b>duplicates</b> tab lists every case of one venue having two or more listings
+      on one night. That's the only thing it checks — no title matching decides anything,
+      because rules that compared titles got this wrong twice, in opposite directions.
+      Similarity is used <i>only</i> to sort the list, so the likely duplicates are at the
+      top and being wrong about the order costs nothing.</p>
+      <p><b>Two different shows on one night is normal</b> — an early and a late set, a
+      support show in the back room. Those will appear here and you should leave them. The
+      list isn't a to-do list you can empty; it's the set of nights worth a glance.</p>
+      <p><b>keep this one</b> is pressed on the listing you want to survive; everything else
+      on that night folds into it. You press the row you're keeping, not the ones you're
+      hiding, so there's no way to get the direction backwards.</p>
+      <p>Folding <b>hides, it doesn't delete</b>. The row stays in the database pointing at
+      the one you kept, disappears from the public calendar and the subscription feed, and
+      can be brought back with <b>unfold</b> — here, or from the review queue where it shows
+      a pink badge. If you later delete the listing you kept, anything folded into it comes
+      back automatically rather than staying hidden behind a row that no longer exists.</p>
+      <p>The scraper won't undo your decision either: a folded row is protected from the
+      pass that deletes listings a venue has stopped advertising.</p>
     </div>
-    <table>
+    <table id="queueTable">
       <thead><tr><th>date</th><th>event</th><th>status</th><th>actions</th></tr></thead>
       <tbody id="tbody"></tbody>
     </table>
+    <div id="dupes" class="hidden"></div>
   </main>
 <script>
   let RULES = null;
   const $ = (s) => document.querySelector(s);
-  const state = { filter: 'non_live', search: '', futureOnly: false, showApproved: false };
+  // dupeFutureOnly defaults true, matching the endpoint: a duplicate is a problem with a
+  // specific upcoming night, and past ones are archive debris nobody needs prompting about.
+  const state = {
+    view: 'queue', filter: 'non_live', search: '', futureOnly: false, showApproved: false,
+    dupeFutureOnly: true,
+  };
 
   async function api(path, opts) {
     const r = await fetch(path, Object.assign({ headers: { 'Content-Type': 'application/json' } }, opts));
     if (r.status === 401) { location.href = '/admin/login'; throw new Error('unauth'); }
-    if (!r.ok) throw new Error('http ' + r.status);
+    if (!r.ok) {
+      // Carry the server's `detail` through. The fold endpoints refuse a chain or a
+      // self-reference with a sentence explaining which row to use instead, and throwing
+      // a bare 'http 400' would discard exactly the part the admin needs to act on.
+      let detail = null;
+      try { detail = (await r.json()).detail; } catch (_) {}
+      const err = new Error(detail || ('http ' + r.status));
+      err.detail = detail;
+      throw err;
+    }
     return r.status === 204 ? null : r.json();
   }
 
@@ -220,9 +292,18 @@ ADMIN_HTML = """<!doctype html>
   }
 
   function badge(ev) {
+    // The duplicate badge leads. A folded row is hidden from the public calendar
+    // whatever its live-music verdict says, so showing the verdict first would describe
+    // a row by a flag that currently has no effect.
+    let dupe = '';
+    if (ev.duplicate_of_id) {
+      dupe = '<span class="b dupe">duplicate of ' + ev.duplicate_of_id + '</span> ';
+    } else if (ev.hidden_duplicate_count) {
+      dupe = '<span class="b dupe">' + ev.hidden_duplicate_count + ' folded in</span> ';
+    }
     if (ev.is_manual_override)
-      return '<span class="b manual">manual: ' + (ev.is_live_music ? 'live' : 'non-live') + '</span>';
-    return '<span class="b ' + (ev.is_live_music ? 'live' : 'nonlive') + '">' +
+      return dupe + '<span class="b manual">manual: ' + (ev.is_live_music ? 'live' : 'non-live') + '</span>';
+    return dupe + '<span class="b ' + (ev.is_live_music ? 'live' : 'nonlive') + '">' +
            (ev.is_live_music ? 'live' : 'non-live') + '</span> ' +
            '<span class="reason">' + esc(ev.classification_reason || '') + '</span>';
   }
@@ -237,6 +318,12 @@ ADMIN_HTML = """<!doctype html>
   }
 
   function actions(ev) {
+    // A folded row gets one action and no others. Its classification is moot while it is
+    // hidden, and offering "mark live" on a row nobody can see invites the admin to spend
+    // a decision on something with no effect.
+    if (ev.duplicate_of_id) {
+      return '<button onclick="unfold(' + ev.id + ')">unfold</button>';
+    }
     let a = approveAction(ev, false, 1) + ' ';
     if (ev.is_manual_override) {
       a += '<button onclick="clearOv(' + ev.id + ')">clear override</button>';
@@ -402,6 +489,137 @@ ADMIN_HTML = """<!doctype html>
     render(data.events, data.count, data.total, data.approved_hidden);
   }
 
+  // --- Duplicate review (#63) ---
+
+  function timeLabel(ev) {
+    // Time is the field that actually distinguishes an early show from a late one, so it
+    // is the most useful thing to put next to two near-identical titles.
+    const t = ev.show_time || ev.doors_time;
+    if (!t) return '<span class="cm">no time listed</span>';
+    const kind = ev.show_time ? 'show' : 'doors';
+    return '<span class="cm">' + kind + ' ' + esc(t.slice(0, 5)) + '</span>';
+  }
+
+  function clusterRow(ev, survivors) {
+    if (ev.duplicate_of_id) {
+      return '<div class="crow folded">' +
+        '<span class="ct">' + esc(ev.name) + '</span>' + timeLabel(ev) +
+        '<span class="b dupe">folded into ' + ev.duplicate_of_id + '</span>' +
+        '<button onclick="unfold(' + ev.id + ')">unfold</button></div>';
+    }
+    // "keep this one" acts on the row the admin wants to survive, and folds every other
+    // unfolded row in the cluster into it. Acting on the winner rather than the loser is
+    // deliberate: a "mark as duplicate" button sits on the row that loses and forces the
+    // admin to reason about the other row while clicking this one, which is how the wrong
+    // row gets hidden.
+    const others = survivors.filter((s) => s !== ev.id);
+    const n = others.length;
+    const label = n === 1 ? 'keep this one' : 'keep this one (folds ' + n + ')';
+    return '<div class="crow">' +
+      '<span class="ct">' + esc(ev.name) + '</span>' + timeLabel(ev) +
+      (ev.is_manually_created ? '<span class="b manual">hand-added</span>' : '') +
+      (ev.is_approved ? '<span class="b live">approved</span>' : '') +
+      '<button class="keep" onclick="absorb(' + ev.id + ',[' + others.join(',') + '])">' +
+        label + '</button></div>';
+  }
+
+  function renderDuplicates(data) {
+    const shown = data.count, total = data.total;
+    $('#dupeCount').innerHTML = total
+      ? (shown < total ? '<span class="warn">' + shown + ' of ' + total + ' shown</span>'
+                       : shown + ' cluster(s)')
+      : '';
+    if (!data.clusters.length) {
+      $('#dupes').innerHTML = '<div class="empty">no venue has two listings on one night' +
+        (state.dupeFutureOnly ? ' from today onward' : '') + '</div>';
+      return;
+    }
+    let html = '';
+    data.clusters.forEach((c) => {
+      const survivors = c.events.filter((e) => !e.duplicate_of_id).map((e) => e.id);
+      html += '<div class="cluster">' +
+        '<div class="chead"><span class="cv">' + esc(c.venue_name || 'unknown venue') + '</span>' +
+        '<span class="cd">' + c.date + '</span><span class="sp"></span>' +
+        // Surfaced so the ordering is legible: a queue whose top score is low means
+        // nothing likely is left, rather than looking like the sort is broken.
+        '<span class="score">similarity ' + c.score.toFixed(2) + '</span></div>';
+      c.events.forEach((ev) => { html += clusterRow(ev, survivors); });
+      html += '</div>';
+    });
+    $('#dupes').innerHTML = html;
+  }
+
+  async function loadDuplicates() {
+    const q = new URLSearchParams({ future_only: state.dupeFutureOnly ? 'true' : 'false' });
+    renderDuplicates(await api('/admin/api/duplicates?' + q.toString()));
+  }
+
+  function showError(e) {
+    $('#err').textContent = (e && (e.detail || e.message)) || 'something went wrong';
+  }
+
+  // Every fold action goes through here. The catch has to live in the *action*, not in
+  // reload(): api() throws, so an uncaught rejection escapes the click handler entirely
+  // and reload() is never reached — the admin sees an unchanged page and no message,
+  // which is the silent failure the error line exists to prevent. The fold endpoints
+  // refuse a chain with a sentence naming the row to use instead, and that sentence is
+  // the whole value of surfacing it.
+  async function foldAction(fn) {
+    $('#err').textContent = '';
+    try {
+      await fn();
+    } catch (e) {
+      showError(e);
+      return;
+    }
+    reload();
+  }
+
+  async function absorb(survivorId, duplicateIds) {
+    // Folding hides rows rather than deleting them, and every fold is undoable from the
+    // row it creates — so this asks once, plainly, rather than with a scary warning.
+    const n = duplicateIds.length;
+    if (!confirm('Hide ' + n + ' other listing' + (n === 1 ? '' : 's') +
+                 ' on this night, keeping the one you chose?\\n\\n' +
+                 'They stay in the database and can be unfolded here at any time.')) return;
+    await foldAction(() => api('/admin/api/events/' + survivorId + '/absorb',
+              { method: 'POST', body: JSON.stringify({ duplicate_ids: duplicateIds }) }));
+  }
+
+  async function unfold(id) {
+    await foldAction(() => api('/admin/api/events/' + id + '/unfold', { method: 'POST' }));
+  }
+
+  function setView(v) {
+    state.view = v;
+    document.querySelectorAll('.fbtn[data-v]').forEach((b) => b.classList.toggle('on', b.dataset.v === v));
+    const isQueue = v === 'queue';
+    $('#queueControls').classList.toggle('hidden', !isQueue);
+    $('#queueTable').classList.toggle('hidden', !isQueue);
+    $('#dupeControls').classList.toggle('hidden', isQueue);
+    $('#dupes').classList.toggle('hidden', isQueue);
+    reload();
+  }
+
+  function toggleDupeFuture() {
+    state.dupeFutureOnly = !state.dupeFutureOnly;
+    $('#dupeFutureBtn').classList.toggle('on', state.dupeFutureOnly);
+    $('#dupeFutureBtn').setAttribute('aria-pressed', state.dupeFutureOnly ? 'true' : 'false');
+    loadDuplicates();
+  }
+
+  // Single entry point so an action can refresh whichever view is open without each
+  // handler having to know which one that is. absorb/unfold are reachable from both.
+  // Its own catch covers a failure to *load*; a failed action is caught in foldAction,
+  // which never gets here.
+  async function reload() {
+    try {
+      if (state.view === 'duplicates') await loadDuplicates(); else await load();
+    } catch (e) {
+      showError(e);
+    }
+  }
+
   async function ov(id, isLive) {
     await api('/admin/api/events/' + id + '/override', { method: 'POST', body: JSON.stringify({ is_live_music: isLive }) });
     load();
@@ -477,7 +695,7 @@ ADMIN_HTML = """<!doctype html>
       clearTimeout(t);
       t = setTimeout(() => { state.search = e.target.value.trim(); load(); }, 300);
     });
-    load();
+    reload();
   });
 </script>
 </body></html>

--- a/backend/app/api/admin.py
+++ b/backend/app/api/admin.py
@@ -227,6 +227,21 @@ async def admin_rules() -> dict:
     return criteria_summary()
 
 
+async def _survivor_names(
+    session: AsyncSession, ids: list[Optional[int]]
+) -> dict[int, str]:
+    """Map event id to name, for the non-null ids in `ids`.
+
+    Shared by the moderation list and the duplicate queue so both label a hidden row with
+    the surviving listing's name rather than its id.
+    """
+    wanted = {i for i in ids if i is not None}
+    if not wanted:
+        return {}
+    rows = await session.execute(select(Event.id, Event.name).where(Event.id.in_(wanted)))
+    return {event_id: name for event_id, name in rows.all()}
+
+
 @router.get("/api/events", dependencies=[Depends(require_admin)])
 async def admin_events(
     filter: str = Query("non_live", pattern="^(non_live|live|all)$"),
@@ -306,9 +321,9 @@ async def admin_events(
         key = (venue_id, normalize_series_name(name))
         series_sizes[key] = series_sizes.get(key, 0) + 1
 
-    # How many rows are folded into each event on this page, so a survivor can say
-    # "2 hidden duplicates" instead of the folded rows simply being absent. Scoped to the
-    # ids actually shown rather than counting the whole table.
+    # How many hidden duplicates each event on this page has, so a surviving row can say
+    # so instead of the hidden rows simply being absent. Scoped to the ids actually shown
+    # rather than counting the whole table.
     fold_counts: dict[int, int] = {}
     if events:
         fold_rows = await session.execute(
@@ -317,6 +332,14 @@ async def admin_events(
             .group_by(Event.duplicate_of_id)
         )
         fold_counts = {target: n for target, n in fold_rows.all()}
+
+    # The surviving row's *name*, for rows that are themselves hidden. The badge has to
+    # read "duplicate of Sub Rosa" rather than "duplicate of 41": an event id is not
+    # something an admin can recognise, and the whole point of the badge is to say which
+    # listing won. The survivor may not be on this page — it can be filtered out, or on
+    # another date entirely after a cross-date fold — so it is looked up rather than
+    # resolved from the rows already loaded.
+    survivor_names = await _survivor_names(session, [e.duplicate_of_id for e in events])
 
     out = []
     for e in events:
@@ -334,10 +357,11 @@ async def admin_events(
             "classification_reason": e.classification_reason,
             "is_approved": e.approved_at is not None,
             "is_manually_created": e.is_manually_created,
-            # Duplicate state (#63). A folded row stays visible here — it is only hidden
+            # Duplicate state (#63). A hidden row stays visible here — it is only hidden
             # from the public calendar — so the admin can see what was suppressed and undo
             # it, which is the entire reason duplicate_of_id is a pointer and not a delete.
             "duplicate_of_id": e.duplicate_of_id,
+            "duplicate_of_name": survivor_names.get(e.duplicate_of_id),
             "hidden_duplicate_count": fold_counts.get(e.id, 0),
             # Detail shown when a row is expanded, to judge live-vs-not by hand.
             # Descriptions are sparse (~10% of events), so the ticket link is often
@@ -528,6 +552,13 @@ async def list_duplicate_candidates(
     clusters = build_clusters(list(rows))
     total = len(clusters)
 
+    # A hidden row's survivor is usually inside the same cluster, but not after a
+    # cross-date or cross-venue fold, so resolve names rather than reading them off the
+    # members already loaded.
+    survivor_names = await _survivor_names(
+        session, [m.duplicate_of_id for c in clusters for m in c["members"]]
+    )
+
     out = []
     for cluster in clusters[:limit]:
         members = cluster["members"]
@@ -553,6 +584,7 @@ async def list_duplicate_candidates(
                 "is_manually_created": m.is_manually_created,
                 "is_approved": m.approved_at is not None,
                 "duplicate_of_id": m.duplicate_of_id,
+                "duplicate_of_name": survivor_names.get(m.duplicate_of_id),
             } for m in members],
         })
 
@@ -646,7 +678,10 @@ async def unfold_duplicate(
     event_id: int,
     session: AsyncSession = Depends(get_session),
 ) -> dict:
-    """Clear `event_id`'s duplicate flag, returning it to the public calendar."""
+    """Clear `event_id`'s duplicate flag, returning it to the public calendar.
+
+    Reached from the admin's "not a duplicate" control.
+    """
     event = await session.get(Event, event_id)
     if not event:
         raise HTTPException(status_code=404, detail="Event not found")

--- a/backend/app/api/admin.py
+++ b/backend/app/api/admin.py
@@ -19,7 +19,7 @@ from fastapi import APIRouter, Depends, HTTPException, Request, Query
 from fastapi.responses import HTMLResponse, JSONResponse, RedirectResponse
 from itsdangerous import URLSafeTimedSerializer, BadSignature, SignatureExpired
 from pydantic import BaseModel
-from sqlalchemy import select, and_, or_, func
+from sqlalchemy import select, and_, or_, func, tuple_
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import joinedload
 
@@ -27,6 +27,7 @@ from app.config import settings
 from app.database import get_session
 from app.models import Event, Venue, SeriesOverride
 from app.classifier import normalize_series_name, criteria_summary, reclassify_floor
+from app.duplicates import FoldError, build_clusters, validate_fold
 from app.scrapers.manager import ScrapeManager
 from app.admin_ui import LOGIN_HTML, ADMIN_HTML
 from app import tokens
@@ -305,6 +306,18 @@ async def admin_events(
         key = (venue_id, normalize_series_name(name))
         series_sizes[key] = series_sizes.get(key, 0) + 1
 
+    # How many rows are folded into each event on this page, so a survivor can say
+    # "2 hidden duplicates" instead of the folded rows simply being absent. Scoped to the
+    # ids actually shown rather than counting the whole table.
+    fold_counts: dict[int, int] = {}
+    if events:
+        fold_rows = await session.execute(
+            select(Event.duplicate_of_id, func.count())
+            .where(Event.duplicate_of_id.in_([e.id for e in events]))
+            .group_by(Event.duplicate_of_id)
+        )
+        fold_counts = {target: n for target, n in fold_rows.all()}
+
     out = []
     for e in events:
         series_key = normalize_series_name(e.name)
@@ -320,6 +333,12 @@ async def admin_events(
             "is_manual_override": e.is_manual_override,
             "classification_reason": e.classification_reason,
             "is_approved": e.approved_at is not None,
+            "is_manually_created": e.is_manually_created,
+            # Duplicate state (#63). A folded row stays visible here — it is only hidden
+            # from the public calendar — so the admin can see what was suppressed and undo
+            # it, which is the entire reason duplicate_of_id is a pointer and not a delete.
+            "duplicate_of_id": e.duplicate_of_id,
+            "hidden_duplicate_count": fold_counts.get(e.id, 0),
             # Detail shown when a row is expanded, to judge live-vs-not by hand.
             # Descriptions are sparse (~10% of events), so the ticket link is often
             # the only way to settle an ambiguous one.
@@ -452,6 +471,190 @@ async def unapprove_event(
             unapproved += 1
     await session.commit()
     return {"ok": True, "id": event_id, "unapproved": unapproved}
+
+
+# --- Duplicate flagging (issue #63) ---
+
+
+class FoldBody(BaseModel):
+    """Ids to fold into the survivor named in the path."""
+
+    duplicate_ids: list[int]
+
+
+@router.get("/api/duplicates", dependencies=[Depends(require_admin)])
+async def list_duplicate_candidates(
+    future_only: bool = Query(True, description="Hide clusters before today"),
+    limit: int = Query(200, ge=1, le=1000),
+    session: AsyncSession = Depends(get_session),
+) -> dict:
+    """Clusters of events that might be duplicates: same venue, same date, two or more.
+
+    Candidate selection is by fact rather than by title inference, deliberately — see
+    app/duplicates.py for why. Similarity only orders the result.
+
+    Defaults to future dates only, the opposite of /api/events. The classification queue
+    wants history because a series action reaches back; a duplicate is a listing problem
+    on a specific night, and past ones are archive debris nobody needs prompting about
+    (#63 notes the reconcile pass deliberately never touches them either).
+    """
+    floor = date.today() if future_only else reclassify_floor()
+
+    # Two queries rather than loading every event and grouping in Python: find the
+    # (venue, date) pairs that have two or more *unfolded* rows, then fetch the rows for
+    # those pairs only. Keeps both bounded on a table that grows without limit.
+    #
+    # Counting only unfolded rows is what makes a cluster resolve itself — folding a row
+    # drops it out of this count, so a reviewed cluster disappears with nothing recording
+    # that it was reviewed.
+    pair_rows = await session.execute(
+        select(Event.venue_id, Event.date)
+        .where(Event.date >= floor, Event.duplicate_of_id.is_(None))
+        .group_by(Event.venue_id, Event.date)
+        .having(func.count() > 1)
+    )
+    pairs = pair_rows.all()
+    if not pairs:
+        return {"clusters": [], "count": 0, "total": 0}
+
+    # Folded rows are fetched too, so a cluster can show what was previously absorbed.
+    result = await session.execute(
+        select(Event)
+        .options(joinedload(Event.venue))
+        .where(tuple_(Event.venue_id, Event.date).in_([(v, d) for v, d in pairs]))
+    )
+    rows = result.unique().scalars().all()
+
+    clusters = build_clusters(list(rows))
+    total = len(clusters)
+
+    out = []
+    for cluster in clusters[:limit]:
+        members = cluster["members"]
+        venue = next((m.venue for m in members if m.venue), None)
+        out.append({
+            "venue_id": cluster["venue_id"],
+            "venue_name": venue.name if venue else None,
+            "date": cluster["date"].isoformat(),
+            # Surfaced so the ordering is legible rather than mysterious, and so a queue
+            # topped by low scores is visibly "nothing likely left" instead of looking
+            # like a bug.
+            "score": round(cluster["score"], 3),
+            "all_approved": cluster["all_approved"],
+            "events": [{
+                "id": m.id,
+                "name": m.name,
+                "artist": m.artist,
+                "show_time": m.show_time.isoformat() if m.show_time else None,
+                "doors_time": m.doors_time.isoformat() if m.doors_time else None,
+                "price_min": m.price_min,
+                "ticket_url": m.ticket_url,
+                "is_live_music": m.is_live_music,
+                "is_manually_created": m.is_manually_created,
+                "is_approved": m.approved_at is not None,
+                "duplicate_of_id": m.duplicate_of_id,
+            } for m in members],
+        })
+
+    return {"clusters": out, "count": len(out), "total": total}
+
+
+@router.post("/api/events/{event_id}/absorb", dependencies=[Depends(require_admin)])
+async def absorb_duplicates(
+    event_id: int,
+    body: FoldBody,
+    session: AsyncSession = Depends(get_session),
+) -> dict:
+    """Fold `body.duplicate_ids` into `event_id`, which survives.
+
+    The survivor is the path parameter because that is the direction the UI acts in: the
+    admin presses "keep this one" on the row they want, and everything else in the cluster
+    folds into it. A "mark this a duplicate" endpoint would put the id of the *loser* in
+    the path and make the caller name the winner in the body, which is the same write with
+    the reasoning inverted — and inverting it is how the wrong row gets hidden.
+
+    Folding hides rows; it never deletes them. plan_upsert's reconcile guard
+    (scraper_must_not_delete) keeps the scraper from deleting them either, which is what
+    makes this reversible at all.
+    """
+    survivor = await session.get(Event, event_id)
+    if not survivor:
+        raise HTTPException(status_code=404, detail="Event not found")
+
+    requested = list(dict.fromkeys(body.duplicate_ids))
+    rows = (await session.execute(
+        select(Event).where(Event.id.in_(requested + [event_id]))
+    )).scalars().all()
+    by_id = {r.id: r for r in rows}
+
+    missing = [i for i in requested if i not in by_id]
+    if missing:
+        raise HTTPException(
+            status_code=404,
+            detail=f"Event(s) not found: {', '.join(str(i) for i in missing)}",
+        )
+
+    try:
+        ids = validate_fold(
+            event_id,
+            requested,
+            already_folded={i: by_id[i].duplicate_of_id for i in by_id},
+        )
+    except FoldError as exc:
+        raise HTTPException(status_code=400, detail=str(exc))
+
+    # Refuse to fold a row that already survives other rows: those rows point at it, and
+    # hiding it would leave them hidden behind something hidden — the chain case, arriving
+    # from the other direction. validate_fold cannot see this; it needs a query.
+    dependents = (await session.execute(
+        select(Event.duplicate_of_id, func.count())
+        .where(Event.duplicate_of_id.in_(ids))
+        .group_by(Event.duplicate_of_id)
+    )).all()
+    if dependents:
+        detail = "; ".join(
+            f"event {target} already has {n} duplicate(s) folded into it"
+            for target, n in dependents
+        )
+        raise HTTPException(
+            status_code=400,
+            detail=f"Unfold those first. {detail}",
+        )
+
+    # Warn rather than refuse on a cross-venue or cross-date fold. A rescheduled or
+    # relocated show is a real duplicate, so blocking it would make the tool useless for
+    # exactly the messy case that needs a human; but it is unusual enough to be worth a
+    # line in the log if it later looks like a mistake.
+    odd = [
+        i for i in ids
+        if by_id[i].venue_id != survivor.venue_id or by_id[i].date != survivor.date
+    ]
+    if odd:
+        logger.info(
+            f"[admin] folding across venue/date into event {event_id}: "
+            f"{', '.join(str(i) for i in odd)}"
+        )
+
+    for i in ids:
+        by_id[i].duplicate_of_id = event_id
+    await session.commit()
+    return {"ok": True, "survivor_id": event_id, "folded": ids}
+
+
+@router.post("/api/events/{event_id}/unfold", dependencies=[Depends(require_admin)])
+async def unfold_duplicate(
+    event_id: int,
+    session: AsyncSession = Depends(get_session),
+) -> dict:
+    """Clear `event_id`'s duplicate flag, returning it to the public calendar."""
+    event = await session.get(Event, event_id)
+    if not event:
+        raise HTTPException(status_code=404, detail="Event not found")
+
+    was = event.duplicate_of_id
+    event.duplicate_of_id = None
+    await session.commit()
+    return {"ok": True, "id": event_id, "was_duplicate_of": was}
 
 
 @router.get("/api/series", dependencies=[Depends(require_admin)])

--- a/backend/app/api/events.py
+++ b/backend/app/api/events.py
@@ -101,7 +101,14 @@ async def get_fullcalendar_events(
     # skipping the join avoids unnecessary overhead for unfiltered calendar loads.
     needs_venue_join = bool(city or size or venue)
 
-    conditions = []
+    # A row an admin folded into another is hidden from every public path (issue #63).
+    #
+    # Server-side here, unlike is_live_music, which this endpoint deliberately does *not*
+    # filter because filters.js toggles it in the browser without refetching. There is no
+    # client-side toggle for duplicates and there should not be: the whole point of
+    # flagging one is that visitors never see it, so it must not be in the payload the
+    # calendar filters over.
+    conditions = [Event.duplicate_of_id.is_(None)]
 
     if start:
         try:
@@ -132,8 +139,9 @@ async def get_fullcalendar_events(
     query = select(Event).options(joinedload(Event.venue))
     if needs_venue_join:
         query = query.join(Event.venue)
-    if conditions:
-        query = query.where(and_(*conditions))
+    # Unconditional: `conditions` always carries the duplicate exclusion, so the old
+    # `if conditions` guard could no longer be false.
+    query = query.where(and_(*conditions))
     query = query.order_by(Event.date)
 
     result = await session.execute(query)
@@ -229,9 +237,19 @@ async def get_event(
     event_id: int,
     session: AsyncSession = Depends(get_session),
 ) -> EventResponse:
-    """Get a single event by ID."""
+    """Get a single event by ID.
+
+    A row folded into another as a duplicate answers 404 like a row that never existed,
+    so "hidden" means hidden on every public path rather than only in the listings. The
+    site itself never calls this — frontend/js/app.js loads the calendar from
+    /api/events/fullcalendar and the modal renders from what it already has — so the
+    only callers are third parties, and leaving a back door to rows an admin has
+    suppressed would make the flag advisory.
+    """
     result = await session.execute(
-        select(Event).options(joinedload(Event.venue)).where(Event.id == event_id)
+        select(Event)
+        .options(joinedload(Event.venue))
+        .where(Event.id == event_id, Event.duplicate_of_id.is_(None))
     )
     event = result.unique().scalar_one_or_none()
     if not event:
@@ -257,7 +275,11 @@ def _list_conditions(
 
     Malformed dates are ignored rather than rejected, matching the previous behavior.
     """
-    conditions = []
+    # A row an admin folded into another as a duplicate is hidden from every public path
+    # (issue #63), and unlike include_non_music there is no parameter to opt back in — a
+    # duplicate is not a category of event a caller might want, it is a listing an admin
+    # has said should not be there.
+    conditions = [Event.duplicate_of_id.is_(None)]
 
     if start:
         try:

--- a/backend/app/api/events.py
+++ b/backend/app/api/events.py
@@ -18,6 +18,7 @@ from sqlalchemy.orm import joinedload
 
 from app.database import get_session
 from app.models import Event, Venue
+from app.timefmt import format_time_12h
 from app.schemas import EventResponse, FullCalendarEvent, EventListResponse
 
 # --- Router setup ---
@@ -212,8 +213,8 @@ async def get_fullcalendar_events(
                 "venue_color": color,
                 "date": event.date.isoformat(),
                 # Strip leading zero from hour for display (e.g. "9:00 PM" not "09:00 PM").
-                "doors_time": event.doors_time.strftime("%I:%M %p").lstrip("0") if event.doors_time else None,
-                "show_time": event.show_time.strftime("%I:%M %p").lstrip("0") if event.show_time else None,
+                "doors_time": format_time_12h(event.doors_time),
+                "show_time": format_time_12h(event.show_time),
                 "ticket_url": event.ticket_url,
                 "price": price_str,
                 "price_min": event.price_min,

--- a/backend/app/api/feeds.py
+++ b/backend/app/api/feeds.py
@@ -46,6 +46,12 @@ async def get_ical_feed(
     today = date.today()
     # Only include upcoming events — no historical clutter in subscribers' calendars
     conditions = [Event.date >= today]
+    # A row an admin folded into another as a duplicate never reaches a subscriber
+    # (issue #63). No opt-in, unlike include_non_music: a duplicate is not a kind of
+    # event someone might want, it is a listing that should not exist. This matters more
+    # here than on the calendar — a subscribed feed writes into someone's own calendar,
+    # where a duplicate entry is not merely clutter but a second reminder for one show.
+    conditions.append(Event.duplicate_of_id.is_(None))
     # Mirror the on-site calendar: hide non-live-music events unless opted in.
     if not include_non_music:
         conditions.append(Event.is_live_music.is_(True))

--- a/backend/app/api/feeds.py
+++ b/backend/app/api/feeds.py
@@ -23,6 +23,7 @@ from sqlalchemy.orm import joinedload
 # --- Internal imports ---
 from app.database import get_session
 from app.models import Event, Venue
+from app.timefmt import format_time_12h
 
 # --- Router setup ---
 router = APIRouter(prefix="/feeds", tags=["feeds"])
@@ -124,9 +125,9 @@ async def get_ical_feed(
         if event.support_artists:
             desc_parts.append(f"w/ {event.support_artists}")
         if event.doors_time:
-            desc_parts.append(f"Doors: {event.doors_time.strftime('%-I:%M %p')}")
+            desc_parts.append(f"Doors: {format_time_12h(event.doors_time)}")
         if event.show_time:
-            desc_parts.append(f"Show: {event.show_time.strftime('%-I:%M %p')}")
+            desc_parts.append(f"Show: {format_time_12h(event.show_time)}")
         if event.price_min is not None:
             if event.price_min == 0:
                 desc_parts.append("Free")

--- a/backend/app/duplicates.py
+++ b/backend/app/duplicates.py
@@ -1,0 +1,204 @@
+"""Candidate detection and validation for admin-flagged duplicate events.
+
+Role: pure logic behind the admin duplicate-review queue and the mark/unmark endpoints
+in app.api.admin. No database access and no ORM imports, so every rule here is testable
+without Postgres.
+
+The division of labour is the whole design, and it is a reaction to how #63 came about.
+Two automated title rules had already been wrong in opposite directions — stripping every
+bracketed token merged genuine early/late double bills, then treating a session label as
+decisive refused to merge "[LATE] Sub Rosa" with "Sub Rosa", which are one show. So:
+
+  * **Grouping is by fact, not inference.** A candidate cluster is simply more than one
+    unfolded event at the same venue on the same date. No title comparison decides
+    anything.
+
+  * **Similarity only orders the queue.** `cluster_score` sorts likely duplicates to the
+    top. Being wrong costs a scroll, never a wrong verdict, which is the property that
+    makes it safe to use fuzzy matching here at all.
+
+  * **A human decides.** Nothing in this module ever sets `duplicate_of_id`.
+
+A cluster resolves itself: folding a row sets `duplicate_of_id`, which removes it from the
+unfolded count, so a (venue, date) group with only one unfolded row left stops being a
+candidate. Nothing has to record "done". What does *not* resolve is a genuine double bill,
+where both rows correctly stay unfolded and the cluster reappears every time — tracked as
+a known limitation in #90, with `cluster_score` ordering as the mitigation.
+"""
+
+# --- Imports ---
+
+import re
+from difflib import SequenceMatcher
+from typing import Any, Iterable, Optional
+
+# --- Similarity (ordering only) ---
+
+# Tokens that distinguish a *session* rather than a show: the ones that made two listings
+# for one night look different. Stripped before comparison so "[LATE] Sub Rosa" scores
+# near-identical to "Sub Rosa" and floats to the top of the queue.
+#
+# This list being incomplete is harmless, which is the point of confining it to ordering.
+# A missed token means a real duplicate ranks lower, not that it is missed.
+_SESSION_NOISE = re.compile(
+    r"(?ix)"
+    r"\b(late|early|first|second|1st|2nd|matinee|encore|night|show|seating|set)\b"
+    r"|\b(box\s*seats?|balcony|orchestra|mezzanine|standing|ga|general\s+admission)\b"
+)
+
+
+def normalize_for_similarity(title: str) -> str:
+    """Reduce a title to what should be compared when ranking duplicate candidates.
+
+    Deliberately aggressive — punctuation, bracketed asides and session words all go.
+    That aggression is exactly what was wrong when a rule like this *decided* whether two
+    rows were the same show; it is fine here because the only consequence is queue order.
+    """
+    text = (title or "").lower()
+    text = re.sub(r"[\(\[\{].*?[\)\]\}]", " ", text)  # bracketed asides
+    text = _SESSION_NOISE.sub(" ", text)
+    text = re.sub(r"[^a-z0-9]+", " ", text)
+    return " ".join(text.split())
+
+
+def title_similarity(a: str, b: str) -> float:
+    """How alike two titles are, 0.0 to 1.0, after normalization.
+
+    One title normalizing to nothing (a listing named only "[LATE]") scores 0 rather than
+    matching every other empty-normalizing title, which would otherwise pull unrelated
+    rows to the top of the queue.
+    """
+    na, nb = normalize_for_similarity(a), normalize_for_similarity(b)
+    if not na or not nb:
+        return 0.0
+    if na == nb:
+        return 1.0
+    return SequenceMatcher(None, na, nb).ratio()
+
+
+def cluster_score(titles: Iterable[str]) -> float:
+    """The strongest pairwise similarity in a cluster — its sort key in the queue.
+
+    Max rather than mean: a cluster of three where two are obviously one show and the
+    third is unrelated still deserves attention, and averaging would bury it.
+    """
+    items = list(titles)
+    best = 0.0
+    for i in range(len(items)):
+        for j in range(i + 1, len(items)):
+            best = max(best, title_similarity(items[i], items[j]))
+    return best
+
+
+# --- Cluster assembly ---
+
+
+def build_clusters(rows: list[Any]) -> list[dict]:
+    """Group rows into duplicate-review clusters, most likely duplicates first.
+
+    `rows` is every event at a (venue, date) that already has two or more *unfolded*
+    rows — the caller does that selection in SQL. Rows already folded are passed in too,
+    so a cluster can show what was previously absorbed into its survivor.
+
+    Only attribute access is used (.id, .name, .date, .venue_id, .duplicate_of_id, ...),
+    so tests pass stand-ins rather than ORM objects.
+
+    Ordering is `cluster_score` descending, then all-approved clusters after unresolved
+    ones, then by date. `approved_at` is used *only* here, as a weak "a human has looked
+    at these rows recently" signal for sort position — never to hide a cluster. Hiding on
+    it would let an approval granted for a live-music decision silently remove a duplicate
+    nobody had assessed; ordering cannot, because the cluster stays reachable. See #90.
+    """
+    grouped: dict[tuple[int, Any], list[Any]] = {}
+    for row in rows:
+        grouped.setdefault((row.venue_id, row.date), []).append(row)
+
+    clusters = []
+    for (venue_id, day), members in grouped.items():
+        unfolded = [r for r in members if getattr(r, "duplicate_of_id", None) is None]
+        # Defensive: the caller's HAVING should guarantee this, but a cluster of one
+        # cannot be reviewed and must never render as a decision waiting to be made.
+        if len(unfolded) < 2:
+            continue
+        # Fall back to doors_time, because the UI's time label does. Sorting on show_time
+        # alone put a row labelled "doors 19:00" below one labelled "show 22:00" whenever
+        # the earlier row had no show time — the ordering and the visible label disagreeing
+        # about the same two rows, in the one column the admin is using to tell them apart.
+        members.sort(key=lambda r: (r.show_time or r.doors_time or _NEVER, r.id))
+        score = cluster_score([r.name for r in unfolded])
+        all_approved = all(getattr(r, "approved_at", None) is not None for r in unfolded)
+        clusters.append({
+            "venue_id": venue_id,
+            "date": day,
+            "score": score,
+            "all_approved": all_approved,
+            "members": members,
+        })
+
+    clusters.sort(key=lambda c: (-c["score"], c["all_approved"], c["date"]))
+    return clusters
+
+
+class _Never:
+    """Sorts after every real time, so rows without a show_time land last."""
+
+    def __lt__(self, other: Any) -> bool:
+        return False
+
+    def __gt__(self, other: Any) -> bool:
+        return True
+
+
+_NEVER = _Never()
+
+
+# --- Validation ---
+
+
+class FoldError(ValueError):
+    """A fold the admin asked for would leave the data in a state nothing can read."""
+
+
+def validate_fold(
+    survivor_id: int,
+    duplicate_ids: Iterable[int],
+    *,
+    already_folded: Optional[dict[int, Optional[int]]] = None,
+) -> list[int]:
+    """Check a fold request and return the duplicate ids to write, de-duplicated.
+
+    `already_folded` maps event id to its current `duplicate_of_id`, for every event in
+    the request. Used for the chain rule, which needs a lookup and so cannot be a
+    database constraint the way the self-reference rule can.
+
+    Rules, and why each exists:
+
+    **No self-reference.** Folding a row into itself makes it its own survivor, so it is
+    hidden with nothing to restore it to. Also enforced by `ck_events_duplicate_of_not_self`
+    in migration 0006 — checked here as well so the admin gets a sentence rather than an
+    IntegrityError.
+
+    **The survivor must not itself be folded.** Otherwise A points at B which points at C:
+    A is hidden behind a row that is itself hidden, so unmarking A restores it to
+    invisibility and the admin has no way to see why. Chains are refused rather than
+    silently rewritten, because the intended survivor is genuinely ambiguous — the caller
+    is told which row to use instead.
+
+    **At least one duplicate.** An empty fold is a no-op that would otherwise report
+    success, which reads as "it worked" on a click that did nothing.
+    """
+    ids = list(dict.fromkeys(duplicate_ids))  # de-dupe, keep order
+    if not ids:
+        raise FoldError("Select at least one event to fold in.")
+    if survivor_id in ids:
+        raise FoldError("An event cannot be a duplicate of itself.")
+
+    folded = already_folded or {}
+    survivor_target = folded.get(survivor_id)
+    if survivor_target is not None:
+        raise FoldError(
+            f"Event {survivor_id} is itself marked as a duplicate of event "
+            f"{survivor_target}. Unfold it first, or fold into event "
+            f"{survivor_target} instead."
+        )
+    return ids

--- a/backend/app/timefmt.py
+++ b/backend/app/timefmt.py
@@ -1,0 +1,44 @@
+"""Render a time as a readable 12-hour clock, identically on every platform.
+
+Role: shared by the JSON event API (app.api.events) and the iCal feed (app.api.feeds),
+the two places a stored time is shown to a person.
+
+Why this is not a strftime call. The obvious spelling, ``strftime('%-I:%M %p')``, uses
+``%-I`` for "hour with no leading zero" — a glibc extension. The Windows C runtime does
+not implement it and raises ``ValueError: Invalid format string``, so
+``GET /feeds/events.ics`` answered 500 on any Windows machine while working on Cloud Run
+and in CI. A local developer could not exercise the feed at all, and nothing in the test
+suite covered it because the tests never rendered one.
+
+``strftime('%I:%M %p').lstrip('0')`` is the portable workaround, and app.api.events was
+already using it. It has a subtler problem: ``%p`` is locale-dependent, so the output of a
+public JSON API and a calendar feed would depend on the server's locale. Formatting from
+the integer fields sidesteps both — no platform-specific directives, no locale, and the
+midnight and noon cases are stated outright rather than inherited.
+
+Requires: nothing outside the standard library.
+"""
+
+# --- Imports ---
+
+from datetime import time
+from typing import Optional
+
+# --- Formatting ---
+
+
+def format_time_12h(value: Optional[time]) -> Optional[str]:
+    """Format `value` as ``h:mm AM/PM``, or None for None.
+
+    Passes None through so call sites can format an optional column without guarding
+    first — doors_time and show_time are both nullable and frequently absent.
+
+    Midnight is 12 AM and noon is 12 PM, which is what the ``% 12 or 12`` does: hour 0 and
+    hour 12 both map to a displayed 12, and the meridiem comes from the original 24-hour
+    value rather than the displayed one.
+    """
+    if value is None:
+        return None
+    hour = value.hour % 12 or 12
+    meridiem = "AM" if value.hour < 12 else "PM"
+    return f"{hour}:{value.minute:02d} {meridiem}"

--- a/backend/tests/test_duplicates.py
+++ b/backend/tests/test_duplicates.py
@@ -364,3 +364,68 @@ class TestAdminUiWiring:
         Throwing a bare 'http 400' would discard exactly the part the admin needs."""
         assert "err.detail" in script
         assert "detail = (await r.json()).detail" in script
+
+
+class TestReaderFacingVocabulary:
+    """The words the admin actually sees.
+
+    The first version of this UI said "folded into 41", "unfold", and "keep this one
+    (folds 2)". Two problems. "Fold" is jargon — the help text had a paragraph whose only
+    job was to define it — and worse, it is *inaccurate*: folding implies the two rows are
+    combined, when nothing is combined. The row is hidden and given a pointer, and the
+    survivor is untouched. And "duplicate of 41" names a row by an id, which is not
+    something a person can recognise.
+
+    Internal names (`unfold()`, `foldAction`, the `/unfold` route) deliberately keep the
+    old term: they are read by us, and `absorb` in particular is accurate about direction.
+    This class only polices what renders.
+    """
+
+    @pytest.fixture(scope="class")
+    def html(self) -> str:
+        from app.admin_ui import ADMIN_HTML
+
+        return ADMIN_HTML
+
+    @pytest.fixture(scope="class")
+    def visible(self, html) -> str:
+        """The page with the <script> block removed — help text, buttons, headings."""
+        import re
+
+        script = re.search(r"<script>(.*?)</script>", html, re.S)
+        return html.replace(script.group(1), "") if script else html
+
+    def test_no_fold_jargon_in_the_visible_page(self, visible):
+        import re
+
+        found = re.findall(r"[Ff]old\w*", visible)
+        assert not found, f"reader-facing fold jargon is back: {sorted(set(found))}"
+
+    def test_the_help_text_explains_hiding_without_defining_a_metaphor(self, visible):
+        assert "hides, it doesn't delete" in visible
+        assert "hidden as a duplicate of it" in visible
+
+    def test_the_button_says_what_clicking_it_asserts(self, html):
+        assert "not a duplicate" in html
+
+    def test_the_badge_names_the_surviving_listing_not_its_id(self, html):
+        """`duplicate of "Sub Rosa"` rather than `duplicate of 41`."""
+        assert "duplicate_of_name" in html
+        assert 'duplicate of \'' not in html, "the id-based badge wording is back"
+
+    def test_the_badge_falls_back_when_the_name_is_missing(self, html):
+        """The survivor can vanish between the two queries that build the page, and a badge
+        reading `duplicate of "undefined"` is worse than one that omits the name."""
+        assert "hidden as a duplicate" in html
+
+    def test_the_survivor_name_is_supplied_by_both_endpoints(self):
+        """The badge is only as good as the payload. Both the moderation list and the
+        duplicate queue have to send it, and they build their rows separately."""
+        import inspect
+
+        from app.api import admin
+
+        for fn in (admin.admin_events, admin.list_duplicate_candidates):
+            assert "duplicate_of_name" in inspect.getsource(fn), (
+                f"{fn.__name__} does not send the surviving listing's name"
+            )

--- a/backend/tests/test_duplicates.py
+++ b/backend/tests/test_duplicates.py
@@ -1,0 +1,366 @@
+"""Tests for admin duplicate flagging (issue #63).
+
+The design being protected here is the division of labour in app/duplicates.py: candidate
+clusters are chosen by *fact* (same venue, same date, two or more unfolded rows), title
+similarity only *orders* the queue, and a human makes every verdict. That split exists
+because two automated title rules had already been wrong in opposite directions — one
+merged genuine early/late double bills, the next refused to merge "[LATE] Sub Rosa" with
+"Sub Rosa", which are one show.
+
+So the assertions come in two flavours, and the distinction matters when one fails:
+
+  * **Ordering** assertions may be tuned freely. Getting an order wrong costs a scroll.
+  * **Grouping and validation** assertions are load-bearing. Getting those wrong hides a
+    show visitors should see, or leaves a row hidden behind a row that is itself hidden.
+"""
+
+from dataclasses import dataclass
+from datetime import date, datetime, time
+from typing import Optional
+
+import pytest
+
+from app.duplicates import (
+    FoldError,
+    build_clusters,
+    cluster_score,
+    normalize_for_similarity,
+    title_similarity,
+    validate_fold,
+)
+
+TODAY = date(2026, 9, 10)
+
+
+@dataclass
+class Row:
+    """Stand-in for an Event row. build_clusters only reads these attributes."""
+
+    id: int
+    name: str
+    venue_id: int = 1
+    date: date = TODAY
+    show_time: Optional[time] = None
+    doors_time: Optional[time] = None
+    duplicate_of_id: Optional[int] = None
+    approved_at: Optional[datetime] = None
+
+
+# --- Similarity: ordering only ---
+
+
+class TestNormalizeForSimilarity:
+    """Deliberately aggressive. That aggression was wrong when a rule like this *decided*
+    whether two rows were one show; it is fine when it only picks a sort order."""
+
+    @pytest.mark.parametrize("title,expected", [
+        ("[LATE] Sub Rosa", "sub rosa"),
+        ("Sub Rosa (Early Show)", "sub rosa"),
+        ("DPAC: Hamilton [Box Seats]", "dpac hamilton"),
+        ("An Evening with X - LATE SHOW", "an evening with x"),
+        ("  Spaced   Out  ", "spaced out"),
+    ])
+    def test_strips_session_noise_and_punctuation(self, title, expected):
+        assert normalize_for_similarity(title) == expected
+
+    def test_a_title_of_only_noise_normalizes_to_nothing(self):
+        assert normalize_for_similarity("[LATE]") == ""
+
+    def test_none_and_empty_are_safe(self):
+        assert normalize_for_similarity(None) == ""
+        assert normalize_for_similarity("") == ""
+
+
+class TestTitleSimilarity:
+    def test_the_two_cases_from_issue_63_score_top(self):
+        """Both real examples the old rules got wrong, in opposite directions. These are
+        the pairs that must float to the top of the queue."""
+        assert title_similarity("Sub Rosa", "[LATE] Sub Rosa") == 1.0
+        assert title_similarity("DPAC: Hamilton", "DPAC: Hamilton [Box Seats]") == 1.0
+
+    def test_unrelated_titles_score_low(self):
+        assert title_similarity("Sub Rosa", "Completely Different Band") < 0.4
+
+    def test_two_titles_that_normalize_to_nothing_do_not_match(self):
+        """Without the empty guard both normalize to "" and score a perfect 1.0, dragging
+        unrelated rows to the top of the queue on the strength of having no title left."""
+        assert title_similarity("[LATE]", "[EARLY]") == 0.0
+
+    def test_one_empty_side_does_not_match_everything(self):
+        assert title_similarity("[LATE]", "Sub Rosa") == 0.0
+
+
+class TestClusterScore:
+    def test_uses_the_strongest_pair_not_the_average(self):
+        """A cluster of three where two are obviously one show deserves attention even if
+        the third is unrelated; averaging would bury it below weaker but tidier clusters."""
+        titles = ["Sub Rosa", "[LATE] Sub Rosa", "Some Unrelated DJ Set"]
+        assert cluster_score(titles) == 1.0
+
+    def test_a_single_title_has_no_pair(self):
+        assert cluster_score(["Sub Rosa"]) == 0.0
+
+    def test_empty(self):
+        assert cluster_score([]) == 0.0
+
+
+# --- Grouping: load-bearing ---
+
+
+class TestBuildClusters:
+    def test_groups_by_venue_and_date(self):
+        rows = [
+            Row(1, "Sub Rosa"),
+            Row(2, "[LATE] Sub Rosa"),
+            Row(3, "Other Show", venue_id=2),
+            Row(4, "Other Show Late", venue_id=2),
+        ]
+        clusters = build_clusters(rows)
+        assert len(clusters) == 2
+        assert {c["venue_id"] for c in clusters} == {1, 2}
+
+    def test_a_different_date_is_a_different_cluster(self):
+        rows = [
+            Row(1, "Sub Rosa"),
+            Row(2, "Sub Rosa", date=TODAY.replace(day=11)),
+        ]
+        assert build_clusters(rows) == []
+
+    def test_a_resolved_cluster_disappears_with_nothing_recording_it(self):
+        """The self-resolving property. Folding row 2 into row 1 leaves one unfolded row,
+        so the cluster stops being a candidate — no "reviewed" flag needed anywhere.
+        """
+        rows = [Row(1, "Sub Rosa"), Row(2, "[LATE] Sub Rosa", duplicate_of_id=1)]
+        assert build_clusters(rows) == []
+
+    def test_folded_rows_are_still_reported_inside_a_live_cluster(self):
+        """A cluster that still has two unfolded rows must show what was already folded
+        in, or the admin cannot see or undo the earlier decision."""
+        rows = [
+            Row(1, "Sub Rosa"),
+            Row(2, "Sub Rosa Support"),
+            Row(3, "[LATE] Sub Rosa", duplicate_of_id=1),
+        ]
+        clusters = build_clusters(rows)
+        assert len(clusters) == 1
+        assert {r.id for r in clusters[0]["members"]} == {1, 2, 3}
+
+    def test_a_lone_row_is_never_a_cluster(self):
+        assert build_clusters([Row(1, "Sub Rosa")]) == []
+
+    def test_score_is_computed_over_unfolded_rows_only(self):
+        """A folded row's title must not prop up the score of a cluster whose remaining
+        rows are unalike — that would rank an already-handled night above a fresh one."""
+        rows = [
+            Row(1, "Sub Rosa"),
+            Row(2, "Totally Unrelated Comedy"),
+            Row(3, "[LATE] Sub Rosa", duplicate_of_id=1),
+        ]
+        assert build_clusters(rows)[0]["score"] < 0.5
+
+    def test_likely_duplicates_sort_above_unlikely_ones(self):
+        rows = [
+            Row(1, "Jazz Jam", venue_id=2),
+            Row(2, "Standup Showcase", venue_id=2),
+            Row(3, "Sub Rosa", venue_id=1),
+            Row(4, "[LATE] Sub Rosa", venue_id=1),
+        ]
+        clusters = build_clusters(rows)
+        assert clusters[0]["venue_id"] == 1, "the near-identical pair should lead"
+
+    def test_members_are_ordered_by_time_with_untimed_rows_last(self):
+        """Time is what actually distinguishes an early show from a late one, so it is the
+        field the admin reads next to two near-identical titles."""
+        rows = [
+            Row(1, "No Time"),
+            Row(2, "Late", show_time=time(22, 30)),
+            Row(3, "Early", show_time=time(19, 0)),
+        ]
+        members = build_clusters(rows)[0]["members"]
+        assert [m.id for m in members] == [3, 2, 1]
+
+    def test_doors_time_is_used_when_there_is_no_show_time(self):
+        """Found by looking at the rendered queue. The UI's time label falls back to
+        doors_time, so sorting on show_time alone put a row reading "doors 19:00" below one
+        reading "show 22:00" — the order contradicting the label, in the very column the
+        admin uses to tell two near-identical listings apart."""
+        rows = [
+            Row(1, "Late Set", show_time=time(22, 0)),
+            Row(2, "Early Set", doors_time=time(19, 0)),
+        ]
+        members = build_clusters(rows)[0]["members"]
+        assert [m.id for m in members] == [2, 1]
+
+    def test_show_time_still_wins_over_doors_time_on_the_same_row(self):
+        """Doors is only a fallback: a row with both sorts by when the music starts."""
+        rows = [
+            Row(1, "Doors Early Show Late", doors_time=time(18, 0), show_time=time(23, 0)),
+            Row(2, "Straightforward", show_time=time(20, 0)),
+        ]
+        members = build_clusters(rows)[0]["members"]
+        assert [m.id for m in members] == [2, 1]
+
+    def test_all_untimed_rows_still_sort_without_raising(self):
+        """The sentinel used for a missing time has to compare consistently against itself,
+        or sorted() raises on a cluster where no row has a time — the common case."""
+        rows = [Row(2, "B"), Row(1, "A"), Row(3, "C")]
+        members = build_clusters(rows)[0]["members"]
+        assert [m.id for m in members] == [1, 2, 3]
+
+
+class TestApprovedOnlyAffectsOrdering:
+    """`approved_at` orders the queue; it must never remove a cluster from it.
+
+    Hiding on approval would let an approval granted for a *live-music* decision silently
+    drop a duplicate nobody had assessed — the queue would go quiet for an unrelated
+    reason. Ordering cannot do that, because the cluster stays reachable. See #90.
+    """
+
+    def test_an_approved_cluster_is_still_returned(self):
+        rows = [
+            Row(1, "Sub Rosa", approved_at=datetime(2026, 9, 1)),
+            Row(2, "[LATE] Sub Rosa", approved_at=datetime(2026, 9, 1)),
+        ]
+        clusters = build_clusters(rows)
+        assert len(clusters) == 1, "approving rows must not hide the cluster"
+        assert clusters[0]["all_approved"] is True
+
+    def test_an_approved_cluster_sorts_below_an_unreviewed_one_of_equal_score(self):
+        rows = [
+            Row(1, "Sub Rosa", venue_id=1, approved_at=datetime(2026, 9, 1)),
+            Row(2, "[LATE] Sub Rosa", venue_id=1, approved_at=datetime(2026, 9, 1)),
+            Row(3, "Sub Rosa", venue_id=2),
+            Row(4, "[LATE] Sub Rosa", venue_id=2),
+        ]
+        clusters = build_clusters(rows)
+        assert [c["venue_id"] for c in clusters] == [2, 1]
+
+    def test_one_unapproved_row_keeps_the_cluster_unresolved(self):
+        rows = [
+            Row(1, "Sub Rosa", approved_at=datetime(2026, 9, 1)),
+            Row(2, "[LATE] Sub Rosa"),
+        ]
+        assert build_clusters(rows)[0]["all_approved"] is False
+
+
+# --- Validation: load-bearing ---
+
+
+class TestValidateFold:
+    def test_a_normal_fold_returns_the_ids(self):
+        assert validate_fold(1, [2, 3], already_folded={1: None, 2: None, 3: None}) == [2, 3]
+
+    def test_duplicate_ids_in_the_request_are_collapsed(self):
+        assert validate_fold(1, [2, 2, 3], already_folded={1: None}) == [2, 3]
+
+    def test_self_reference_is_refused(self):
+        """Also blocked by ck_events_duplicate_of_not_self in migration 0006. Checked here
+        too so the admin gets a sentence rather than an IntegrityError."""
+        with pytest.raises(FoldError, match="cannot be a duplicate of itself"):
+            validate_fold(1, [1, 2], already_folded={1: None})
+
+    def test_an_empty_fold_is_refused(self):
+        """A no-op that reported success would read as "it worked" on a click that did
+        nothing."""
+        with pytest.raises(FoldError, match="at least one"):
+            validate_fold(1, [], already_folded={1: None})
+
+    def test_folding_into_a_row_that_is_itself_folded_is_refused(self):
+        """The chain case. A -> B -> C leaves A hidden behind a row that is also hidden, so
+        unfolding A restores it to invisibility with no way to see why."""
+        with pytest.raises(FoldError, match="itself marked as a duplicate"):
+            validate_fold(2, [3], already_folded={2: 1, 3: None})
+
+    def test_the_refusal_names_the_row_to_use_instead(self):
+        """Chains are refused rather than silently rewritten, because the intended survivor
+        is genuinely ambiguous — so the message has to say what to do next."""
+        with pytest.raises(FoldError, match=r"fold into event 1 instead"):
+            validate_fold(2, [3], already_folded={2: 1, 3: None})
+
+
+# --- The read paths, and the UI that drives all this ---
+
+
+class TestEveryPublicReadPathExcludesFoldedRows:
+    """Four public paths can return an event, and closing three leaves one open.
+
+    Source-level because these need a database to exercise end to end, and the failure
+    being guarded against is an omission — a path nobody remembered to filter — which a
+    passing test on the other three would not reveal. `/api/events` is covered properly in
+    test_events_api.py, where _list_conditions is reachable without Postgres.
+    """
+
+    @staticmethod
+    def _source(fn) -> str:
+        import inspect
+
+        return inspect.getsource(fn)
+
+    def test_the_fullcalendar_feed_filters_server_side(self):
+        """Deliberately unlike is_live_music, which this endpoint does not filter because
+        filters.js toggles it in the browser without refetching. There is no client toggle
+        for duplicates, so a folded row must never reach the payload at all."""
+        from app.api.events import get_fullcalendar_events
+
+        assert "duplicate_of_id" in self._source(get_fullcalendar_events)
+
+    def test_the_single_event_endpoint_filters(self):
+        """Otherwise a folded row stays reachable by id and the flag is only advisory."""
+        from app.api.events import get_event
+
+        assert "duplicate_of_id" in self._source(get_event)
+
+    def test_the_ical_feed_filters(self):
+        """The one that matters most: a subscribed feed writes into someone's own calendar,
+        where a duplicate is a second reminder for one show rather than mere clutter."""
+        from app.api.feeds import get_ical_feed
+
+        assert "duplicate_of_id" in self._source(get_ical_feed)
+
+
+class TestAdminUiWiring:
+    """admin_ui.py is ~600 lines of JS inside a Python string, so nothing type-checks it
+    and a typo in an onclick handler fails silently in the browser — the button simply
+    does nothing. These are cheap structural guards over that.
+    """
+
+    @pytest.fixture(scope="class")
+    def html(self) -> str:
+        from app.admin_ui import ADMIN_HTML
+
+        return ADMIN_HTML
+
+    @pytest.fixture(scope="class")
+    def script(self, html) -> str:
+        import re
+
+        match = re.search(r"<script>(.*?)</script>", html, re.S)
+        assert match, "the dashboard has no <script> block"
+        return match.group(1)
+
+    def test_every_onclick_handler_is_defined(self, html, script):
+        import re
+
+        referenced = set(re.findall(r'onclick="(\w+)\(', html))
+        defined = set(re.findall(r"(?:async\s+)?function\s+(\w+)", script))
+        # `event.stopPropagation()` is a DOM object, not a function of ours.
+        missing = referenced - defined - {"event"}
+        assert not missing, f"onclick handlers with no definition: {sorted(missing)}"
+
+    def test_the_duplicate_actions_are_wired(self, script):
+        assert "/admin/api/duplicates" in script
+        assert "/absorb" in script
+        assert "/unfold" in script
+
+    def test_keep_this_one_acts_on_the_survivor(self, script):
+        """The direction guard. absorb() takes the id of the row being *kept* first and the
+        rows being hidden second, matching the endpoint. Inverting it would hide the row the
+        admin clicked — the failure mode the "keep this one" wording exists to prevent."""
+        assert "absorb(survivorId, duplicateIds)" in script
+        assert "'/admin/api/events/' + survivorId + '/absorb'" in script
+
+    def test_the_error_line_surfaces_the_servers_detail(self, script):
+        """The fold endpoints refuse a chain with a sentence naming the row to use instead.
+        Throwing a bare 'http 400' would discard exactly the part the admin needs."""
+        assert "err.detail" in script
+        assert "detail = (await r.json()).detail" in script

--- a/backend/tests/test_events_api.py
+++ b/backend/tests/test_events_api.py
@@ -131,9 +131,29 @@ class TestListConditions:
         assert "is_live_music" not in opted_in
 
     def test_a_malformed_date_is_ignored_rather_than_raising(self):
-        """Pre-existing behavior, preserved through the extraction."""
-        conditions = _list_conditions(start="not-a-date", include_non_music=True)
-        assert conditions == []
+        """Pre-existing behavior, preserved through the extraction.
+
+        Asserts on the absence of a *date* clause rather than on an empty list: the
+        duplicate exclusion (#63) is now unconditional, so the baseline is one clause
+        rather than none. Checking for `events.date` keeps the original meaning — that a
+        malformed date is dropped instead of raising — without the count standing in for it.
+        """
+        sql = self._sql(_list_conditions(start="not-a-date", include_non_music=True))
+        assert "events.date" not in sql
+        assert "is_live_music" not in sql
+
+    def test_folded_duplicates_are_excluded_by_default(self):
+        """A row an admin folded into another must not reach the public list (#63)."""
+        assert "duplicate_of_id" in self._sql(_list_conditions())
+
+    def test_there_is_no_opt_in_for_folded_duplicates(self):
+        """Unlike include_non_music. A duplicate is not a category of event a caller might
+        legitimately want — it is a listing an admin has said should not be there — so the
+        exclusion survives every combination of parameters."""
+        assert "duplicate_of_id" in self._sql(_list_conditions(include_non_music=True))
+        assert "duplicate_of_id" in self._sql(
+            _list_conditions(search="band", genre="rock", status="onsale", start="2026-09-01")
+        )
 
 
 class TestListFiltering:

--- a/backend/tests/test_timefmt.py
+++ b/backend/tests/test_timefmt.py
@@ -1,0 +1,84 @@
+"""Tests for format_time_12h, the shared 12-hour clock renderer.
+
+Motivated by a real crash rather than by tidiness. ``GET /feeds/events.ics`` answered 500
+on any Windows machine, because ``feeds.py`` formatted times with ``strftime('%-I:%M %p')``
+and ``%-I`` is a glibc extension the Windows C runtime rejects with ``ValueError: Invalid
+format string``. It worked on Cloud Run and in CI, so nothing caught it — and no test
+rendered a feed at all, which is why the platform gap went unnoticed.
+
+The parity class below is the point of the file: ``app.api.events`` was already producing
+this format by a different route, and that route is a public API contract. The helper had
+to match it exactly, not merely closely.
+"""
+
+from datetime import time
+
+import pytest
+
+from app.timefmt import format_time_12h
+
+
+class TestFormatTime12h:
+    @pytest.mark.parametrize("value,expected", [
+        (time(0, 0), "12:00 AM"),      # midnight is 12 AM, not 0 AM
+        (time(0, 30), "12:30 AM"),
+        (time(1, 5), "1:05 AM"),       # no leading zero on the hour...
+        (time(9, 5), "9:05 AM"),       # ...but minutes keep theirs
+        (time(11, 59), "11:59 AM"),
+        (time(12, 0), "12:00 PM"),     # noon is 12 PM, and PM not AM
+        (time(12, 1), "12:01 PM"),
+        (time(13, 45), "1:45 PM"),
+        (time(19, 0), "7:00 PM"),      # a typical doors time
+        (time(22, 30), "10:30 PM"),    # a typical late show
+        (time(23, 59), "11:59 PM"),
+    ])
+    def test_formats(self, value, expected):
+        assert format_time_12h(value) == expected
+
+    def test_none_passes_through(self):
+        """doors_time and show_time are both nullable and often absent, so every call site
+        would otherwise need the same guard."""
+        assert format_time_12h(None) is None
+
+    def test_seconds_are_ignored(self):
+        assert format_time_12h(time(20, 15, 42)) == "8:15 PM"
+
+    def test_no_platform_specific_directive_is_used(self):
+        """The regression guard. `%-I` is a glibc extension: it works on Linux, and raises
+        ValueError on Windows. Reintroducing it would 500 the iCal feed on every Windows
+        dev machine while CI stayed green, which is exactly how it survived the first time.
+        """
+        import inspect
+
+        from app import timefmt
+
+        source = inspect.getsource(timefmt.format_time_12h)
+        assert "strftime" not in source, (
+            "format_time_12h should build the string from the integer fields; strftime "
+            "reintroduces both the platform and the locale dependency"
+        )
+
+
+class TestParityWithThePreviousApiOutput:
+    """`/api/events` already emitted this format via `strftime('%I:%M %p').lstrip('0')`.
+
+    That is a public response field, so the shared helper has to reproduce it exactly —
+    a formatting change here would silently alter the API for every consumer. Asserted
+    against the old expression rather than against hand-written strings, so this compares
+    the two implementations rather than my reading of one of them.
+    """
+
+    @pytest.mark.parametrize("value", [
+        time(0, 0), time(0, 30), time(1, 5), time(9, 5), time(11, 59),
+        time(12, 0), time(12, 1), time(13, 45), time(19, 0), time(22, 30), time(23, 59),
+    ])
+    def test_matches_the_expression_it_replaced(self, value):
+        previous = value.strftime("%I:%M %p").lstrip("0")
+        assert format_time_12h(value) == previous
+
+    def test_the_locale_dependency_is_gone(self):
+        """The one deliberate difference from the old expression: `%p` is locale-dependent,
+        so a server with a non-English locale could have changed the output of a public API
+        and a calendar feed. The meridiem is now fixed."""
+        assert format_time_12h(time(9, 0)).endswith("AM")
+        assert format_time_12h(time(21, 0)).endswith("PM")


### PR DESCRIPTION
Implements #63's feature on top of the `duplicate_of_id` column from #87. Refs #90.

**Scope note:** this is duplicate flagging only. Manual event entry — the other half of the
task — is coming as a separate PR rather than doubling this diff; the two share no code.

## The design, and why

#63 exists because two automated title rules were wrong in opposite directions in one
afternoon: stripping bracketed tokens merged genuine early/late double bills, then treating
a session label as decisive refused to merge `[LATE] Sub Rosa` with `Sub Rosa`, which are
one show. So the labour is split three ways:

| | |
|---|---|
| **Candidates by fact** | More than one *unfolded* event at the same venue on the same date. No title comparison decides anything. |
| **Similarity only orders** | Wrong order costs a scroll, never a wrong verdict. That is what makes fuzzy matching safe to use here at all. |
| **A human decides** | Nothing sets `duplicate_of_id` without a click. |

**The queue is self-resolving.** Folding a row drops it from the unfolded count, so a
reviewed cluster disappears with nothing recording that it was reviewed. What does *not*
resolve is a genuine double bill — the known limitation in #90, with similarity ordering as
the agreed mitigation.

## "keep this one", not "mark as duplicate"

The button sits on the row that **survives** and folds every other unfolded row into it.
The endpoint takes the survivor in the path for the same reason. A "mark as duplicate"
button would sit on the row that *loses*, forcing the admin to reason about the other row
while clicking this one — which is how the wrong row gets hidden.

Verified on a running instance: clicking **keep this one** on `Hamilton` left
`Hamilton [Box Seats]` folded into it, not the reverse.

## Verified against a live instance, not just unit tests

Seeded three venues and eight events covering both real #63 cases, a genuine double bill,
and a lone event. The ordering came out as designed:

```
[1.00] Motorco Music Hall 2026-09-04    Sub Rosa / [LATE] Sub Rosa
[1.00] DPAC 2026-09-06                  Hamilton / Hamilton [Box Seats]
[0.25] The Pinhook 2026-09-08           Jazz Jam / Standup Showcase   <- the #90 noise, correctly last
```

The lone event never appeared as a cluster.

**Guardrails** — every one exercised over HTTP:

| attempt | result |
|---|---|
| self-fold | 400 `An event cannot be a duplicate of itself.` |
| empty fold | 400 `Select at least one event to fold in.` |
| nonexistent id | 404 `Event(s) not found: 9999` |
| fold into an already-folded row | 400 `Event 2 is itself marked as a duplicate of event 1. Unfold it first, or fold into event 1 instead.` |
| fold a row that has children | 400 `Unfold those first. event 1 already has 1 duplicate(s) folded into it` |
| direct SQL `duplicate_of_id = id` | rejected by `ck_events_duplicate_of_not_self` |

Chains are refused rather than silently rewritten: the intended survivor is genuinely
ambiguous, so the message names the row to use instead. Cross-venue/cross-date folds are
allowed but logged — a rescheduled show is a real duplicate, so blocking it would fail
exactly the messy case that needs a human.

**Round trip is lossless.** Fold → row leaves `/api/events`, `/fullcalendar`, the feed, and
404s by id. Unfold → it returns. Confirmed both directions.

## All four public read paths

`/api/events`, `/api/events/fullcalendar`, `/api/events/{id}` (404 — so "hidden" means
hidden everywhere, not just in listings) and `/feeds/events.ics`.

No opt-in parameter, unlike `include_non_music`: a duplicate is not a category of event a
caller might legitimately want. The fullcalendar exclusion is **server-side** even though
`is_live_music` deliberately is not — there is no client-side toggle for duplicates and
there should not be.

The feed matters most, and the live test showed why. The unflagged `Hamilton` pair appeared
**twice** in `events.ics` while fullcalendar's display-time dedup collapsed it to one — so a
subscriber gets two calendar entries for one show. That is the case this feature fixes, and
it is invisible from the calendar alone.

## Two bugs found by driving the UI, not reading it

1. **Members sorted on `show_time` while the label falls back to `doors_time`** — a row
   reading `doors 19:00` rendered *below* one reading `show 22:00`. The order contradicted
   the label in the one column used to tell two near-identical listings apart. Caught in a
   screenshot.
2. **`absorb()` awaited `api()`, which throws** — the rejection escaped the click handler
   and `reload()`'s catch never ran, so a chain refusal produced **no message at all**: the
   exact silent failure the error line was added to prevent. The catch now lives in the
   action. Confirmed the message now renders in-page.

## Tests

+41. Every load-bearing guard mutation-tested by removing it and confirming a distinct set
of tests fails:

| mutation | caught by |
|---|---|
| duplicate exclusion off in `_list_conditions` | 2 |
| exclusion off in fullcalendar | 1 |
| exclusion off in the ics feed | 1 |
| cluster-of-one guard removed | 3 |
| empty-normalization guard removed | 1 |
| approved clusters hidden instead of sorted | 2 |
| score over folded rows too | 1 |
| `doors_time` fallback removed | 1 |

Also guards the inline admin JS — ~600 lines inside a Python string that nothing
type-checks — by asserting every `onclick` handler resolves to a defined function.

Backend suite: **467 passed, 4 skipped**. Frontend: 13 passed.

## Follow-up commits after the first review pass

### The word "folded" was wrong, and it was in the UI

The interface said `folded into 41`, `unfold`, `keep this one (folds 2)`. Two problems, the
second the serious one: it is jargon — the help text carried a paragraph whose only job was
to define it, which is the tell — and it is **inaccurate**. Folding implies the rows are
combined. They are not. The survivor is untouched; the other is hidden with a pointer to
it. And `duplicate of 41` named a listing by an event id, which nobody can recognise.

| | before | after |
|---|---|---|
| badge | `folded into 41` | `duplicate of "Sub Rosa"` |
| button | `unfold` | `not a duplicate` |
| button | `keep this one (folds 2)` | `keep this one (hides 2)` |
| help | a paragraph defining "fold" | gone |

Both endpoints now send the survivor's **name**, looked up rather than read off the loaded
rows — it can be filtered off the page, or on another date after a cross-date fold. There is
a fallback for the survivor being deleted between the two queries, since
`duplicate of "undefined"` is worse than omitting the name.

That badge alone gets `text-transform: none`. It is the only badge whose text is user data,
and act names are often cased on purpose (`MF DOOM`, `girl in red`) — uppercasing discards
that and reads as shouting.

Internal names keep the old term deliberately: `unfold()`, `foldAction`, the `/unfold`
route. Those are read by us, and `absorb` is accurate about direction.

A test class now asserts no fold jargon reaches the rendered page, so it cannot drift back.

### `GET /feeds/events.ics` returned 500 on Windows — fixed here

`feeds.py` used `strftime('%-I:%M %p')`. `%-I` is a glibc extension; Windows rejects it with
`ValueError: Invalid format string`. Fine on Cloud Run and in CI, broken on **every Windows
dev machine** — the feed could not be exercised locally at all. I hit it while verifying the
duplicate exclusion above and had to null every event's times to get a response, which is
how a bug like this hides: the workaround looks like test setup.

Nothing covered it, because no test rendered a feed.

New `app/timefmt.py` builds the string from the integer fields, so there is no
platform-specific directive to get wrong. `app.api.events` was already using the portable
`strftime('%I:%M %p').lstrip('0')` for the same job and now shares the helper — that
expression had its own flaw, `%p` being locale-dependent, so a public API's output depended
on the server's locale.

Parity is asserted **against the old expression itself** rather than hand-written strings,
because that field is a public contract. Midnight and noon covered explicitly. A guard test
fails if `strftime` reappears in the helper.

Verified live: 200 with times present, rendering `Doors: 7:00 PM`, `Show: 10:30 PM`.

**Suite now: 499 passed, 4 skipped.** Frontend: 13 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

