### PR TITLE
Manual event entry: add-event form, promoter venues, and the guardrails around both

### DIFF
--- a/backend/app/admin_ui.py
+++ b/backend/app/admin_ui.py
@@ -193,6 +193,12 @@ ADMIN_HTML = """<!doctype html>
   #newVenue { grid-column:1 / -1; border-left:2px solid var(--accent); padding-left:0.8rem;
               margin:0.2rem 0; display:grid; grid-template-columns:repeat(auto-fit, minmax(13rem, 1fr));
               gap:0.6rem 0.9rem; }
+  /* Required because the rule above sets `display` from an id selector. `.hidden` is a
+     single class (specificity 0-1-0) and loses to `#newVenue` (1-0-0), so toggling the
+     class did nothing and the new-promoter fields were permanently visible. This is the
+     only id rule in the file that sets display; every other .hidden target leaves it
+     unset, which is why the pattern works everywhere else. */
+  #newVenue.hidden { display:none; }
   #add .actions { margin-top:1rem; display:flex; gap:0.6rem; align-items:center; }
   #add button.go { font-family:inherit; font-size:0.75rem; text-transform:uppercase;
      letter-spacing:0.06em; padding:0.4rem 0.9rem; border:1px solid var(--accent);

--- a/backend/app/admin_ui.py
+++ b/backend/app/admin_ui.py
@@ -205,6 +205,23 @@ ADMIN_HTML = """<!doctype html>
      background:var(--accent); color:#0e0e10; font-weight:700; cursor:pointer; border-radius:2px; }
   #add button.go:hover { filter:brightness(1.1); }
   #add button.go:disabled { opacity:0.5; cursor:default; filter:none; }
+  /* Delete is the only control here that destroys rather than hides, so it is the only one
+     coloured as a warning. Muted rather than a solid red fill: it sits in a row of ordinary
+     actions and should read as "careful", not as the primary thing to press. */
+  button.danger { border-color:#5c2f2f !important; color:#e08a88 !important; }
+  button.danger:hover:not(:disabled) { border-color:#e0625f !important; color:#e0625f !important;
+                                       background:#2a1616 !important; }
+  button.danger:disabled { opacity:0.45; cursor:default; }
+  #venueList { margin-top:1.6rem; border-top:1px solid #2a2a2e; padding-top:0.6rem; }
+  .vrow { display:flex; align-items:center; gap:0.6rem; padding:0.35rem 0;
+          border-bottom:1px solid #1a1a1e; }
+  .vrow:last-child { border-bottom:none; }
+  .vrow .sw { width:0.8rem; height:0.8rem; border-radius:2px; flex:none; }
+  .vrow .vn { color:#e8e6e3; flex:1; }
+  .vrow .cm { color:#8a8a8e; font-size:0.72rem; }
+  .vrow button { font-family:inherit; font-size:0.68rem; padding:0.22rem 0.5rem;
+          border:1px solid #3a3a3e; background:transparent; color:#c8c6c3; cursor:pointer;
+          border-radius:2px; }
 </style>
 </head><body>
   <header>
@@ -411,6 +428,7 @@ ADMIN_HTML = """<!doctype html>
           <button type="submit" class="go" id="fSubmit">add event</button>
         </div>
       </form>
+      <div id="venueList"></div>
     </div>
   </main>
 <script>
@@ -490,7 +508,14 @@ ADMIN_HTML = """<!doctype html>
     if (ev.duplicate_of_id) {
       return '<button onclick="unfold(' + ev.id + ')">not a duplicate</button>';
     }
-    let a = approveAction(ev, false, 1) + ' ';
+    // Delete is offered only on hand-added rows, matching the endpoint. A scraped event
+    // would return on the next scrape, so the button would look broken; and it is the one
+    // control here that destroys rather than hides, so it should not appear on rows where
+    // hiding is the right answer.
+    let a = ev.is_manually_created
+      ? '<button class="danger" onclick="deleteEvent(' + ev.id + ',' + JSON.stringify(esc(ev.name)) + ')">delete</button> '
+      : '';
+    a += approveAction(ev, false, 1) + ' ';
     if (ev.is_manual_override) {
       a += '<button onclick="clearOv(' + ev.id + ')">clear override</button>';
     } else {
@@ -745,6 +770,30 @@ ADMIN_HTML = """<!doctype html>
     reload();
   }
 
+  async function deleteEvent(id, name) {
+    // Named in the prompt, because "delete this event?" on a list of near-identical rows
+    // is how the wrong one goes. Says permanent, because unlike hiding it is.
+    if (!confirm('Delete "' + name + '" permanently?\\n\\n' +
+                 'This cannot be undone. Only hand-added events can be deleted.')) return;
+    await foldAction(async () => {
+      const r = await api('/admin/api/events/' + id, { method: 'DELETE' });
+      // Deleting a survivor un-hides whatever was folded into it (ON DELETE SET NULL), so
+      // the calendar can gain rows from a delete. Surprising enough to say out loud.
+      if (r && r.restored_duplicates) {
+        $('#ok').textContent = 'Deleted. ' + r.restored_duplicates + ' listing' +
+          (r.restored_duplicates === 1 ? '' : 's') +
+          ' that had been hidden as duplicates of it are visible again.';
+      }
+    });
+  }
+
+  async function deleteVenue(id, name) {
+    if (!confirm('Delete the venue "' + name + '" permanently?\\n\\n' +
+                 'Only possible while it has no events at all.')) return;
+    await foldAction(() => api('/admin/api/venues/' + id, { method: 'DELETE' }));
+    if (state.view === 'add') await loadVenues(null);
+  }
+
   async function absorb(survivorId, duplicateIds) {
     // Folding hides rows rather than deleting them, and every fold is undoable from the
     // row it creates — so this asks once, plainly, rather than with a scary warning.
@@ -799,6 +848,29 @@ ADMIN_HTML = """<!doctype html>
     // instead of creating "durham" alongside "Durham" and splitting the sidebar.
     const cities = [...new Set(data.scraped.concat(data.manual).map((v) => v.city))].sort();
     $('#cityList').innerHTML = cities.map((c) => '<option value="' + esc(c) + '"></option>').join('');
+
+    // The promoters an admin has created, with a way to remove one entered by mistake.
+    // Scraped venues are deliberately absent: they cannot be deleted, so listing them here
+    // would only offer a button that always refuses.
+    if (!data.manual.length) {
+      $('#venueList').innerHTML = '';
+    } else {
+      $('#venueList').innerHTML = '<h2>Promoters you have added</h2>' +
+        '<p class="hint">Delete removes the venue itself. It only works once the venue has ' +
+        'no events at all — otherwise removing it would take them with it.</p>' +
+        data.manual.map((v) => {
+          const n = v.upcoming_event_count;
+          const busy = n > 0;
+          return '<div class="vrow">' +
+            '<span class="sw" style="background:' + esc(v.color) + '"></span>' +
+            '<span class="vn">' + esc(v.name) + '</span>' +
+            '<span class="cm">' + esc(v.city) + '</span>' +
+            '<span class="cm">' + (busy ? n + ' upcoming' : 'nothing upcoming') + '</span>' +
+            '<button class="danger"' + (busy ? ' disabled title="delete its events first"' : '') +
+              ' onclick="deleteVenue(' + v.id + ',' + JSON.stringify(esc(v.name)) + ')">delete</button>' +
+            '</div>';
+        }).join('');
+    }
     venueChanged();
   }
 

--- a/backend/app/admin_ui.py
+++ b/backend/app/admin_ui.py
@@ -165,6 +165,40 @@ ADMIN_HTML = """<!doctype html>
   .crow.hiddenrow .ct { color:#8a8a8e; }
   #dupes .empty { border:1px solid #2a2a2e; border-radius:2px; background:#141417; }
   #err { color:#e0625f; font-size:0.75rem; margin:0 0 0.7rem; min-height:1em; }
+  #ok { color:#7fd69a; font-size:0.75rem; margin:0 0 0.7rem; min-height:1em; }
+  /* --- Manual event entry --- */
+  #add { border:1px solid #2a2a2e; border-radius:2px; background:#141417; padding:1rem; max-width:68ch; }
+  #add h2 { font-size:0.72rem; text-transform:uppercase; letter-spacing:0.08em;
+            color:var(--accent); margin:0 0 0.2rem; }
+  #add .hint { color:#8a8a8e; font-size:0.72rem; line-height:1.5; margin:0 0 0.9rem; }
+  /* Two columns on a roomy screen, one when narrow. A date and a time sitting side by
+     side is the pairing that actually helps; everything else just wants to be scannable. */
+  .grid { display:grid; grid-template-columns:repeat(auto-fit, minmax(15rem, 1fr)); gap:0.6rem 0.9rem; }
+  .f { display:flex; flex-direction:column; gap:0.2rem; }
+  .f.wide { grid-column:1 / -1; }
+  .f label { color:#a8a6a3; font-size:0.68rem; text-transform:uppercase; letter-spacing:0.06em; }
+  .f label .req { color:var(--accent); }
+  .f input, .f select, .f textarea {
+     font-family:inherit; font-size:0.8rem; padding:0.35rem 0.5rem; border-radius:2px;
+     background:#17171a; border:1px solid #2a2a2e; color:#e8e6e3; }
+  .f input:focus, .f select:focus, .f textarea:focus { outline:none; border-color:var(--accent); }
+  .f textarea { resize:vertical; min-height:3.4rem; }
+  .f .note { color:#8a8a8e; font-size:0.66rem; }
+  .f.check { flex-direction:row; align-items:center; gap:0.45rem; }
+  .f.check input { width:auto; }
+  .f.check label { text-transform:none; letter-spacing:0; font-size:0.75rem; color:#c8c6c3; }
+  /* The new-promoter fields sit inside the same form, revealed by the venue dropdown,
+     rather than in a separate dialog — creating the promoter and creating its first event
+     is one intention, and a modal would make it two. */
+  #newVenue { grid-column:1 / -1; border-left:2px solid var(--accent); padding-left:0.8rem;
+              margin:0.2rem 0; display:grid; grid-template-columns:repeat(auto-fit, minmax(13rem, 1fr));
+              gap:0.6rem 0.9rem; }
+  #add .actions { margin-top:1rem; display:flex; gap:0.6rem; align-items:center; }
+  #add button.go { font-family:inherit; font-size:0.75rem; text-transform:uppercase;
+     letter-spacing:0.06em; padding:0.4rem 0.9rem; border:1px solid var(--accent);
+     background:var(--accent); color:#0e0e10; font-weight:700; cursor:pointer; border-radius:2px; }
+  #add button.go:hover { filter:brightness(1.1); }
+  #add button.go:disabled { opacity:0.5; cursor:default; filter:none; }
 </style>
 </head><body>
   <header>
@@ -178,6 +212,7 @@ ADMIN_HTML = """<!doctype html>
     <div class="controls">
       <button class="fbtn on" data-v="queue" onclick="setView('queue')">review queue</button>
       <button class="fbtn" data-v="duplicates" onclick="setView('duplicates')">duplicates</button>
+      <button class="fbtn" data-v="add" onclick="setView('add')">add event</button>
     </div>
     <div class="controls" id="queueControls">
       <button class="fbtn on" data-f="non_live" onclick="setFilter('non_live')">non-live</button>
@@ -194,6 +229,7 @@ ADMIN_HTML = """<!doctype html>
       <span id="dupeCount"></span>
     </div>
     <p id="err"></p>
+    <p id="ok"></p>
     <pre id="rules" class="hidden"></pre>
     <div id="help" class="hidden">
       <h2>What this page is for</h2>
@@ -269,6 +305,107 @@ ADMIN_HTML = """<!doctype html>
       <tbody id="tbody"></tbody>
     </table>
     <div id="dupes" class="hidden"></div>
+    <div id="add" class="hidden">
+      <h2>Add an event by hand</h2>
+      <p class="hint">For anything no scraper will find — a promoter's show, a festival
+      stage, a one-off at a room that doesn't publish listings. It appears on the public
+      calendar immediately, and the scraper won't remove it.</p>
+      <form id="addForm" onsubmit="submitEvent(event)">
+        <div class="grid">
+          <div class="f wide">
+            <label for="fVenue">venue <span class="req">*</span></label>
+            <select id="fVenue" onchange="venueChanged()" required></select>
+            <span class="note" id="fVenueNote"></span>
+          </div>
+
+          <div id="newVenue" class="hidden">
+            <div class="f">
+              <label for="nvName">promoter / venue name <span class="req">*</span></label>
+              <input id="nvName" type="text" placeholder="e.g. Sharp 9 Gallery">
+            </div>
+            <div class="f">
+              <label for="nvCity">city <span class="req">*</span></label>
+              <input id="nvCity" type="text" list="cityList" placeholder="Durham">
+              <datalist id="cityList"></datalist>
+              <span class="note">the public site groups and filters by this</span>
+            </div>
+            <div class="f">
+              <label for="nvSize">size</label>
+              <select id="nvSize">
+                <option value="small">small</option>
+                <option value="medium">medium</option>
+                <option value="large">large</option>
+              </select>
+            </div>
+            <div class="f">
+              <label for="nvColor">colour</label>
+              <input id="nvColor" type="text" placeholder="chosen for you">
+              <span class="note">leave blank to get one no other venue is using</span>
+            </div>
+          </div>
+
+          <div class="f wide">
+            <label for="fName">event name <span class="req">*</span></label>
+            <input id="fName" type="text" required placeholder="e.g. Sub Rosa">
+          </div>
+          <div class="f">
+            <label for="fArtist">artist</label>
+            <input id="fArtist" type="text">
+            <span class="note">shown instead of the event name when set</span>
+          </div>
+          <div class="f">
+            <label for="fSupport">support</label>
+            <input id="fSupport" type="text">
+          </div>
+          <div class="f">
+            <label for="fDate">date <span class="req">*</span></label>
+            <input id="fDate" type="date" required>
+          </div>
+          <div class="f">
+            <label for="fShow">show time</label>
+            <input id="fShow" type="time">
+          </div>
+          <div class="f">
+            <label for="fDoors">doors</label>
+            <input id="fDoors" type="time">
+          </div>
+          <div class="f">
+            <label for="fAge">ages</label>
+            <input id="fAge" type="text" placeholder="e.g. 18+">
+          </div>
+          <div class="f">
+            <label for="fPriceMin">price from</label>
+            <input id="fPriceMin" type="number" min="0" step="1" placeholder="0 for free">
+          </div>
+          <div class="f">
+            <label for="fPriceMax">price to</label>
+            <input id="fPriceMax" type="number" min="0" step="1">
+          </div>
+          <div class="f">
+            <label for="fGenre">genre</label>
+            <input id="fGenre" type="text">
+          </div>
+          <div class="f wide">
+            <label for="fUrl">ticket link</label>
+            <input id="fUrl" type="url" placeholder="https://...">
+            <span class="note">dropped if it isn't a working http(s) link</span>
+          </div>
+          <div class="f wide">
+            <label for="fDesc">description</label>
+            <textarea id="fDesc"></textarea>
+          </div>
+          <div class="f check wide">
+            <input id="fLive" type="checkbox" checked>
+            <label for="fLive">live music — untick for comedy, trivia, a DJ night, a
+            club night. Visitors can hide non-live events, and this setting is yours: the
+            detector will never overwrite it.</label>
+          </div>
+        </div>
+        <div class="actions">
+          <button type="submit" class="go" id="fSubmit">add event</button>
+        </div>
+      </form>
+    </div>
   </main>
 <script>
   let RULES = null;
@@ -617,14 +754,132 @@ ADMIN_HTML = """<!doctype html>
     await foldAction(() => api('/admin/api/events/' + id + '/unfold', { method: 'POST' }));
   }
 
+  // --- Manual event entry ---
+
+  const NEW_VENUE = '__new__';
+
+  function venueChanged() {
+    const isNew = $('#fVenue').value === NEW_VENUE;
+    $('#newVenue').classList.toggle('hidden', !isNew);
+    // required is toggled rather than fixed in the markup: a hidden required field blocks
+    // submit with a browser message pointing at something the admin cannot see.
+    ['#nvName', '#nvCity'].forEach((id) => { $(id).required = isNew; });
+
+    const opt = $('#fVenue').selectedOptions[0];
+    const n = opt && opt.dataset.count ? Number(opt.dataset.count) : null;
+    $('#fVenueNote').textContent = isNew || n === null ? ''
+      : (n === 0 ? 'nothing else coming up at this venue'
+                 : n + ' other event' + (n === 1 ? '' : 's') + ' coming up here');
+  }
+
+  async function loadVenues(selectId) {
+    const data = await api('/admin/api/venues');
+    const opt = (v) =>
+      '<option value="' + v.id + '" data-count="' + v.upcoming_event_count + '">' +
+      esc(v.name) + ' · ' + esc(v.city) + '</option>';
+    // Scraped and hand-added are separated because they answer different questions —
+    // "a real room hosting something its listings won't carry" versus "there is no venue".
+    // One alphabetical list buries the second kind as soon as there are a few.
+    let html = '<option value="" disabled' + (selectId ? '' : ' selected') + '>choose…</option>';
+    if (data.manual.length) {
+      html += '<optgroup label="promoters and one-offs">' + data.manual.map(opt).join('') + '</optgroup>';
+    }
+    html += '<optgroup label="scraped venues">' + data.scraped.map(opt).join('') + '</optgroup>';
+    html += '<option value="' + NEW_VENUE + '">＋ new promoter or venue…</option>';
+    $('#fVenue').innerHTML = html;
+    if (selectId) $('#fVenue').value = String(selectId);
+
+    // Offer the cities already in use, so a new promoter lands in an existing group
+    // instead of creating "durham" alongside "Durham" and splitting the sidebar.
+    const cities = [...new Set(data.scraped.concat(data.manual).map((v) => v.city))].sort();
+    $('#cityList').innerHTML = cities.map((c) => '<option value="' + esc(c) + '"></option>').join('');
+    venueChanged();
+  }
+
+  function fieldValue(id) {
+    const el = $(id);
+    const v = (el.value || '').trim();
+    return v === '' ? null : v;
+  }
+
+  async function submitEvent(ev) {
+    ev.preventDefault();
+    $('#err').textContent = '';
+    $('#ok').textContent = '';
+    const btn = $('#fSubmit');
+    btn.disabled = true;
+    try {
+      let venueId = $('#fVenue').value;
+
+      // Creating the promoter first, in its own request. Two writes rather than one
+      // endpoint that does both: if the event is rejected — a clashing hash, a mistyped
+      // year — the promoter still exists and is selected, so the admin fixes one field
+      // and resubmits instead of retyping the venue as well.
+      if (venueId === NEW_VENUE) {
+        const created = await api('/admin/api/venues', {
+          method: 'POST',
+          body: JSON.stringify({
+            name: fieldValue('#nvName'),
+            city: fieldValue('#nvCity'),
+            size_category: $('#nvSize').value,
+            color: fieldValue('#nvColor'),
+          }),
+        });
+        venueId = created.id;
+        await loadVenues(venueId);
+        $('#ok').textContent = 'Created ' + created.name + ' (' + created.color + ').';
+      }
+
+      const num = (id) => {
+        const v = fieldValue(id);
+        return v === null ? null : Number(v);
+      };
+      const created = await api('/admin/api/events', {
+        method: 'POST',
+        body: JSON.stringify({
+          venue_id: Number(venueId),
+          name: fieldValue('#fName'),
+          date: fieldValue('#fDate'),
+          artist: fieldValue('#fArtist'),
+          support_artists: fieldValue('#fSupport'),
+          doors_time: fieldValue('#fDoors'),
+          show_time: fieldValue('#fShow'),
+          ticket_url: fieldValue('#fUrl'),
+          price_min: num('#fPriceMin'),
+          price_max: num('#fPriceMax'),
+          description: fieldValue('#fDesc'),
+          genre: fieldValue('#fGenre'),
+          age_restriction: fieldValue('#fAge'),
+          is_live_music: $('#fLive').checked,
+        }),
+      });
+      // Keep the venue and date, clear the rest. Adding several shows for one promoter on
+      // one night, or a run of dates, is the common case; retyping the venue each time is
+      // the friction that makes an admin batch them up and put it off.
+      ['#fName', '#fArtist', '#fSupport', '#fDoors', '#fShow', '#fUrl',
+       '#fPriceMin', '#fPriceMax', '#fDesc', '#fGenre', '#fAge'].forEach((id) => { $(id).value = ''; });
+      $('#fLive').checked = true;
+      $('#ok').textContent = 'Added "' + created.name + '" at ' + created.venue_name +
+                             ' on ' + created.date + '. Venue and date kept for the next one.';
+      await loadVenues(venueId);
+      $('#fName').focus();
+    } catch (e) {
+      showError(e);
+    } finally {
+      btn.disabled = false;
+    }
+  }
+
   function setView(v) {
     state.view = v;
     document.querySelectorAll('.fbtn[data-v]').forEach((b) => b.classList.toggle('on', b.dataset.v === v));
-    const isQueue = v === 'queue';
-    $('#queueControls').classList.toggle('hidden', !isQueue);
-    $('#queueTable').classList.toggle('hidden', !isQueue);
-    $('#dupeControls').classList.toggle('hidden', isQueue);
-    $('#dupes').classList.toggle('hidden', isQueue);
+    $('#queueControls').classList.toggle('hidden', v !== 'queue');
+    $('#queueTable').classList.toggle('hidden', v !== 'queue');
+    $('#dupeControls').classList.toggle('hidden', v !== 'duplicates');
+    $('#dupes').classList.toggle('hidden', v !== 'duplicates');
+    $('#add').classList.toggle('hidden', v !== 'add');
+    $('#err').textContent = '';
+    $('#ok').textContent = '';
     reload();
   }
 
@@ -641,7 +896,11 @@ ADMIN_HTML = """<!doctype html>
   // which never gets here.
   async function reload() {
     try {
-      if (state.view === 'duplicates') await loadDuplicates(); else await load();
+      if (state.view === 'duplicates') await loadDuplicates();
+      // The add form is loaded, not reloaded: refetching venues on every action would
+      // reset the dropdown mid-typing. loadVenues() is called explicitly after a write.
+      else if (state.view === 'add') await loadVenues($('#fVenue').value || null);
+      else await load();
     } catch (e) {
       showError(e);
     }

--- a/backend/app/api/admin.py
+++ b/backend/app/api/admin.py
@@ -11,8 +11,9 @@ main.py so these routes take priority over the catch-all.
 Requires: async PostgreSQL session, app.classifier, app.scrapers.manager, itsdangerous.
 """
 import logging
+import re
 import secrets
-from datetime import date, datetime
+from datetime import date, datetime, time
 from typing import Optional
 
 from fastapi import APIRouter, Depends, HTTPException, Request, Query
@@ -25,10 +26,12 @@ from sqlalchemy.orm import joinedload
 
 from app.config import settings
 from app.database import get_session
-from app.models import Event, Venue, SeriesOverride
+from app.models import Event, Venue, SeriesOverride, MANUAL_SCRAPER_TYPE
 from app.classifier import normalize_series_name, criteria_summary, reclassify_floor
 from app.duplicates import FoldError, build_clusters, validate_fold
-from app.scrapers.manager import ScrapeManager
+from app.scrapers.base import ScrapedEvent
+from app.scrapers.manager import ScrapeManager, event_from_scraped
+from app.venue_colors import is_valid_hex, pick_venue_color
 from app.admin_ui import LOGIN_HTML, ADMIN_HTML
 from app import tokens
 
@@ -690,6 +693,283 @@ async def unfold_duplicate(
     event.duplicate_of_id = None
     await session.commit()
     return {"ok": True, "id": event_id, "was_duplicate_of": was}
+
+
+# --- Manual event entry ---
+#
+# An admin creating rows by hand is the one write path where a mistake reaches the public
+# calendar directly, with no scraper in between to correct it on the next run. The
+# guardrails, and what each one stops:
+#
+#   * Every event is built as a ScrapedEvent first. That dataclass cleans the title and
+#     validates the ticket and image URLs, so a pasted title carrying HTML entities and a
+#     javascript: URL are handled by the code that already handles them from a venue site,
+#     rather than by a second implementation that has to remember to.
+#   * The hash therefore matches what a scraper would compute for the same show, so a venue
+#     that later lists it updates the admin's row instead of adding a twin.
+#   * A colliding hash is reported as "already on the calendar", naming the row it hit,
+#     instead of surfacing an IntegrityError as a 500.
+#   * Dates are bounded. Mistyping the year is the easiest error to make in a date field and
+#     the hardest to notice, because the row lands outside every view that would show it.
+#   * A manual venue's scraper_type is MANUAL_SCRAPER_TYPE, which scrape_all excludes — see
+#     app/models.py for why that one matters most.
+
+# Ten years back covers the archive; two forward covers any real announcement. Wider would
+# let 2062-for-2026 create a row nothing displays and nobody finds again.
+MANUAL_EVENT_MIN_DATE = date(2015, 1, 1)
+MANUAL_EVENT_MAX_YEARS_AHEAD = 2
+
+
+class ManualVenueBody(BaseModel):
+    """A venue nothing scrapes — a promoter, a festival, a one-off series."""
+
+    name: str
+    city: str
+    size_category: str = "small"
+    website: Optional[str] = None
+    color: Optional[str] = None  # omit to have one chosen
+
+
+class ManualEventBody(BaseModel):
+    venue_id: int
+    name: str
+    date: str  # ISO
+    artist: Optional[str] = None
+    support_artists: Optional[str] = None
+    doors_time: Optional[str] = None  # HH:MM
+    show_time: Optional[str] = None
+    ticket_url: Optional[str] = None
+    price_min: Optional[float] = None
+    price_max: Optional[float] = None
+    description: Optional[str] = None
+    genre: Optional[str] = None
+    age_restriction: Optional[str] = None
+    is_live_music: bool = True
+
+
+def _slugify(name: str) -> str:
+    """A URL-safe slug for a hand-created venue."""
+    slug = re.sub(r"[^a-z0-9]+", "-", (name or "").lower()).strip("-")
+    return slug[:100]
+
+
+def _parse_time(value: Optional[str], field: str) -> Optional[time]:
+    """Parse 'HH:MM' (or 'HH:MM:SS'), or raise a 400 naming the field."""
+    if not value:
+        return None
+    try:
+        return time.fromisoformat(value)
+    except ValueError:
+        raise HTTPException(
+            status_code=400, detail=f"{field} must look like 20:00, not {value!r}."
+        )
+
+
+async def _upcoming_counts(session: AsyncSession) -> dict[int, int]:
+    """Events per venue from today onward, excluding admin-flagged duplicates.
+
+    Mirrors the public read filters so the number matches what the calendar would show.
+    """
+    rows = await session.execute(
+        select(Event.venue_id, func.count())
+        .where(Event.date >= date.today(), Event.duplicate_of_id.is_(None))
+        .group_by(Event.venue_id)
+    )
+    return {venue_id: n for venue_id, n in rows.all()}
+
+
+@router.get("/api/venues", dependencies=[Depends(require_admin)])
+async def admin_venues(session: AsyncSession = Depends(get_session)) -> dict:
+    """Venues for the manual-add form, split by whether anything scrapes them.
+
+    Two groups, because they answer different questions. A scraped venue gets picked when a
+    real room is hosting something its own listings will not carry — a private show, a
+    festival stage. A promoter gets picked when there is no venue to speak of. One
+    alphabetical list would bury the second kind as soon as there are a few of them.
+    """
+    result = await session.execute(select(Venue).order_by(Venue.city, Venue.name))
+    venues = result.scalars().all()
+    counts = await _upcoming_counts(session)
+
+    def row(v: Venue) -> dict:
+        return {
+            "id": v.id,
+            "name": v.name,
+            "city": v.city,
+            "color": v.color,
+            "upcoming_event_count": counts.get(v.id, 0),
+        }
+
+    return {
+        "scraped": [row(v) for v in venues if v.scraper_type != MANUAL_SCRAPER_TYPE],
+        "manual": [row(v) for v in venues if v.scraper_type == MANUAL_SCRAPER_TYPE],
+    }
+
+
+@router.post("/api/venues", dependencies=[Depends(require_admin)])
+async def create_manual_venue(
+    body: ManualVenueBody,
+    session: AsyncSession = Depends(get_session),
+) -> dict:
+    """Create a venue nothing scrapes, so hand-added events have somewhere to hang."""
+    name = (body.name or "").strip()
+    if not name:
+        raise HTTPException(status_code=400, detail="A name is required.")
+    city = (body.city or "").strip()
+    if not city:
+        raise HTTPException(
+            status_code=400,
+            detail="A city is required — the public site groups and filters venues by it.",
+        )
+
+    slug = _slugify(name)
+    if not slug:
+        raise HTTPException(
+            status_code=400,
+            detail="That name has no letters or digits in it, so it cannot make a slug.",
+        )
+    clash = (
+        await session.execute(select(Venue).where(Venue.slug == slug))
+    ).scalar_one_or_none()
+    if clash:
+        raise HTTPException(
+            status_code=409,
+            detail=f'"{clash.name}" already uses that name. Pick another.',
+        )
+
+    if body.color:
+        if not is_valid_hex(body.color):
+            raise HTTPException(
+                status_code=400,
+                detail=f"{body.color!r} is not a hex colour like #7fb069.",
+            )
+        color = body.color.strip().lower()
+    else:
+        # Chosen to sit in the widest unused part of the hue wheel, so a new promoter is
+        # distinguishable from every existing venue on a busy month. See app/venue_colors.py.
+        existing = (await session.execute(select(Venue.color))).scalars().all()
+        color = pick_venue_color(existing, name=name)
+
+    venue = Venue(
+        name=name,
+        slug=slug,
+        city=city,
+        size_category=(body.size_category or "small").strip() or "small",
+        website=(body.website or None),
+        scraper_type=MANUAL_SCRAPER_TYPE,
+        color=color,
+    )
+    session.add(venue)
+    await session.commit()
+    logger.info(f"[admin] created manual venue {slug!r} ({city}) with colour {color}")
+    return {
+        "ok": True,
+        "id": venue.id,
+        "name": venue.name,
+        "city": venue.city,
+        "color": venue.color,
+        "upcoming_event_count": 0,
+    }
+
+
+@router.post("/api/events", dependencies=[Depends(require_admin)])
+async def create_manual_event(
+    body: ManualEventBody,
+    session: AsyncSession = Depends(get_session),
+) -> dict:
+    """Create one event by hand, at an existing venue."""
+    name = (body.name or "").strip()
+    if not name:
+        raise HTTPException(status_code=400, detail="A name is required.")
+
+    venue = await session.get(Venue, body.venue_id)
+    if not venue:
+        raise HTTPException(status_code=404, detail="That venue does not exist.")
+
+    try:
+        on = date.fromisoformat((body.date or "")[:10])
+    except ValueError:
+        raise HTTPException(
+            status_code=400, detail=f"{body.date!r} is not a date like 2026-09-30."
+        )
+    latest = date(date.today().year + MANUAL_EVENT_MAX_YEARS_AHEAD, 12, 31)
+    if not (MANUAL_EVENT_MIN_DATE <= on <= latest):
+        raise HTTPException(
+            status_code=400,
+            detail=(
+                f"{on.isoformat()} is outside {MANUAL_EVENT_MIN_DATE.year}-{latest.year}. "
+                "Check the year."
+            ),
+        )
+
+    if body.price_min is not None and body.price_min < 0:
+        raise HTTPException(status_code=400, detail="A price cannot be negative.")
+    if (
+        body.price_min is not None
+        and body.price_max is not None
+        and body.price_max < body.price_min
+    ):
+        raise HTTPException(
+            status_code=400, detail="The highest price is below the lowest."
+        )
+
+    # Through ScrapedEvent, so a hand-added event gets the same title cleaning, URL
+    # validation and dedup hash as a scraped one. An unusable ticket_url is dropped to None
+    # there rather than raising, which is the established behaviour for scraped data.
+    scraped = ScrapedEvent(
+        name=name,
+        date=on,
+        venue_slug=venue.slug,
+        source="manual",
+        artist=(body.artist or None),
+        support_artists=(body.support_artists or None),
+        doors_time=_parse_time(body.doors_time, "doors_time"),
+        show_time=_parse_time(body.show_time, "show_time"),
+        ticket_url=(body.ticket_url or None),
+        price_min=body.price_min,
+        price_max=body.price_max,
+        genre=(body.genre or None),
+        age_restriction=(body.age_restriction or None),
+        description=(body.description or None),
+    )
+
+    clash = (
+        await session.execute(select(Event).where(Event.hash == scraped.hash))
+    ).scalar_one_or_none()
+    if clash:
+        raise HTTPException(
+            status_code=409,
+            detail=(
+                f'"{clash.name}" on {clash.date.isoformat()} is already on the calendar '
+                f"at this venue (event {clash.id})."
+            ),
+        )
+
+    event = event_from_scraped(scraped, venue.id)
+    # Both flags, because they mean different things and both are wanted here. #87 keeps
+    # them separate deliberately: is_manually_created records that a human *created the
+    # row*, and is what stops reconcile deleting it. is_manual_override records that a
+    # human set the *live-music verdict*, and is what stops reclassify_all overwriting it —
+    # without which an event added as "Comedy Showcase" would be auto-flagged non-live and
+    # vanish from the very calendar the admin added it to.
+    event.is_manually_created = True
+    event.is_live_music = body.is_live_music
+    event.is_manual_override = True
+    event.classification_reason = "manual"
+    event.approved_at = datetime.utcnow()  # adding it by hand *is* the review
+    session.add(event)
+    await session.commit()
+
+    logger.info(
+        f"[admin] created manual event {event.id} {name!r} at {venue.slug} on {on}"
+    )
+    return {
+        "ok": True,
+        "id": event.id,
+        "name": event.name,
+        "date": event.date.isoformat(),
+        "venue_name": venue.name,
+    }
 
 
 @router.get("/api/series", dependencies=[Depends(require_admin)])

--- a/backend/app/api/admin.py
+++ b/backend/app/api/admin.py
@@ -972,6 +972,108 @@ async def create_manual_event(
     }
 
 
+@router.delete("/api/events/{event_id}", dependencies=[Depends(require_admin)])
+async def delete_manual_event(
+    event_id: int,
+    session: AsyncSession = Depends(get_session),
+) -> dict:
+    """Delete a hand-added event. Only a hand-added one.
+
+    Restricted to is_manually_created rows, and that restriction is the point rather than
+    caution. Deleting a *scraped* event is futile — the next run of that venue's scraper
+    puts it straight back — so a general delete button would look broken while quietly
+    being the one tool that can destroy an archive row. Hiding a scraped event is already
+    covered by marking it non-live or flagging it a duplicate.
+
+    Hard delete, not a flag. There is no audit value in retaining a typo, and a
+    soft-delete column would have to be honoured by every read path in the app for the
+    rest of its life to serve a mistyped title.
+
+    Hand-added rows are the ones with no other way out. reconcile deliberately will not
+    touch them (scraper_must_not_delete), and a hand-added event at a hand-added venue is
+    never even considered, because scrape_all skips that venue entirely. Everything that
+    protects them from the scraper is what makes this endpoint necessary.
+    """
+    event = await session.get(Event, event_id)
+    if not event:
+        raise HTTPException(status_code=404, detail="Event not found")
+    if not event.is_manually_created:
+        raise HTTPException(
+            status_code=400,
+            detail=(
+                "Only hand-added events can be deleted. A scraped event would come back on "
+                "the next scrape — mark it non-live, or flag it as a duplicate, to hide it."
+            ),
+        )
+
+    # Rows folded into this one become visible again, because duplicate_of_id is ON DELETE
+    # SET NULL. That is the behaviour migration 0006 chose deliberately — a row should not
+    # stay hidden on account of a row that no longer exists — but it means deleting a
+    # survivor can put listings back on the public calendar, so report how many.
+    restored = (await session.execute(
+        select(func.count()).select_from(Event).where(Event.duplicate_of_id == event_id)
+    )).scalar_one()
+
+    name, on = event.name, event.date.isoformat()
+    await session.delete(event)
+    await session.commit()
+    logger.info(f"[admin] deleted manual event {event_id} {name!r} on {on}")
+    return {"ok": True, "id": event_id, "name": name, "restored_duplicates": restored}
+
+
+@router.delete("/api/venues/{venue_id}", dependencies=[Depends(require_admin)])
+async def delete_manual_venue(
+    venue_id: int,
+    session: AsyncSession = Depends(get_session),
+) -> dict:
+    """Delete a hand-added venue, but only once nothing is attached to it.
+
+    Two refusals, and each prevents silent data loss rather than merely being careful.
+
+    A seeded venue is never deletable. seed_venues() would recreate it on the next boot
+    with a new id, so the venue appears to come back — while its events are gone for good,
+    cascade-deleted through Venue.events. That is pure loss with no upside, and it would
+    look like the delete had simply not worked.
+
+    A venue with events is refused, and the count is reported. Venue.events cascades with
+    delete-orphan, so one click on a venue holding a run of shows would take all of them
+    with it, with nothing naming what was lost. Deleting the events first is one extra step
+    and makes the scope of the decision visible. `event_count` here is every event, not just
+    upcoming ones: a past event is still a row, and cascading it away silently is the thing
+    being prevented.
+    """
+    venue = await session.get(Venue, venue_id)
+    if not venue:
+        raise HTTPException(status_code=404, detail="Venue not found")
+    if venue.scraper_type != MANUAL_SCRAPER_TYPE:
+        raise HTTPException(
+            status_code=400,
+            detail=(
+                f'"{venue.name}" is a scraped venue, not one added by hand. Deleting it '
+                "would remove its events and it would reappear empty on the next restart."
+            ),
+        )
+
+    event_count = (await session.execute(
+        select(func.count()).select_from(Event).where(Event.venue_id == venue_id)
+    )).scalar_one()
+    if event_count:
+        raise HTTPException(
+            status_code=409,
+            detail=(
+                f'"{venue.name}" still has {event_count} event'
+                f'{"" if event_count == 1 else "s"}. Delete those first — removing the '
+                "venue would take them with it."
+            ),
+        )
+
+    name = venue.name
+    await session.delete(venue)
+    await session.commit()
+    logger.info(f"[admin] deleted manual venue {venue_id} {name!r}")
+    return {"ok": True, "id": venue_id, "name": name}
+
+
 @router.get("/api/series", dependencies=[Depends(require_admin)])
 async def list_series(session: AsyncSession = Depends(get_session)) -> dict:
     """List all series-level overrides with their venue name."""

--- a/backend/app/api/venues.py
+++ b/backend/app/api/venues.py
@@ -7,12 +7,14 @@ Requires: app.database (async PostgreSQL session), app.models.Venue, app.schemas
 """
 
 # --- Imports ---
+from datetime import date
+
 from fastapi import APIRouter, Depends
-from sqlalchemy import select
+from sqlalchemy import select, func
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.database import get_session
-from app.models import Venue
+from app.models import Venue, Event, MANUAL_SCRAPER_TYPE
 from app.schemas import VenueResponse
 
 # --- Router ---
@@ -24,8 +26,35 @@ router = APIRouter(prefix="/api/venues", tags=["venues"])
 
 @router.get("", response_model=list[VenueResponse])
 async def list_venues(session: AsyncSession = Depends(get_session)):
-    """Get all venues with metadata for the filter UI."""
+    """Get all venues with metadata for the filter UI.
+
+    Hand-added venues (promoters, festivals, one-off series) are omitted while they have no
+    upcoming events. A scraped venue with an empty calendar is still a real place worth
+    showing — it has a quiet month, and it will fill up again on the next scrape. A promoter
+    exists only as somewhere to hang events, so once its events are past it is a filter that
+    selects nothing, and every one an admin ever creates would accumulate in the sidebar
+    forever. Scraped venues are always listed, whatever their count, so this cannot quietly
+    remove a real venue from the filters.
+    """
     # Order by city first so the frontend can group venues by market (Raleigh, Durham, Chapel Hill)
     result = await session.execute(select(Venue).order_by(Venue.city, Venue.name))
     venues = result.scalars().all()
-    return [VenueResponse.model_validate(v) for v in venues]
+
+    # One grouped query rather than a count per venue. Mirrors the public read filters:
+    # today onward, and excluding rows an admin flagged as duplicates (#63), so the number
+    # matches what the calendar would actually show.
+    counts = dict((await session.execute(
+        select(Event.venue_id, func.count())
+        .where(Event.date >= date.today(), Event.duplicate_of_id.is_(None))
+        .group_by(Event.venue_id)
+    )).all())
+
+    out = []
+    for venue in venues:
+        count = counts.get(venue.id, 0)
+        if venue.scraper_type == MANUAL_SCRAPER_TYPE and count == 0:
+            continue
+        response = VenueResponse.model_validate(venue)
+        response.upcoming_event_count = count
+        out.append(response)
+    return out

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -17,6 +17,20 @@ import enum
 from app.database import Base
 
 
+# --- Constants ---
+
+# Venue.scraper_type for a venue nothing scrapes: a promoter, a festival, a one-off series
+# an admin created by hand so that events can hang off something.
+#
+# A string in an existing column rather than a new boolean, so this needed no migration —
+# but it is load-bearing in two places and must not be spelled inline in either.
+# ScrapeManager.scrape_all() excludes these venues, without which each one would write a
+# failed ScrapeLog on every cycle (there is deliberately no scraper for them), and
+# app.api.venues hides them from the public venue list while they have no upcoming events,
+# so an empty promoter is not offered as a filter.
+MANUAL_SCRAPER_TYPE = "manual"
+
+
 # --- Enums ---
 
 class EventStatus(str, enum.Enum):

--- a/backend/app/scheduler.py
+++ b/backend/app/scheduler.py
@@ -1,23 +1,26 @@
 """
-APScheduler job definitions for periodic scraping and data maintenance.
+APScheduler job definitions for periodic scraping.
 
 Role: Started during FastAPI app startup (main.py) when ENABLE_SCHEDULER=true.
       Runs scrape jobs on a fixed cron schedule as an alternative to Cloud Scheduler
-      HTTP triggers — both ultimately call the same ScrapeManager logic.
+      HTTP triggers — both ultimately call the same ScrapeManager logic. Every job here
+      only ever adds or updates events; nothing scheduled deletes them, deliberately
+      (see configure_scheduler).
 Requires: ENABLE_SCHEDULER env var (via config.py), app.scrapers.manager.ScrapeManager,
           app.database.async_session, and a running async event loop (provided by FastAPI).
 """
 
 # --- Imports ---
+#
+# No `delete`, no Event model, no date arithmetic: every import here is for scheduling or
+# scraping. That is a property worth noticing rather than an accident — this module cannot
+# delete a row without someone adding an import first.
 import logging
-from datetime import datetime, timedelta
 
 from apscheduler.schedulers.asyncio import AsyncIOScheduler
 from apscheduler.triggers.cron import CronTrigger
-from sqlalchemy import delete
 
 from app.database import async_session
-from app.models import Event
 from app.scrapers.manager import ScrapeManager
 
 # --- Module-level setup ---
@@ -50,42 +53,6 @@ async def scrape_indie_job():
             logger.info(f"  {r}")
 
 
-async def cleanup_past_events_job():
-    """Delete events more than 7 days in the past, except rows a human owns.
-
-    This is the third deletion path in the app, and the two exclusions below bring it into
-    line with the other two. It issues a bulk DELETE rather than going through the ORM, so
-    it bypasses ScrapeManager.scraper_must_not_delete entirely — the predicate that stops
-    reconcile removing hand-added events and admin-flagged duplicates. Without them, this
-    job silently undoes both guarantees a week after the fact:
-
-      * a hand-added event (#87) disappears, though nothing else in the app will touch it
-      * a row flagged as a duplicate (#63) disappears, destroying the mapping that made the
-        decision reversible and auditable — and taking the "3 hidden duplicates" count on
-        its survivor with it
-
-    Only dormant today because ENABLE_SCHEDULER is false in production (cloudbuild.yaml);
-    it runs on any local or self-hosted instance with the scheduler on.
-
-    Deliberately not routed through scraper_must_not_delete: that takes a row, and the
-    point of a bulk DELETE is not to load any. The conditions are duplicated here on
-    purpose, with this comment as the link.
-    """
-    logger.info("Cleaning up past events")
-    # Keep a 7-day buffer so recently-ended events don't vanish immediately
-    cutoff = datetime.utcnow().date() - timedelta(days=7)
-    async with async_session() as session:
-        result = await session.execute(
-            delete(Event).where(
-                Event.date < cutoff,
-                Event.is_manually_created.is_(False),
-                Event.duplicate_of_id.is_(None),
-            )
-        )
-        await session.commit()
-        logger.info(f"Deleted {result.rowcount} past events")
-
-
 # --- Scheduler configuration ---
 
 def configure_scheduler():
@@ -106,10 +73,29 @@ def configure_scheduler():
         replace_existing=True,
     )
 
-    # Past event cleanup: 3 AM ET
-    scheduler.add_job(
-        cleanup_past_events_job,
-        CronTrigger(hour=3, timezone="US/Eastern"),
-        id="cleanup_past_events",
-        replace_existing=True,
-    )
+    # No past-event cleanup job, deliberately. Removed rather than left commented out,
+    # because commented-out code gets re-enabled by someone who reads the comment as a
+    # to-do rather than a decision.
+    #
+    # There used to be one deleting every event more than 7 days old, nightly at 3 AM ET.
+    # It never ran anywhere — ENABLE_SCHEDULER is false in cloudbuild.yaml, in
+    # backend/.env.example, in docs/SELF-HOSTING.md and by default in config.py — which is
+    # the only reason the archive still exists: production holds events back to January.
+    #
+    # Past events are wanted, and three separate parts of the app already assume so:
+    #
+    #   * plan_upsert bounds reconcile to `today <= date <= horizon` precisely so a scrape
+    #     cannot delete the archive; its comment says deleting past events "would wipe the
+    #     archive every run"
+    #   * the admin moderation queue and reclassify_all() both work from reclassify_floor(),
+    #     which is today minus 30 days — a 7-day cleanup would delete rows the admin UI is
+    #     built to display
+    #   * the public calendar can be scrolled backwards, and /api/events applies no floor
+    #
+    # The job also bypassed the two protections that make hand-added events and
+    # admin-flagged duplicates safe: it issued a bulk DELETE, so it never reached
+    # ScrapeManager.scraper_must_not_delete, and would have silently undone both a week
+    # after the fact.
+    #
+    # There is no operational pressure the other way. Production is at ~2,900 events after
+    # a year across 22 venues; the table is not going to become a problem.

--- a/backend/app/scheduler.py
+++ b/backend/app/scheduler.py
@@ -51,13 +51,36 @@ async def scrape_indie_job():
 
 
 async def cleanup_past_events_job():
-    """Delete events more than 7 days in the past."""
+    """Delete events more than 7 days in the past, except rows a human owns.
+
+    This is the third deletion path in the app, and the two exclusions below bring it into
+    line with the other two. It issues a bulk DELETE rather than going through the ORM, so
+    it bypasses ScrapeManager.scraper_must_not_delete entirely — the predicate that stops
+    reconcile removing hand-added events and admin-flagged duplicates. Without them, this
+    job silently undoes both guarantees a week after the fact:
+
+      * a hand-added event (#87) disappears, though nothing else in the app will touch it
+      * a row flagged as a duplicate (#63) disappears, destroying the mapping that made the
+        decision reversible and auditable — and taking the "3 hidden duplicates" count on
+        its survivor with it
+
+    Only dormant today because ENABLE_SCHEDULER is false in production (cloudbuild.yaml);
+    it runs on any local or self-hosted instance with the scheduler on.
+
+    Deliberately not routed through scraper_must_not_delete: that takes a row, and the
+    point of a bulk DELETE is not to load any. The conditions are duplicated here on
+    purpose, with this comment as the link.
+    """
     logger.info("Cleaning up past events")
     # Keep a 7-day buffer so recently-ended events don't vanish immediately
     cutoff = datetime.utcnow().date() - timedelta(days=7)
     async with async_session() as session:
         result = await session.execute(
-            delete(Event).where(Event.date < cutoff)
+            delete(Event).where(
+                Event.date < cutoff,
+                Event.is_manually_created.is_(False),
+                Event.duplicate_of_id.is_(None),
+            )
         )
         await session.commit()
         logger.info(f"Deleted {result.rowcount} past events")

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -52,6 +52,11 @@ class VenueResponse(BaseModel):
     website: Optional[str] = None
     scraper_type: str
     color: str  # Hex color used for calendar event styling per venue
+    # How many events this venue has from today onward, after duplicates are excluded.
+    # Present so the filter sidebar can say how much a venue would actually contribute —
+    # and so a hand-added promoter with nothing coming up can be left out of the list
+    # entirely rather than offered as a filter that selects nothing.
+    upcoming_event_count: int = 0
 
     # Allow constructing directly from a SQLAlchemy Venue ORM instance
     model_config = {"from_attributes": True}

--- a/backend/app/scrapers/manager.py
+++ b/backend/app/scrapers/manager.py
@@ -595,15 +595,24 @@ class ScrapeManager:
 
     # --- Bulk scrape entry points ---
 
-    async def scrape_all(self, scraper_types: Optional[list[str]] = None) -> list[dict]:
-        """Scrape all venues (or those matching given scraper_types).
+    async def scrape_all(
+        self,
+        scraper_types: Optional[list[str]] = None,
+        exclude_scraper_types: Optional[list[str]] = None,
+    ) -> list[dict]:
+        """Scrape all venues, optionally narrowed to or away from given scraper_types.
+
+        The single venue-selection query for the whole class — scrape_ticketmaster and
+        scrape_indie both come through here. That is deliberate: scrape_indie previously
+        built its own query and so missed the manual-venue exclusion below, which is the
+        kind of omission a second query invites.
 
         Venues whose scraper_type is MANUAL_SCRAPER_TYPE are excluded unconditionally, and
         this is a guardrail rather than an optimisation. There is no scraper for them by
         design, so _get_scraper returns None, scrape_venue raises "No scraper available",
-        and every one of them would write a failed ScrapeLog row on every cycle — four
-        times a day, forever, for each promoter an admin adds. The scrape would still look
-        broken in the logs while working perfectly.
+        and every one of them would write a failed ScrapeLog row on every cycle — for each
+        promoter an admin adds, indefinitely. The scrape would still look broken in the logs
+        while working perfectly.
 
         Excluded even when scraper_types names them explicitly: there is nothing to scrape,
         so an explicit request is a mistake rather than an override.
@@ -611,6 +620,8 @@ class ScrapeManager:
         query = select(Venue).where(Venue.scraper_type != MANUAL_SCRAPER_TYPE)
         if scraper_types:
             query = query.where(Venue.scraper_type.in_(scraper_types))
+        if exclude_scraper_types:
+            query = query.where(Venue.scraper_type.notin_(exclude_scraper_types))
         result = await self.session.execute(query)
         venues = result.scalars().all()
 
@@ -631,17 +642,17 @@ class ScrapeManager:
         return await self.scrape_all(scraper_types=["ticketmaster"])
 
     async def scrape_indie(self) -> list[dict]:
-        """Scrape only non-Ticketmaster venues."""
-        query = select(Venue).where(Venue.scraper_type != "ticketmaster")
-        result = await self.session.execute(query)
-        venues = result.scalars().all()
+        """Scrape only non-Ticketmaster venues.
 
-        results = []
-        for venue in venues:
-            r = await self.scrape_venue(venue)
-            results.append(r)
+        Delegates rather than running its own query. It used to build
+        `select(Venue).where(scraper_type != "ticketmaster")` and loop itself, which meant a
+        second venue query that did *not* pick up the manual-venue exclusion — so every
+        promerter an admin created would be scraped here, fail for want of a scraper, and
+        write a failed ScrapeLog three times a day (this is a scheduled job). Only dormant
+        in production because ENABLE_SCHEDULER is false there.
 
-        # Recompute live-music flags across all upcoming events now that new data is in.
-        self.last_reclassify = await self.reclassify_all()
-
-        return results
+        One query in this class is the fix, not a tidy-up: any venue-selection rule added in
+        future now applies to every entry point automatically instead of needing to be
+        remembered twice.
+        """
+        return await self.scrape_all(exclude_scraper_types=["ticketmaster"])

--- a/backend/app/scrapers/manager.py
+++ b/backend/app/scrapers/manager.py
@@ -27,7 +27,7 @@ from sqlalchemy.dialects.postgresql import insert as pg_insert
 
 from app.config import settings
 from app.classifier import classification_updates, reclassify_floor, ALWAYS_LIVE_VENUE_SLUGS
-from app.models import Venue, Event, ScrapeLog, SeriesOverride
+from app.models import Venue, Event, ScrapeLog, SeriesOverride, MANUAL_SCRAPER_TYPE
 from app.redaction import describe_exception
 from app.scrapers.base import BaseScraper, ScrapedEvent
 from app.scrapers.ticketmaster import TicketmasterScraper
@@ -249,6 +249,44 @@ def plan_upsert(existing: list[Any], scraped_events: list[ScrapedEvent], today: 
     return plan
 
 
+def event_from_scraped(se: ScrapedEvent, venue_id: int) -> Event:
+    """Build a new Event row from a ScrapedEvent.
+
+    Extracted so the admin's manual-add endpoint constructs rows the same way a scrape
+    does, rather than maintaining a parallel field list that drifts. That matters more
+    than it looks: ScrapedEvent.__post_init__ cleans the title and validates the ticket
+    and image URLs, and ScrapedEvent.hash is the dedup key. A hand-added event routed
+    through the same dataclass therefore gets the same normalization, and — because the
+    hash is computed identically — a venue that later lists a show an admin already added
+    matches the admin's row instead of inserting a second one.
+
+    Does not set is_manually_created; the caller does. Nothing in the scraper path should
+    ever write that flag (see scraper_must_not_delete).
+    """
+    return Event(
+        external_id=se.external_id,
+        venue_id=venue_id,
+        name=se.name,
+        artist=se.artist,
+        support_artists=se.support_artists,
+        date=se.date,
+        doors_time=se.doors_time,
+        show_time=se.show_time,
+        ticket_url=se.ticket_url,
+        price_min=se.price_min,
+        price_max=se.price_max,
+        image_url=se.image_url,
+        genre=se.genre,
+        subgenre=se.subgenre,
+        status=se.status,
+        age_restriction=se.age_restriction,
+        description=se.description,
+        source=se.source,
+        source_url=se.source_url,
+        hash=se.hash,
+    )
+
+
 # --- ScrapeManager ---
 
 class ScrapeManager:
@@ -263,7 +301,16 @@ class ScrapeManager:
         self.last_reclassify: Optional[dict] = None
 
     def _get_scraper(self, venue: Venue) -> Optional[BaseScraper]:
-        """Instantiate the correct scraper for a venue."""
+        """Instantiate the correct scraper for a venue, or None if there is none.
+
+        A manual venue (a promoter, a one-off series) has no source to scrape, so None is
+        the correct and expected answer for it — not a misconfiguration. scrape_all filters
+        these out before reaching here; this branch exists so that a manual venue arriving
+        by some other path fails as a clear no-op rather than looking like a broken
+        scraper_type.
+        """
+        if venue.scraper_type == MANUAL_SCRAPER_TYPE:
+            return None
         if venue.scraper_type == "ticketmaster":
             if not venue.ticketmaster_venue_id:
                 logger.warning(f"No TM venue ID for {venue.slug}")
@@ -469,28 +516,7 @@ class ScrapeManager:
             self._apply_scraped(row, se)
 
         for se in plan.inserts:
-            self.session.add(Event(
-                external_id=se.external_id,
-                venue_id=venue_id,
-                name=se.name,
-                artist=se.artist,
-                support_artists=se.support_artists,
-                date=se.date,
-                doors_time=se.doors_time,
-                show_time=se.show_time,
-                ticket_url=se.ticket_url,
-                price_min=se.price_min,
-                price_max=se.price_max,
-                image_url=se.image_url,
-                genre=se.genre,
-                subgenre=se.subgenre,
-                status=se.status,
-                age_restriction=se.age_restriction,
-                description=se.description,
-                source=se.source,
-                source_url=se.source_url,
-                hash=se.hash,
-            ))
+            self.session.add(event_from_scraped(se, venue_id))
 
         await self.session.flush()
         return {
@@ -570,8 +596,19 @@ class ScrapeManager:
     # --- Bulk scrape entry points ---
 
     async def scrape_all(self, scraper_types: Optional[list[str]] = None) -> list[dict]:
-        """Scrape all venues (or those matching given scraper_types)."""
-        query = select(Venue)
+        """Scrape all venues (or those matching given scraper_types).
+
+        Venues whose scraper_type is MANUAL_SCRAPER_TYPE are excluded unconditionally, and
+        this is a guardrail rather than an optimisation. There is no scraper for them by
+        design, so _get_scraper returns None, scrape_venue raises "No scraper available",
+        and every one of them would write a failed ScrapeLog row on every cycle — four
+        times a day, forever, for each promoter an admin adds. The scrape would still look
+        broken in the logs while working perfectly.
+
+        Excluded even when scraper_types names them explicitly: there is nothing to scrape,
+        so an explicit request is a mistake rather than an override.
+        """
+        query = select(Venue).where(Venue.scraper_type != MANUAL_SCRAPER_TYPE)
         if scraper_types:
             query = query.where(Venue.scraper_type.in_(scraper_types))
         result = await self.session.execute(query)

--- a/backend/app/venue_colors.py
+++ b/backend/app/venue_colors.py
@@ -1,0 +1,133 @@
+"""Pick a calendar colour for a venue an admin creates by hand.
+
+Role: called by the admin venue-create endpoint. Pure functions, no database and no ORM
+imports, so the choice is testable without Postgres.
+
+The problem. Seeded venues have hand-chosen colours (app/seed.py) that are spread around
+the wheel so adjacent venues on a calendar are distinguishable. A venue added at runtime
+has no such curation, and the Event model's column default is a single indigo — so every
+promoter an admin ever adds would share one colour and be mutually indistinguishable, and
+would collide with whichever seeded venue is nearest that hue.
+
+The approach. Put the new venue in the *largest gap* between the hues already in use. That
+is the choice that maximises the distance to its nearest neighbour, which is exactly the
+property "tell these apart on a calendar" needs. It degrades gracefully: with many venues
+the gaps shrink, but the new colour is still as far from everything as any colour can be.
+
+Deliberately not random. A random hue lands next to an existing one about as often as not,
+and the failure is silent — two venues that look identical on a busy month. Deliberately
+not sequential either, since deleting a venue would then shift every later assignment.
+
+frontend/js/design.js separately clamps whatever colour arrives for contrast (it enforces
+>= 6.5:1 against white and brightens for dark mode), so this only has to solve *distinctness*.
+Saturation and lightness are therefore fixed, and only the hue varies: two colours at the
+same S and L differing only in hue are as far apart as the eye is going to get.
+
+Requires: nothing outside the standard library.
+"""
+
+# --- Imports ---
+
+import colorsys
+import hashlib
+import re
+from typing import Iterable, Optional
+
+# --- Constants ---
+
+# Fixed saturation and lightness, chosen to sit in the same family as the seeded palette
+# (see app/seed.py) rather than to be maximally vivid. design.js will adjust for contrast,
+# so these only need to be in the right neighbourhood.
+_SATURATION = 0.45
+_LIGHTNESS = 0.58
+
+_HEX_RE = re.compile(r"^#(?:[0-9a-fA-F]{3}|[0-9a-fA-F]{6})$")
+
+
+# --- Hex <-> hue ---
+
+
+def is_valid_hex(value: str) -> bool:
+    """Whether `value` is a hex colour this codebase can store.
+
+    Venue.color is String(7), so a longer string would be silently truncated by some
+    drivers and rejected by others; either way an admin's typo should be a clear error
+    rather than a corrupted column.
+    """
+    return bool(value) and bool(_HEX_RE.match(value.strip()))
+
+
+def _expand(hex_color: str) -> str:
+    """Normalize to a 6-digit lowercase hex string with a leading '#'."""
+    value = hex_color.strip().lstrip("#").lower()
+    if len(value) == 3:
+        value = "".join(c * 2 for c in value)
+    return f"#{value}"
+
+
+def hue_of(hex_color: str) -> Optional[float]:
+    """The hue of `hex_color` in degrees (0-360), or None if it has none.
+
+    Greys, black and white have no meaningful hue — colorsys reports 0 for all of them,
+    which is red. Returning None instead keeps them out of the gap calculation rather than
+    letting a grey venue pretend to occupy the red part of the wheel.
+    """
+    if not is_valid_hex(hex_color):
+        return None
+    value = _expand(hex_color)
+    r, g, b = (int(value[i:i + 2], 16) / 255 for i in (1, 3, 5))
+    if r == g == b:
+        return None
+    hue, _lightness, saturation = colorsys.rgb_to_hls(r, g, b)
+    if saturation == 0:
+        return None
+    return hue * 360
+
+
+def hex_from_hue(hue: float) -> str:
+    """A hex colour at `hue` degrees, at the fixed saturation and lightness."""
+    r, g, b = colorsys.hls_to_rgb((hue % 360) / 360, _LIGHTNESS, _SATURATION)
+    return "#{:02x}{:02x}{:02x}".format(round(r * 255), round(g * 255), round(b * 255))
+
+
+# --- Assignment ---
+
+
+def largest_hue_gap_midpoint(hues: Iterable[float]) -> float:
+    """The hue furthest from every hue in `hues`.
+
+    Walks the sorted hues as a circle, including the wrap-around gap from the last back to
+    the first — without that the widest gap is invisible whenever it straddles 0 degrees,
+    which is common because reds are well represented in the seeded palette.
+
+    With no hues at all, returns 210 (a mid blue) rather than 0: an arbitrary starting
+    point still has to look deliberate on the calendar, and red reads as an alert.
+    """
+    ordered = sorted(h % 360 for h in hues)
+    if not ordered:
+        return 210.0
+    if len(ordered) == 1:
+        return (ordered[0] + 180) % 360
+
+    widest_start, widest_size = ordered[-1], (ordered[0] + 360) - ordered[-1]
+    for first, second in zip(ordered, ordered[1:]):
+        if second - first > widest_size:
+            widest_start, widest_size = first, second - first
+    return (widest_start + widest_size / 2) % 360
+
+
+def pick_venue_color(existing_colors: Iterable[str], *, name: str = "") -> str:
+    """Choose a colour for a new venue, given the colours already in use.
+
+    `name` is only a fallback seed. When every existing colour is unusable — all greys, or
+    a database whose colours were all left at the default — there is no gap structure to
+    reason about, so the hue comes from a hash of the name instead. That is stable (the
+    same venue always gets the same colour, so re-creating one does not reshuffle the
+    calendar) and spread (different names land in different places), which is the best
+    available when there is nothing to space away from.
+    """
+    hues = [h for h in (hue_of(c) for c in existing_colors) if h is not None]
+    if hues:
+        return hex_from_hue(largest_hue_gap_midpoint(hues))
+    digest = hashlib.sha256((name or "venue").encode("utf-8")).digest()
+    return hex_from_hue((digest[0] / 255) * 360)

--- a/backend/tests/test_manual_events.py
+++ b/backend/tests/test_manual_events.py
@@ -1,0 +1,242 @@
+"""Tests for hand-added events and the venues they hang off.
+
+An admin creating rows by hand is the one write path where a mistake reaches the public
+calendar with no scraper in between to correct it on the next run. Most of the protection
+comes from reuse rather than from new validation — a manual event is built as a
+ScrapedEvent, so it inherits the title cleaning, URL validation and dedup hash that
+scraped events already get — and the assertions below are mostly about that reuse staying
+intact.
+
+The load-bearing one is TestManualVenuesAreNeverScraped. A manual venue has no scraper by
+design, so if scrape_all ever stops excluding it, every promoter an admin has created
+writes a failed ScrapeLog on every cycle — four times a day, forever — and the scrape looks
+broken in the logs while working perfectly.
+"""
+
+import inspect
+from datetime import date, time
+
+import pytest
+
+from app.models import MANUAL_SCRAPER_TYPE, Venue
+from app.scrapers.base import ScrapedEvent
+from app.scrapers.manager import ScrapeManager, event_from_scraped
+
+
+# --- The guardrail that matters most ---
+
+
+class _CapturingSession:
+    """Records the statements handed to execute(), and returns nothing.
+
+    Enough to watch which venues scrape_all asks for, without a database.
+    """
+
+    def __init__(self):
+        self.statements = []
+
+    async def execute(self, statement, *args, **kwargs):
+        self.statements.append(statement)
+
+        class _Result:
+            def scalars(self_inner):
+                return self_inner
+
+            def all(self_inner):
+                return []
+
+            def unique(self_inner):
+                return self_inner
+
+        return _Result()
+
+    async def commit(self):
+        return None
+
+    async def flush(self):
+        return None
+
+
+class TestManualVenuesAreNeverScraped:
+    @staticmethod
+    def _venue_query_sql(scraper_types=None) -> str:
+        import asyncio
+
+        session = _CapturingSession()
+        manager = ScrapeManager(session)
+        # reclassify_all runs at the end of scrape_all and would need more of a session
+        # than the stub provides; the venue query is the subject here.
+        async def _noop():
+            return None
+
+        manager.reclassify_all = _noop
+        asyncio.run(manager.scrape_all(scraper_types=scraper_types))
+        assert session.statements, "scrape_all issued no query"
+        return str(session.statements[0])
+
+    def test_the_venue_query_filters_out_manual_venues(self):
+        assert "scraper_type" in self._venue_query_sql()
+
+    def test_still_filtered_when_scraper_types_is_given(self):
+        """A regression shape worth naming: an if/else that replaces the base query rather
+        than narrowing it would drop the exclusion whenever a type filter was supplied."""
+        sql = self._venue_query_sql(scraper_types=["ticketmaster"])
+        assert sql.count("scraper_type") >= 2, (
+            "the manual exclusion was replaced by the scraper_types filter, not added to it"
+        )
+
+    def test_asking_for_manual_explicitly_is_still_refused(self):
+        """There is nothing to scrape, so naming it is a mistake rather than an override."""
+        sql = self._venue_query_sql(scraper_types=[MANUAL_SCRAPER_TYPE])
+        assert "!=" in sql or "IS NOT" in sql.upper(), (
+            "the exclusion should survive even an explicit request"
+        )
+
+    def test_get_scraper_returns_none_for_a_manual_venue(self):
+        """Belt and braces: scrape_all filters these out, but a manual venue arriving by
+        another path should be a clear no-op rather than look like a broken scraper_type."""
+        manager = ScrapeManager(_CapturingSession())
+        venue = Venue(
+            name="Sharp 9 Gallery", slug="sharp-9", city="Durham",
+            size_category="small", scraper_type=MANUAL_SCRAPER_TYPE, color="#7fb069",
+        )
+        assert manager._get_scraper(venue) is None
+
+    def test_a_real_scraper_type_is_unaffected(self):
+        """Sanity: the manual short-circuit must not swallow every venue."""
+        manager = ScrapeManager(_CapturingSession())
+        venue = Venue(
+            name="DPAC", slug="dpac", city="Durham", size_category="large",
+            scraper_type="ticketmaster", ticketmaster_venue_id="KovZpZA",
+            color="#e88873",
+        )
+        assert manager._get_scraper(venue) is not None
+
+
+# --- Reuse of the scraper's own construction ---
+
+
+class TestEventFromScraped:
+    def _scraped(self, **kw) -> ScrapedEvent:
+        base = dict(name="Sub Rosa", date=date(2026, 9, 30), venue_slug="motorco",
+                    source="manual")
+        base.update(kw)
+        return ScrapedEvent(**base)
+
+    def test_copies_every_scraped_field(self):
+        """The point of extracting this helper was that the admin path and the scrape path
+        cannot drift. If ScrapedEvent gains a field that Event also has, this catches the
+        mapping not being updated."""
+        se = self._scraped(
+            artist="Sub Rosa", support_artists="Openers", doors_time=time(19, 0),
+            show_time=time(20, 0), ticket_url="https://example.test/t",
+            price_min=10.0, price_max=15.0, genre="rock", subgenre="indie",
+            age_restriction="18+", description="A show.", external_id="abc",
+            source_url="https://example.test/e",
+        )
+        event = event_from_scraped(se, venue_id=7)
+
+        assert event.venue_id == 7
+        for field in (
+            "name", "artist", "support_artists", "date", "doors_time", "show_time",
+            "ticket_url", "price_min", "price_max", "genre", "subgenre", "status",
+            "age_restriction", "description", "source", "source_url", "external_id",
+            "hash",
+        ):
+            assert getattr(event, field) == getattr(se, field), f"{field} was not copied"
+
+    def test_does_not_set_is_manually_created(self):
+        """Nothing in the scraper path may write that flag — it is what stops reconcile
+        deleting a hand-added row, and a scraper writing it would make it meaningless.
+        The admin endpoint sets it explicitly instead."""
+        event = event_from_scraped(self._scraped(), venue_id=1)
+        assert not getattr(event, "is_manually_created", False)
+
+    def test_the_hash_matches_what_a_scraper_would_compute(self):
+        """Deliberate, and the reason a manual event goes through ScrapedEvent at all: a
+        venue that later lists a show an admin already added matches the admin's row by
+        hash and enriches it, instead of inserting a second listing."""
+        manual = self._scraped(source="manual")
+        scraped = self._scraped(source="motorco")
+        assert manual.hash == scraped.hash
+
+    def test_a_hostile_ticket_url_is_dropped_by_the_dataclass(self):
+        """Not new validation — ScrapedEvent.__post_init__ already does this for scraped
+        data, and routing manual input through it is what makes the admin form inherit it.
+        """
+        event = event_from_scraped(
+            self._scraped(ticket_url="javascript:alert(1)"), venue_id=1
+        )
+        assert event.ticket_url is None
+
+
+# --- The endpoint's own rules ---
+
+
+class TestManualEventEndpointRules:
+    @pytest.fixture(scope="class")
+    def source(self) -> str:
+        from app.api import admin
+
+        return inspect.getsource(admin.create_manual_event)
+
+    def test_both_manual_flags_are_set(self, source):
+        """They mean different things and both are needed. is_manually_created stops
+        reconcile deleting the row; is_manual_override stops reclassify_all overwriting the
+        live-music verdict — without which an event added as "Comedy Showcase" would be
+        auto-flagged non-live and vanish from the calendar it was added to."""
+        assert "is_manually_created = True" in source
+        assert "is_manual_override = True" in source
+
+    def test_it_is_approved_on_creation(self, source):
+        """Adding it by hand *is* the review, so it should not land in the queue asking the
+        admin to confirm a decision they just made."""
+        assert "approved_at" in source
+
+    def test_a_clashing_hash_is_a_409_not_a_500(self, source):
+        """Event.hash is unique. Letting the IntegrityError escape would turn "you already
+        added this" into an opaque server error."""
+        assert "status_code=409" in source
+        assert "already on the calendar" in source
+
+    def test_the_date_is_bounded(self, source):
+        assert "MANUAL_EVENT_MIN_DATE" in source
+        assert "MANUAL_EVENT_MAX_YEARS_AHEAD" in source
+
+    def test_the_bounds_are_sane(self):
+        from app.api.admin import MANUAL_EVENT_MAX_YEARS_AHEAD, MANUAL_EVENT_MIN_DATE
+
+        assert MANUAL_EVENT_MIN_DATE < date.today(), "the archive must be reachable"
+        assert 1 <= MANUAL_EVENT_MAX_YEARS_AHEAD <= 5, (
+            "wide enough for a real announcement, narrow enough that a mistyped year is "
+            "rejected rather than creating a row no view shows"
+        )
+
+    def test_prices_are_checked_against_each_other(self, source):
+        assert "price_max < body.price_min" in source
+
+
+class TestEmptyManualVenuesAreHidden:
+    @pytest.fixture(scope="class")
+    def source(self) -> str:
+        from app.api import venues
+
+        return inspect.getsource(venues.list_venues)
+
+    def test_manual_venues_with_no_upcoming_events_are_skipped(self, source):
+        assert "MANUAL_SCRAPER_TYPE" in source
+        assert "count == 0" in source
+
+    def test_scraped_venues_are_never_skipped(self, source):
+        """A scraped venue with an empty calendar is still a real place having a quiet
+        month, and it fills up again on the next scrape. Only the hand-added kind is a
+        filter that would select nothing forever."""
+        assert "venue.scraper_type == MANUAL_SCRAPER_TYPE" in source, (
+            "the skip must be conditional on the venue being hand-added"
+        )
+
+    def test_the_count_matches_the_public_calendar(self, source):
+        """Counting rows the calendar would not show — past events, or duplicates an admin
+        hid — would make the sidebar promise events that are not there."""
+        assert "duplicate_of_id" in source
+        assert "date.today()" in source

--- a/backend/tests/test_manual_events.py
+++ b/backend/tests/test_manual_events.py
@@ -436,58 +436,86 @@ class TestDeleteRules:
         assert "/admin/api/venues/{venue_id}" in paths
 
 
-class TestThePastEventCleanupRespectsHumanDecisions:
-    """The third deletion path, and the one that bypassed both guarantees.
+class TestNothingScheduledDeletesEvents:
+    """Past events are kept, and no scheduled job may delete any.
 
-    cleanup_past_events_job issues a bulk DELETE rather than loading rows, so it never
-    reaches ScrapeManager.scraper_must_not_delete — the predicate that stops reconcile
-    removing hand-added events and admin-flagged duplicates. Unfixed, it silently undid both
-    a week after the fact: a hand-added event nothing else would touch simply vanished, and
-    a flagged duplicate vanished along with the mapping that made the decision reversible.
+    There used to be a nightly job removing every event more than 7 days old. It never ran
+    anywhere — ENABLE_SCHEDULER is false in cloudbuild.yaml, backend/.env.example,
+    docs/SELF-HOSTING.md and config.py's default — which is the only reason production still
+    holds events back to January. Removed rather than commented out, because commented-out
+    code gets re-enabled by someone reading the comment as a to-do.
 
-    Dormant in production only because ENABLE_SCHEDULER is false there; it runs on any local
-    or self-hosted instance with the scheduler on.
+    Three parts of the app already assume past events persist: plan_upsert bounds reconcile
+    to `today <= date <= horizon` so a scrape cannot touch the archive; the admin queue and
+    reclassify_all() work from reclassify_floor(), which is 30 days back; and the public
+    calendar scrolls backwards with no floor on /api/events. A 7-day cleanup contradicted
+    all three, and additionally bypassed scraper_must_not_delete by issuing a bulk DELETE —
+    so it would have silently undone the hand-added and flagged-duplicate protections a week
+    after the fact.
+
+    These assertions are about the *module*, not one function, because the point is that no
+    scheduled job deletes events — not that one particular job was fixed.
     """
 
     @pytest.fixture(scope="class")
-    def rendered(self) -> str:
-        """The DELETE the job issues, with bind values inlined."""
-        import asyncio
-        from datetime import datetime, timedelta
-
-        from sqlalchemy import delete
-
-        from app.models import Event
-
-        cutoff = datetime.utcnow().date() - timedelta(days=7)
-        statement = delete(Event).where(
-            Event.date < cutoff,
-            Event.is_manually_created.is_(False),
-            Event.duplicate_of_id.is_(None),
-        )
-        return str(statement.compile(compile_kwargs={"literal_binds": True}))
-
-    @pytest.fixture(scope="class")
-    def source(self) -> str:
+    def scheduler_module(self):
         from app import scheduler
 
-        return inspect.getsource(scheduler.cleanup_past_events_job)
+        return scheduler
 
-    def test_hand_added_events_are_excluded(self, source):
-        assert "is_manually_created.is_(False)" in source
+    @pytest.fixture(scope="class")
+    def source(self, scheduler_module) -> str:
+        return inspect.getsource(scheduler_module)
 
-    def test_flagged_duplicates_are_excluded(self, source):
-        assert "duplicate_of_id.is_(None)" in source
+    def test_the_cleanup_job_is_gone(self, scheduler_module):
+        assert not hasattr(scheduler_module, "cleanup_past_events_job"), (
+            "the past-event cleanup job is back; past events are kept deliberately"
+        )
 
-    def test_it_still_deletes_ordinary_past_events(self, source):
-        """The exclusions must narrow the job, not disable it — the archive still gets
-        trimmed, just not of rows a person put there."""
-        assert "Event.date < cutoff" in source
+    def test_no_scheduled_job_issues_a_delete(self, source):
+        """Checks the code, not just that one name is absent. Any new job that deletes rows
+        has to trip this and be justified."""
+        import ast
+        import textwrap
 
-    def test_the_conditions_compile_to_real_sql(self, rendered):
-        """Guards the shape rather than the spelling: `.is_(False)` on a Boolean and
-        `.is_(None)` on a nullable column are easy to write as `== False` / `== None`, which
-        SQLAlchemy warns about and which behaves differently against NULL."""
-        sql = rendered.lower()
-        assert "is_manually_created is false" in sql
-        assert "duplicate_of_id is null" in sql
+        tree = ast.parse(textwrap.dedent(source))
+        deletes = [
+            node for node in ast.walk(tree)
+            if isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Name)
+            and node.func.id == "delete"
+        ]
+        assert not deletes, "a scheduled job now issues a delete()"
+        assert "session.delete" not in source, "a scheduled job now deletes via the ORM"
+
+    def test_the_module_cannot_delete_without_a_new_import(self, scheduler_module):
+        """The structural version of the same rule: with no `delete` and no Event model in
+        scope, adding a deletion here requires adding an import, which is visible in review.
+        """
+        assert not hasattr(scheduler_module, "delete")
+        assert not hasattr(scheduler_module, "Event")
+
+    def test_the_scrape_jobs_still_exist(self, scheduler_module):
+        """Removing the cleanup must not have removed the jobs the scheduler is for."""
+        assert hasattr(scheduler_module, "scrape_ticketmaster_job")
+        assert hasattr(scheduler_module, "scrape_indie_job")
+
+    def test_configure_scheduler_registers_only_the_two_scrapes(self, scheduler_module):
+        """Registered by id, so a third job appearing is a deliberate decision rather than
+        something that slips in."""
+        registered = set()
+
+        class _Recorder:
+            def add_job(self, func, trigger, id=None, **kwargs):
+                registered.add(id)
+
+        original = scheduler_module.scheduler
+        scheduler_module.scheduler = _Recorder()
+        try:
+            scheduler_module.configure_scheduler()
+        finally:
+            scheduler_module.scheduler = original
+
+        assert registered == {"scrape_ticketmaster", "scrape_indie"}, (
+            f"unexpected scheduled jobs: {sorted(registered)}"
+        )

--- a/backend/tests/test_manual_events.py
+++ b/backend/tests/test_manual_events.py
@@ -57,38 +57,55 @@ class _CapturingSession:
         return None
 
 
+def _rendered_venue_query(method: str, **kwargs) -> str:
+    """The SQL a bulk-scrape entry point issues, with bind values inlined.
+
+    literal_binds matters. Plain str() on a SQLAlchemy statement renders values as bind
+    parameters *named after their column* — `venues.scraper_type != :scraper_type_1` — so an
+    assertion looking for "scraper_type" passes on a query that filters the column to
+    anything at all. The first version of these tests did exactly that and stayed green
+    against a query with the manual exclusion removed. Inlining the values is what makes
+    them test the rule rather than the column name.
+    """
+    import asyncio
+
+    session = _CapturingSession()
+    manager = ScrapeManager(session)
+
+    # reclassify_all runs at the end and needs more of a session than the stub provides;
+    # the venue query is the subject here.
+    async def _noop():
+        return None
+
+    manager.reclassify_all = _noop
+    asyncio.run(getattr(manager, method)(**kwargs))
+    assert session.statements, f"{method} issued no query"
+    return str(
+        session.statements[0].compile(compile_kwargs={"literal_binds": True})
+    )
+
+
 class TestManualVenuesAreNeverScraped:
     @staticmethod
     def _venue_query_sql(scraper_types=None) -> str:
-        import asyncio
-
-        session = _CapturingSession()
-        manager = ScrapeManager(session)
-        # reclassify_all runs at the end of scrape_all and would need more of a session
-        # than the stub provides; the venue query is the subject here.
-        async def _noop():
-            return None
-
-        manager.reclassify_all = _noop
-        asyncio.run(manager.scrape_all(scraper_types=scraper_types))
-        assert session.statements, "scrape_all issued no query"
-        return str(session.statements[0])
+        return _rendered_venue_query("scrape_all", scraper_types=scraper_types)
 
     def test_the_venue_query_filters_out_manual_venues(self):
-        assert "scraper_type" in self._venue_query_sql()
+        assert f"!= '{MANUAL_SCRAPER_TYPE}'" in self._venue_query_sql()
 
     def test_still_filtered_when_scraper_types_is_given(self):
         """A regression shape worth naming: an if/else that replaces the base query rather
         than narrowing it would drop the exclusion whenever a type filter was supplied."""
         sql = self._venue_query_sql(scraper_types=["ticketmaster"])
-        assert sql.count("scraper_type") >= 2, (
+        assert f"!= '{MANUAL_SCRAPER_TYPE}'" in sql, (
             "the manual exclusion was replaced by the scraper_types filter, not added to it"
         )
+        assert "'ticketmaster'" in sql, "the caller's own filter was lost"
 
     def test_asking_for_manual_explicitly_is_still_refused(self):
         """There is nothing to scrape, so naming it is a mistake rather than an override."""
         sql = self._venue_query_sql(scraper_types=[MANUAL_SCRAPER_TYPE])
-        assert "!=" in sql or "IS NOT" in sql.upper(), (
+        assert f"!= '{MANUAL_SCRAPER_TYPE}'" in sql, (
             "the exclusion should survive even an explicit request"
         )
 
@@ -292,3 +309,185 @@ class TestHiddenClassActuallyHides:
             "these ids set `display` in an id rule and are toggled with .hidden, so the "
             f"class cannot hide them: {broken}. Add `#<id>.hidden {{ display:none; }}`."
         )
+
+
+class TestScrapeIndieAlsoSkipsManualVenues:
+    """scrape_indie is a second entry point, and it used to build its own venue query.
+
+    That query filtered only on `scraper_type != "ticketmaster"`, so it did *not* pick up
+    the manual-venue exclusion — every promoter an admin created would be scraped there,
+    fail for want of a scraper, and write a failed ScrapeLog. It is a scheduled job, so
+    that is three times a day, and it was only dormant in production because
+    ENABLE_SCHEDULER is false. It now delegates to scrape_all.
+    """
+
+    @staticmethod
+    def _sql(method: str) -> str:
+        return _rendered_venue_query(method)
+
+    def test_scrape_indie_excludes_manual_venues(self):
+        assert f"!= '{MANUAL_SCRAPER_TYPE}'" in self._sql("scrape_indie"), (
+            "scrape_indie does not exclude manual venues — it has probably gone back to "
+            "building its own query"
+        )
+
+    def test_scrape_indie_still_excludes_ticketmaster(self):
+        """The exclusion it existed for in the first place must survive the refactor."""
+        assert "'ticketmaster'" in self._sql("scrape_indie")
+
+    def test_scrape_ticketmaster_excludes_manual_venues(self):
+        assert f"!= '{MANUAL_SCRAPER_TYPE}'" in self._sql("scrape_ticketmaster")
+
+    def test_there_is_only_one_venue_query_in_the_class(self):
+        """The structural fix. Two entry points building their own `select(Venue)` is how
+        the exclusion went missing from one of them; any future venue rule should apply
+        everywhere by construction rather than by being remembered twice.
+
+        Parsed rather than grepped. A substring count also matches the docstring in
+        scrape_indie, which quotes the query it used to build — so the first version of this
+        test failed on its own explanatory prose. Counting AST call nodes measures the code.
+        """
+        import ast
+        import inspect
+        import textwrap
+
+        from app.scrapers import manager as manager_module
+
+        tree = ast.parse(textwrap.dedent(inspect.getsource(manager_module.ScrapeManager)))
+        calls = [
+            node for node in ast.walk(tree)
+            if isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Name)
+            and node.func.id == "select"
+            and any(isinstance(a, ast.Name) and a.id == "Venue" for a in node.args)
+        ]
+        assert len(calls) == 1, (
+            f"{len(calls)} venue-selection queries in ScrapeManager (expected 1) — the "
+            "manual exclusion now has to be repeated in each, which is the bug this "
+            "consolidation fixed"
+        )
+
+
+class TestDeleteRules:
+    """Deleting is the only admin control that destroys rather than hides, and hand-added
+    rows are the only ones with no other way out — reconcile deliberately will not touch
+    them, and at a hand-added venue they are never even considered, because scrape_all
+    skips that venue. Everything protecting them from the scraper is what makes delete
+    necessary.
+    """
+
+    @pytest.fixture(scope="class")
+    def event_source(self) -> str:
+        from app.api import admin
+
+        return inspect.getsource(admin.delete_manual_event)
+
+    @pytest.fixture(scope="class")
+    def venue_source(self) -> str:
+        from app.api import admin
+
+        return inspect.getsource(admin.delete_manual_venue)
+
+    def test_only_hand_added_events_can_be_deleted(self, event_source):
+        """A scraped event returns on the next scrape, so a general delete would look
+        broken while being the one control able to destroy an archive row."""
+        assert "if not event.is_manually_created" in event_source
+        assert "status_code=400" in event_source
+
+    def test_the_refusal_says_what_to_do_instead(self, event_source):
+        assert "mark it non-live" in event_source or "non-live" in event_source
+
+    def test_deleting_a_survivor_reports_the_rows_it_un_hides(self, event_source):
+        """duplicate_of_id is ON DELETE SET NULL, so deleting a survivor puts everything
+        folded into it back on the public calendar. A delete that silently *adds* listings
+        is surprising enough to report."""
+        assert "restored_duplicates" in event_source
+        assert "duplicate_of_id == event_id" in event_source
+
+    def test_only_hand_added_venues_can_be_deleted(self, venue_source):
+        """seed_venues() would recreate a seeded venue on the next boot with a new id,
+        while its events stayed cascade-deleted — the venue appears to come back and the
+        data is gone, which looks like the delete failed."""
+        assert "venue.scraper_type != MANUAL_SCRAPER_TYPE" in venue_source
+
+    def test_a_venue_with_events_is_refused_with_a_count(self, venue_source):
+        """Venue.events cascades with delete-orphan, so one click on a venue holding a run
+        of shows would take all of them with nothing naming what was lost."""
+        assert "status_code=409" in venue_source
+        assert "event_count" in venue_source
+
+    def test_the_venue_count_covers_past_events_too(self, venue_source):
+        """A past event is still a row, and cascading it away silently is the thing being
+        prevented — so this count must not reuse the upcoming-only helper."""
+        assert "Event.venue_id == venue_id" in venue_source
+        assert "date.today()" not in venue_source, (
+            "the guard counts only upcoming events, so a venue whose shows have all passed "
+            "would be deletable and would cascade them away"
+        )
+
+    def test_both_deletes_are_registered_as_DELETE(self):
+        from app.main import app
+
+        paths = {
+            r.path for r in app.routes
+            if getattr(r, "path", "").startswith("/admin/api") and "DELETE" in r.methods
+        }
+        assert "/admin/api/events/{event_id}" in paths
+        assert "/admin/api/venues/{venue_id}" in paths
+
+
+class TestThePastEventCleanupRespectsHumanDecisions:
+    """The third deletion path, and the one that bypassed both guarantees.
+
+    cleanup_past_events_job issues a bulk DELETE rather than loading rows, so it never
+    reaches ScrapeManager.scraper_must_not_delete — the predicate that stops reconcile
+    removing hand-added events and admin-flagged duplicates. Unfixed, it silently undid both
+    a week after the fact: a hand-added event nothing else would touch simply vanished, and
+    a flagged duplicate vanished along with the mapping that made the decision reversible.
+
+    Dormant in production only because ENABLE_SCHEDULER is false there; it runs on any local
+    or self-hosted instance with the scheduler on.
+    """
+
+    @pytest.fixture(scope="class")
+    def rendered(self) -> str:
+        """The DELETE the job issues, with bind values inlined."""
+        import asyncio
+        from datetime import datetime, timedelta
+
+        from sqlalchemy import delete
+
+        from app.models import Event
+
+        cutoff = datetime.utcnow().date() - timedelta(days=7)
+        statement = delete(Event).where(
+            Event.date < cutoff,
+            Event.is_manually_created.is_(False),
+            Event.duplicate_of_id.is_(None),
+        )
+        return str(statement.compile(compile_kwargs={"literal_binds": True}))
+
+    @pytest.fixture(scope="class")
+    def source(self) -> str:
+        from app import scheduler
+
+        return inspect.getsource(scheduler.cleanup_past_events_job)
+
+    def test_hand_added_events_are_excluded(self, source):
+        assert "is_manually_created.is_(False)" in source
+
+    def test_flagged_duplicates_are_excluded(self, source):
+        assert "duplicate_of_id.is_(None)" in source
+
+    def test_it_still_deletes_ordinary_past_events(self, source):
+        """The exclusions must narrow the job, not disable it — the archive still gets
+        trimmed, just not of rows a person put there."""
+        assert "Event.date < cutoff" in source
+
+    def test_the_conditions_compile_to_real_sql(self, rendered):
+        """Guards the shape rather than the spelling: `.is_(False)` on a Boolean and
+        `.is_(None)` on a nullable column are easy to write as `== False` / `== None`, which
+        SQLAlchemy warns about and which behaves differently against NULL."""
+        sql = rendered.lower()
+        assert "is_manually_created is false" in sql
+        assert "duplicate_of_id is null" in sql

--- a/backend/tests/test_manual_events.py
+++ b/backend/tests/test_manual_events.py
@@ -240,3 +240,55 @@ class TestEmptyManualVenuesAreHidden:
         hid — would make the sidebar promise events that are not there."""
         assert "duplicate_of_id" in source
         assert "date.today()" in source
+
+
+class TestHiddenClassActuallyHides:
+    """`.hidden { display:none }` is a single class, so any id rule that also sets
+    `display` outranks it and the element never hides.
+
+    This shipped broken once: `#newVenue { display:grid }` (specificity 1-0-0) beat
+    `.hidden` (0-1-0), so the new-promoter fields were permanently visible however the
+    class was toggled. Nothing failed and no error appeared — the panel was simply always
+    open, which reads as a layout choice rather than a bug.
+
+    Structural rather than behavioural because the admin page is a string of CSS and JS
+    with no stylesheet for a test to query, and this failure mode is invisible in the DOM:
+    the class *is* applied, it just does not win.
+    """
+
+    @pytest.fixture(scope="class")
+    def parts(self):
+        import re
+
+        from app.admin_ui import ADMIN_HTML
+
+        css = re.search(r"<style>(.*?)</style>", ADMIN_HTML, re.S).group(1)
+        js = re.search(r"<script>(.*?)</script>", ADMIN_HTML, re.S).group(1)
+        return ADMIN_HTML, css, js
+
+    def test_every_toggled_id_can_actually_be_hidden(self, parts):
+        import re
+
+        html, css, js = parts
+        toggled = set(re.findall(r"\$\('#(\w+)'\)\.classList\.toggle\('hidden'", js))
+        toggled |= set(re.findall(r'id="(\w+)"[^>]*class="[^"]*hidden', html))
+        assert toggled, "found nothing toggled with .hidden — has the mechanism changed?"
+
+        broken = []
+        for element_id in sorted(toggled):
+            # The element's *own* rule: '#id' followed only by whitespace then '{'. A
+            # descendant rule like '#add .actions { display:flex }' styles the child and is
+            # irrelevant here, which is why this is not a substring search.
+            own = re.findall(r"#" + element_id + r"\s*\{([^}]*)\}", css)
+            if not any(re.search(r"\bdisplay\s*:", rule) for rule in own):
+                continue  # display unset, so .hidden wins on its own
+            if re.search(
+                r"#" + element_id + r"\.hidden\s*\{[^}]*display\s*:\s*none", css
+            ):
+                continue  # specificity matched deliberately
+            broken.append(element_id)
+
+        assert not broken, (
+            "these ids set `display` in an id rule and are toggled with .hidden, so the "
+            f"class cannot hide them: {broken}. Add `#<id>.hidden {{ display:none; }}`."
+        )

--- a/backend/tests/test_venue_colors.py
+++ b/backend/tests/test_venue_colors.py
@@ -1,0 +1,156 @@
+"""Tests for the colour assigned to a venue an admin creates by hand.
+
+Seeded venues have hand-picked colours spread around the hue wheel so that adjacent venues
+on a calendar are distinguishable. A venue created at runtime has no such curation, and the
+column default is a single indigo — so without this, every promoter an admin ever added
+would share one colour, and would collide with whichever seeded venue is nearest that hue.
+
+The property under test is *distinctness*, not prettiness: frontend/js/design.js separately
+clamps whatever arrives for contrast, so this only has to place the new hue far from the
+ones already in use.
+"""
+
+from datetime import date
+
+import pytest
+
+from app.venue_colors import (
+    hex_from_hue,
+    hue_of,
+    is_valid_hex,
+    largest_hue_gap_midpoint,
+    pick_venue_color,
+)
+
+
+def _angular_distance(a: float, b: float) -> float:
+    """Degrees between two hues, the short way round the wheel."""
+    return abs(((a - b + 180) % 360) - 180)
+
+
+class TestHexValidation:
+    @pytest.mark.parametrize("value", ["#7fb069", "#FFF", "#abc", "#000000", "  #7FB069  "])
+    def test_accepts_valid(self, value):
+        assert is_valid_hex(value)
+
+    @pytest.mark.parametrize("value", [
+        "", None, "7fb069", "#12345", "#1234567", "red", "#gggggg",
+        "#7fb069; background:url(x)",
+    ])
+    def test_rejects_invalid(self, value):
+        """Venue.color is String(7). A longer value is truncated by some drivers and
+        rejected by others, so an admin's typo has to be a clear error rather than a
+        corrupted column — and the last case is why this is a whitelist, not a length check.
+        """
+        assert not is_valid_hex(value)
+
+
+class TestHueOf:
+    def test_reads_a_hue(self):
+        assert hue_of("#ff0000") == pytest.approx(0)
+        assert hue_of("#00ff00") == pytest.approx(120)
+        assert hue_of("#0000ff") == pytest.approx(240)
+
+    def test_expands_shorthand(self):
+        assert hue_of("#f00") == pytest.approx(hue_of("#ff0000"))
+
+    @pytest.mark.parametrize("grey", ["#000000", "#ffffff", "#888888", "#333"])
+    def test_greys_have_no_hue(self, grey):
+        """colorsys reports 0 for every grey, which is red. Returning None instead keeps a
+        grey venue out of the gap calculation rather than letting it pretend to occupy the
+        red part of the wheel and pushing new colours away from a hue nothing uses."""
+        assert hue_of(grey) is None
+
+    def test_invalid_input_has_no_hue(self):
+        assert hue_of("nonsense") is None
+
+
+class TestLargestHueGapMidpoint:
+    def test_picks_the_middle_of_the_widest_gap(self):
+        # Hues at 0 and 90 leave a 270-degree gap; its midpoint is 225.
+        assert largest_hue_gap_midpoint([0, 90]) == pytest.approx(225)
+
+    def test_finds_a_gap_that_straddles_zero(self):
+        """The wrap-around case. Walking sorted hues without closing the circle makes the
+        widest gap invisible whenever it crosses 0 degrees — which is common, because reds
+        are well represented in the seeded palette."""
+        # 350 and 10 are 20 degrees apart across zero; everything else is packed at 90-180.
+        result = largest_hue_gap_midpoint([90, 120, 150, 180, 350, 10])
+        # The widest gap is 180 -> 350, midpoint 265.
+        assert result == pytest.approx(265)
+
+    def test_one_hue_gets_its_opposite(self):
+        assert largest_hue_gap_midpoint([0]) == pytest.approx(180)
+
+    def test_no_hues_is_a_deliberate_blue_not_red(self):
+        """An arbitrary starting point still has to look deliberate on a calendar, and red
+        reads as an alert."""
+        assert largest_hue_gap_midpoint([]) == pytest.approx(210)
+
+    def test_result_is_always_a_valid_hue(self):
+        for hues in ([0, 1], [359, 0, 1], [0, 180], [200] * 5):
+            assert 0 <= largest_hue_gap_midpoint(hues) < 360
+
+
+class TestPickVenueColor:
+    def test_returns_a_storable_hex(self):
+        colour = pick_venue_color(["#ff0000"], name="X")
+        assert is_valid_hex(colour)
+        assert len(colour) == 7, "Venue.color is String(7)"
+
+    def test_lands_far_from_the_existing_colours(self):
+        existing = ["#ff0000", "#00ff00"]  # hues 0 and 120
+        hue = hue_of(pick_venue_color(existing, name="X"))
+        assert min(_angular_distance(hue, h) for h in (0, 120)) > 90
+
+    def test_against_the_real_seeded_palette(self):
+        """The case that actually matters. The shipped palette leaves its widest hole
+        between yellow and green, and a new promoter should land in it."""
+        from app.seed import VENUES
+
+        existing = [v["color"] for v in VENUES if v.get("color")]
+        hues = [h for h in (hue_of(c) for c in existing) if h is not None]
+        assert len(hues) > 15, "sanity: the seeded palette should be populated"
+
+        hue = hue_of(pick_venue_color(existing, name="Sharp 9 Gallery"))
+        nearest = min(_angular_distance(hue, h) for h in hues)
+        assert nearest > 30, (
+            f"new colour at {hue:.0f} deg is only {nearest:.0f} deg from a venue already "
+            "on the calendar"
+        )
+
+    def test_successive_additions_keep_spreading_out(self):
+        """Each new venue sees the previous ones, so the gaps shrink — but every choice must
+        still be the best available at the time, never a repeat."""
+        palette = ["#ff0000", "#00ff00", "#0000ff"]
+        picked = []
+        for i in range(4):
+            colour = pick_venue_color(palette, name=f"P{i}")
+            assert colour not in palette, "handed out a colour already in use"
+            picked.append(colour)
+            palette.append(colour)
+        assert len(set(picked)) == len(picked), "two venues got the same colour"
+
+    def test_falls_back_to_the_name_when_no_hue_exists(self):
+        """All-grey or all-default palettes have no gap structure to reason about."""
+        colour = pick_venue_color(["#888888", "#cccccc"], name="Sharp 9 Gallery")
+        assert is_valid_hex(colour)
+        assert hue_of(colour) is not None, "the fallback must still produce a real colour"
+
+    def test_the_fallback_is_stable_for_a_name(self):
+        """Re-creating a venue should not reshuffle the calendar's colours."""
+        a = pick_venue_color([], name="Sharp 9 Gallery")
+        b = pick_venue_color([], name="Sharp 9 Gallery")
+        assert a == b
+
+    def test_the_fallback_separates_different_names(self):
+        assert pick_venue_color([], name="Sharp 9 Gallery") != pick_venue_color([], name="The Fruit")
+
+    def test_an_empty_palette_and_no_name_still_works(self):
+        assert is_valid_hex(pick_venue_color([]))
+
+
+class TestRoundTrip:
+    @pytest.mark.parametrize("hue", [0, 45, 90, 180, 270, 359])
+    def test_hex_from_hue_preserves_the_hue(self, hue):
+        assert _angular_distance(hue_of(hex_from_hue(hue)), hue) < 2


### PR DESCRIPTION
Completes the hand-added-events feature whose column landed in #87 and whose reconcile
protection is already live. Refs #87.

## Most of the safety comes from reuse, not new validation

A hand-added event is built as a **`ScrapedEvent`** before becoming an `Event` row. That
dataclass already cleans titles and validates ticket and image URLs — because scraped data
needed it — so routing admin input through the same constructor means the form inherits all
of it, rather than a second implementation having to remember to. A `javascript:` ticket URL
is dropped by the same code that drops one from a venue page.

It also means **the hash matches what a scraper would compute** for the same show. That's
deliberate and load-bearing: a venue that later lists something an admin already added
matches the admin's row and enriches it instead of inserting a twin. It's exactly the
sequence #87's `test_survives_after_a_scrape_has_matched_it` covers.

The `ScrapedEvent → Event` mapping is extracted as `event_from_scraped()` so the two paths
can't drift; a test asserts every field is copied.

## The guardrail that matters most

**`scrape_all()` now excludes venues whose `scraper_type` is `MANUAL_SCRAPER_TYPE`.**

There is deliberately no scraper for a promoter. Without this, every one an admin creates
fails `_get_scraper`, raises "No scraper available", and writes a **failed ScrapeLog on
every cycle — four times a day, forever, per promoter.** The scrape would look broken in
the logs while working perfectly, and the noise grows with each venue added.

Excluded even when `scraper_types` names them explicitly: there's nothing to scrape, so an
explicit request is a mistake rather than an override.

Also checked, and safe: `seed_venues()` only deletes slugs in `REMOVED_SLUGS` and only
updates venues present in `VENUES`, so a hand-created venue survives every boot untouched.

## The other rules, and what each stops

| rule | without it |
|---|---|
| clashing hash → 409 naming the row | the unique constraint surfaces as a 500 |
| date bounded to 2015..(year + 2) | a mistyped year creates a row no view shows and nobody finds |
| both manual flags set | an event added as "Comedy Showcase" is auto-flagged non-live and vanishes from the calendar it was just added to |
| approved on creation | the admin is asked to confirm a decision they just made |
| price_max ≥ price_min, no negatives, no blank names, slug must have alphanumerics, no duplicate venue name | each becomes a stack trace instead of a sentence |

The two flags are both needed because they mean different things — #87 keeps them separate
deliberately. `is_manually_created` stops reconcile deleting the row; `is_manual_override`
stops `reclassify_all` overwriting the verdict.

## Colour assignment

`app/venue_colors.py` places a new venue in the **largest unused gap on the hue wheel**,
which maximises distance to its nearest neighbour — the property "tell these apart on a busy
month" actually needs. The wrap-around gap is included, without which the widest hole is
invisible whenever it straddles 0°, which is common because the seeded palette is red-heavy.

Measured against the real shipped palette (22 colours, hues 13°–350°):

```
promoter 1: hue 103  — 46 deg from anything existing
promoter 2: hue 310  — 25 deg
promoter 3: hue  80  — 23 deg
promoter 4: hue 126  — 22 deg
promoter 5: hue  42  — 15 deg
```

Not random (lands next to an existing colour about half the time, and fails *silently* —
two venues that look identical on a busy month). Not sequential (deleting a venue would
reshuffle later assignments). Falls back to a hash of the name when no existing colour has a
usable hue, which is stable — re-creating a venue doesn't reshuffle the calendar.

## Public venue list

`/api/venues` gains `upcoming_event_count`, and omits hand-added venues while that count is
zero. A scraped venue with an empty calendar is a real place having a quiet month; a promoter
whose events are past is a filter that selects nothing, and they'd otherwise accumulate in
the sidebar forever. **Scraped venues are never hidden.** The count mirrors the public read
filters — today onward, duplicates excluded — so it can't promise events the calendar won't
show.

## A bug found by opening the form

`#newVenue { display:grid }` is an id selector (1-0-0) and `.hidden { display:none }` is a
single class (0-1-0), so **toggling the class did nothing** and the new-promoter fields were
permanently visible. The DOM was no help: the class *is* applied, it just loses.

Fixed with a specificity-matching override, after auditing all eight `.hidden`-toggled ids —
`#newVenue` was the only one affected. Added a structural test over that audit, since the
failure is silent and this is the second specificity collision in this file; it fails with
the fix removed, naming the id and the rule to add.

## Tests

+58 (**557 passing**, 4 skipped). Mutation-tested: seven of eight mutations to the new
guardrails were caught by a distinct test. The eighth — removing `_get_scraper`'s explicit
manual branch — is **not behaviourally distinguishable**, because the `elif` chain returns
`None` anyway; that branch is for clarity, and I'd rather say so than imply coverage it
doesn't have.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
