### PR TITLE
Derive promotion release notes from the PRs, and post them on the promotion PR

### DIFF
--- a/.github/scripts/release_notes.py
+++ b/.github/scripts/release_notes.py
@@ -1,0 +1,183 @@
+"""Build release notes for a main -> prod promotion, one line per component PR.
+
+Role: run by .github/workflows/release-notes.yml when a promotion PR is opened against
+`prod`, and available on demand (workflow_dispatch, or locally) to preview what a
+promotion would carry. Writes markdown to stdout.
+
+Why this exists. A promotion here is a single PR carrying every commit merged to `main`
+since the last one — 29 commits across 10 PRs at the time of writing. `git log --oneline`
+over that range mixes merge commits with the individual commits inside each PR, so a
+hand-written summary of it describes what the author *remembers* doing. The first run of
+this script surfaced four merged security fixes from a fork that nobody had thought to
+mention, which is the whole argument for deriving the list instead.
+
+PRs are matched to the range by **merge commit SHA**, not by grepping `#\\d+` out of commit
+subjects. That is what makes it correct for squash-merged PRs, which leave no "Merge pull
+request #N" line to grep, and immune to a commit message that merely mentions an issue
+number.
+
+Everything comes from the GitHub API via `gh`, so there is no checkout, no fetch-depth
+trap, and it behaves the same locally as in Actions.
+
+Requires: the `gh` CLI, authenticated. In Actions that is GH_TOKEN=${{ github.token }}.
+"""
+
+# --- Imports ---
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+from typing import Any, Optional
+
+# The compare API returns at most 250 commits and `gh pr list` is capped below. A
+# promotion larger than this is not a release note problem, but say so rather than
+# silently truncating — a quiet cap here would reintroduce exactly the "the summary
+# omitted things" failure this script exists to prevent.
+COMPARE_COMMIT_CAP = 250
+PR_LOOKBACK = 100
+
+
+# --- GitHub API ---
+
+
+def gh_json(*args: str) -> Any:
+    """Run `gh` and parse its JSON output, failing loudly."""
+    result = subprocess.run(
+        ["gh", *args], capture_output=True, text=True, encoding="utf-8"
+    )
+    if result.returncode != 0:
+        sys.exit(f"gh {' '.join(args)} failed:\n{result.stderr.strip()}")
+    return json.loads(result.stdout or "null")
+
+
+def commits_in_range(repo: str, base: str, head: str) -> list[dict]:
+    """Commits on `head` that are not on `base`.
+
+    `base...head` (three dots) is deliberate: it compares against the merge base, so the
+    result is what a promotion PR would actually contain. Note this repo's promotions
+    always report status "diverged" with a non-zero `behind_by` — every past promotion left
+    its own merge commit on `prod` — so divergence here is normal and not worth warning
+    about.
+    """
+    data = gh_json("api", f"repos/{repo}/compare/{base}...{head}")
+    commits = data.get("commits", [])
+    if len(commits) >= COMPARE_COMMIT_CAP:
+        print(
+            f"> **Note:** the compare API returned {len(commits)} commits, at or near its "
+            f"{COMPARE_COMMIT_CAP} cap. This list may be incomplete.\n",
+            file=sys.stderr,
+        )
+    return commits
+
+
+def merged_prs(repo: str, base: str) -> list[dict]:
+    """Recently merged PRs targeting `base`, newest first."""
+    return gh_json(
+        "pr", "list", "--repo", repo, "--state", "merged", "--base", base,
+        "--limit", str(PR_LOOKBACK),
+        "--json", "number,title,mergedAt,mergeCommit,url,author",
+    )
+
+
+def pr_commit_shas(repo: str, number: int) -> set[str]:
+    """Every commit inside a PR, so its contents can be told apart from a direct push."""
+    data = gh_json("pr", "view", str(number), "--repo", repo, "--json", "commits")
+    return {c["oid"] for c in (data or {}).get("commits", [])}
+
+
+# --- Notes ---
+
+
+def build(repo: str, base: str, head: str, pr_base: str) -> str:
+    range_commits = commits_in_range(repo, base, head)
+    range_shas = {c["sha"] for c in range_commits}
+    if not range_shas:
+        return f"`{head}` has nothing that `{base}` does not. Nothing to promote."
+
+    shipping = [
+        pr for pr in merged_prs(repo, pr_base)
+        if (pr.get("mergeCommit") or {}).get("oid") in range_shas
+    ]
+    shipping.sort(key=lambda p: p["mergedAt"])
+
+    lines = [
+        f"**{len(range_commits)} commits across {len(shipping)} pull requests** "
+        f"will ship when `{head}` reaches `{base}`.",
+        "",
+    ]
+
+    if shipping:
+        lines.append("## What's shipping")
+        lines.append("")
+        for pr in shipping:
+            author = (pr.get("author") or {}).get("login")
+            # Attribution only when it is not the usual maintainer path — a fork
+            # contribution is the case worth noticing in a release note.
+            by = f" _(@{author})_" if author and author != "ty-fi" else ""
+            lines.append(f"- [**#{pr['number']}**]({pr['url']}) — {pr['title']}{by}")
+        lines.append("")
+
+    # Anything in the range that no merged PR accounts for: pushed straight to the branch,
+    # or merged from a PR older than the lookback. Either way a PR-based summary would
+    # omit it silently, which is the failure mode this whole script is guarding against.
+    explained = set()
+    for pr in shipping:
+        explained.add((pr.get("mergeCommit") or {}).get("oid"))
+        explained |= pr_commit_shas(repo, pr["number"])
+    unexplained = [c for c in range_commits if c["sha"] not in explained]
+
+    if unexplained:
+        lines.append(f"## Not covered by any merged PR — {len(unexplained)}")
+        lines.append("")
+        lines.append(
+            "_Pushed directly, or from a PR older than the lookback window. Listed because "
+            "a summary built only from PRs would otherwise leave these out silently._"
+        )
+        lines.append("")
+        for c in unexplained[:20]:
+            subject = c["commit"]["message"].splitlines()[0]
+            lines.append(f"- `{c['sha'][:8]}` {subject}")
+        if len(unexplained) > 20:
+            lines.append(f"- …and {len(unexplained) - 20} more")
+        lines.append("")
+
+    return "\n".join(lines).rstrip() + "\n"
+
+
+# --- Entry point ---
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--repo", default=os.environ.get("GITHUB_REPOSITORY", ""))
+    parser.add_argument("--base", default="prod", help="the branch being deployed to")
+    parser.add_argument("--head", default="main", help="the branch being promoted")
+    parser.add_argument(
+        "--pr-base", default=None,
+        help="branch the component PRs were merged into (defaults to --head)",
+    )
+    args = parser.parse_args()
+    if not args.repo:
+        sys.exit("--repo is required (or set GITHUB_REPOSITORY)")
+
+    # Force UTF-8 out. Python picks the console encoding on Windows, which is cp1252 here,
+    # and the em-dashes in PR titles come out as raw 0x97 — invalid UTF-8, so the notes
+    # arrive in a PR body as mojibake. Linux runners default to UTF-8 and would never show
+    # this, which is precisely why it needs pinning rather than leaving to the platform.
+    sys.stdout.reconfigure(encoding="utf-8")
+
+    notes = build(args.repo, args.base, args.head, args.pr_base or args.head)
+    print(notes)
+
+    # Also render into the Actions run summary, so a workflow_dispatch preview is readable
+    # without opening the log.
+    summary_path = os.environ.get("GITHUB_STEP_SUMMARY")
+    if summary_path:
+        with open(summary_path, "a", encoding="utf-8") as handle:
+            handle.write(notes)
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/workflows/release-notes.yml
+++ b/.github/workflows/release-notes.yml
@@ -1,0 +1,88 @@
+name: Release notes
+
+# Fires on the promotion PR — the one that carries `main` into `prod` — and posts a
+# one-line-per-PR summary of everything it ships.
+#
+# Why this is automated rather than written by hand: a promotion here is a single PR
+# carrying every commit merged to `main` since the last one, so `git log --oneline` over
+# that range mixes merge commits with the individual commits inside each PR. A summary
+# written from that describes what the author remembers doing. The first derived run
+# surfaced four merged security fixes from a fork that nobody had mentioned.
+on:
+  pull_request:
+    # Only promotions. An ordinary feature PR targets `main` and gets nothing from this.
+    branches: [prod]
+    types: [opened, reopened, synchronize]
+  # Preview what a promotion would carry, before opening the PR. Renders into the run
+  # summary rather than commenting anywhere.
+  workflow_dispatch:
+    inputs:
+      base:
+        description: "Branch being deployed to"
+        default: prod
+      head:
+        description: "Branch being promoted"
+        default: main
+
+# Read the repo, write one comment. Nothing here needs more.
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  notes:
+    name: Summarise what is shipping
+    runs-on: ubuntu-latest
+
+    steps:
+      # No actions/checkout of the *code* is needed — every fact comes from the GitHub API,
+      # which sidesteps the fetch-depth trap that would otherwise make `git rev-list` return
+      # nothing on a shallow clone. The checkout is only here for the script itself.
+      - uses: actions/checkout@v4
+        with:
+          sparse-checkout: .github/scripts
+          sparse-checkout-cone-mode: false
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Build the notes
+        id: build
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+        run: |
+          BASE="${{ github.event.inputs.base || github.base_ref }}"
+          HEAD="${{ github.event.inputs.head || github.head_ref }}"
+          echo "Comparing $BASE...$HEAD"
+          python .github/scripts/release_notes.py --base "$BASE" --head "$HEAD" \
+            | tee "$RUNNER_TEMP/notes.md"
+
+      - name: Post or update the comment
+        if: github.event_name == 'pull_request'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          # A comment, not the PR body. Overwriting the body would destroy whatever the
+          # author wrote, and this re-runs on every push to the promotion branch.
+          #
+          # The marker makes it idempotent: find our previous comment and edit it, rather
+          # than adding one per run and burying the PR under near-identical summaries.
+          MARKER="<!-- release-notes -->"
+          BODY="$MARKER"$'\n'"$(cat "$RUNNER_TEMP/notes.md")"
+
+          EXISTING=$(gh api "repos/${{ github.repository }}/issues/${{ github.event.number }}/comments" \
+            --jq "[.[] | select(.body | startswith(\"$MARKER\"))] | first | .id // empty")
+
+          if [ -n "$EXISTING" ]; then
+            gh api --method PATCH \
+              "repos/${{ github.repository }}/issues/comments/$EXISTING" \
+              -f body="$BODY" > /dev/null
+            echo "Updated comment $EXISTING"
+          else
+            gh api --method POST \
+              "repos/${{ github.repository }}/issues/${{ github.event.number }}/comments" \
+              -f body="$BODY" > /dev/null
+            echo "Posted a new comment"
+          fi

--- a/backend/tests/test_release_notes.py
+++ b/backend/tests/test_release_notes.py
@@ -1,0 +1,184 @@
+"""Tests for .github/scripts/release_notes.py.
+
+That script builds the body of a main -> prod promotion PR. A promotion carries every
+commit merged to `main` since the last one — 29 across 10 PRs when it was written — so a
+summary written by hand from `git log` describes what the author remembers rather than what
+is shipping. Its first derived run surfaced four merged security fixes from a fork that
+nobody had mentioned.
+
+The assertion worth having is the matching rule: PRs are identified by **merge commit SHA**,
+never by grepping `#\\d+` out of commit subjects. Subject-grepping looks equivalent and is
+not — it silently misses squash-merged PRs, which leave no "Merge pull request #N" line, and
+it falsely claims any commit whose message happens to mention an issue number.
+
+Loaded by path because the script lives under .github/, outside the package the rest of the
+suite imports.
+"""
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+SCRIPT = (
+    Path(__file__).resolve().parents[2] / ".github" / "scripts" / "release_notes.py"
+)
+
+
+@pytest.fixture(scope="module")
+def notes():
+    spec = importlib.util.spec_from_file_location("release_notes", SCRIPT)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _commit(sha: str, subject: str) -> dict:
+    return {"sha": sha, "commit": {"message": subject}}
+
+
+def _pr(number: int, title: str, merge_sha: str, merged_at: str, author="ty-fi") -> dict:
+    return {
+        "number": number,
+        "title": title,
+        "mergedAt": merged_at,
+        "mergeCommit": {"oid": merge_sha},
+        "url": f"https://github.com/o/r/pull/{number}",
+        "author": {"login": author},
+    }
+
+
+@pytest.fixture
+def fake_api(notes, monkeypatch):
+    """Stub the three GitHub calls, so `build()` is exercised without a network."""
+
+    def install(range_commits, prs, pr_commits=None):
+        pr_commits = pr_commits or {}
+        monkeypatch.setattr(notes, "commits_in_range", lambda *a, **k: range_commits)
+        monkeypatch.setattr(notes, "merged_prs", lambda *a, **k: prs)
+        monkeypatch.setattr(
+            notes, "pr_commit_shas", lambda repo, n: pr_commits.get(n, set())
+        )
+
+    return install
+
+
+class TestMatchingRule:
+    def test_a_pr_is_matched_by_its_merge_commit(self, notes, fake_api):
+        fake_api(
+            [_commit("aaa", "Merge pull request #42 from o/feature")],
+            [_pr(42, "Add a thing", "aaa", "2026-09-01T10:00:00Z")],
+        )
+        out = notes.build("o/r", "prod", "main", "main")
+        assert "**#42**" in out
+        assert "Add a thing" in out
+
+    def test_a_squash_merged_pr_is_still_matched(self, notes, fake_api):
+        """The case subject-grepping gets wrong. A squash merge leaves an ordinary commit
+        subject with no "Merge pull request #N" in it, so only the SHA identifies it."""
+        fake_api(
+            [_commit("bbb", "Add a thing")],  # no PR number anywhere in the subject
+            [_pr(42, "Add a thing", "bbb", "2026-09-01T10:00:00Z")],
+        )
+        assert "**#42**" in notes.build("o/r", "prod", "main", "main")
+
+    def test_a_commit_merely_mentioning_a_number_is_not_credited(self, notes, fake_api):
+        """The other half of the same rule. "Fixes #42" in a message must not make #42
+        appear in the release notes when its merge commit is not in the range."""
+        fake_api(
+            [_commit("ccc", "Refactor the parser. Fixes #42")],
+            [_pr(42, "Something else entirely", "zzz", "2026-09-01T10:00:00Z")],
+        )
+        out = notes.build("o/r", "prod", "main", "main")
+        assert "**#42**" not in out
+        assert "Something else entirely" not in out
+
+    def test_a_pr_outside_the_range_is_excluded(self, notes, fake_api):
+        """An already-promoted PR must not reappear in the next release's notes."""
+        fake_api(
+            [_commit("aaa", "in range")],
+            [
+                _pr(1, "Already shipped", "old", "2026-08-01T10:00:00Z"),
+                _pr(2, "Shipping now", "aaa", "2026-09-01T10:00:00Z"),
+            ],
+        )
+        out = notes.build("o/r", "prod", "main", "main")
+        assert "Already shipped" not in out
+        assert "Shipping now" in out
+
+
+class TestUnexplainedCommits:
+    def test_a_direct_push_is_reported(self, notes, fake_api):
+        """The failure this script exists to prevent, in miniature: a PR-only summary would
+        omit a commit pushed straight to the branch, and omit it silently."""
+        fake_api(
+            [_commit("aaa", "Merge pull request #42 from o/f"), _commit("ddd", "hotfix typo")],
+            [_pr(42, "A thing", "aaa", "2026-09-01T10:00:00Z")],
+            {42: set()},
+        )
+        out = notes.build("o/r", "prod", "main", "main")
+        assert "Not covered by any merged PR" in out
+        assert "hotfix typo" in out
+        assert "ddd"[:8] in out
+
+    def test_commits_inside_a_pr_are_not_reported_as_direct_pushes(self, notes, fake_api):
+        """Each PR's own commits are in the range too. Without asking for them, every
+        component commit would be listed as an unexplained direct push."""
+        fake_api(
+            [
+                _commit("aaa", "Merge pull request #42 from o/f"),
+                _commit("eee", "first commit inside the PR"),
+                _commit("fff", "second commit inside the PR"),
+            ],
+            [_pr(42, "A thing", "aaa", "2026-09-01T10:00:00Z")],
+            {42: {"eee", "fff"}},
+        )
+        out = notes.build("o/r", "prod", "main", "main")
+        assert "Not covered by any merged PR" not in out
+
+
+class TestPresentation:
+    def test_an_empty_range_says_so_rather_than_rendering_an_empty_list(self, notes, fake_api):
+        fake_api([], [])
+        out = notes.build("o/r", "prod", "main", "main")
+        assert "Nothing to promote" in out
+        assert "What's shipping" not in out
+
+    def test_the_counts_are_stated(self, notes, fake_api):
+        fake_api(
+            [_commit("aaa", "m"), _commit("bbb", "x")],
+            [_pr(1, "A", "aaa", "2026-09-01T10:00:00Z")],
+            {1: {"bbb"}},
+        )
+        out = notes.build("o/r", "prod", "main", "main")
+        assert "2 commits across 1 pull requests" in out
+
+    def test_ordering_is_by_merge_time(self, notes, fake_api):
+        """Reading order should match the order things landed, not the API's."""
+        fake_api(
+            [_commit("a1", "m"), _commit("a2", "m")],
+            [
+                _pr(9, "Later", "a2", "2026-09-02T10:00:00Z"),
+                _pr(8, "Earlier", "a1", "2026-09-01T10:00:00Z"),
+            ],
+        )
+        out = notes.build("o/r", "prod", "main", "main")
+        assert out.index("Earlier") < out.index("Later")
+
+    def test_a_fork_contributor_is_credited(self, notes, fake_api):
+        """Attribution is the detail that makes an outside contribution visible in a release
+        note — the four fork security fixes were the thing a hand-written summary missed."""
+        fake_api(
+            [_commit("aaa", "m")],
+            [_pr(74, "A security fix", "aaa", "2026-09-01T10:00:00Z", author="someone")],
+        )
+        assert "_(@someone)_" in notes.build("o/r", "prod", "main", "main")
+
+    def test_the_maintainer_is_not_credited_on_every_line(self, notes, fake_api):
+        """Crediting the usual author on all ten lines is noise that hides the one line
+        where attribution matters."""
+        fake_api(
+            [_commit("aaa", "m")],
+            [_pr(88, "A routine fix", "aaa", "2026-09-01T10:00:00Z", author="ty-fi")],
+        )
+        assert "_(@" not in notes.build("o/r", "prod", "main", "main")


### PR DESCRIPTION
A promotion here is one PR carrying every commit merged to `main` since the last one — **29
across 10 PRs right now.** The deploy skill's step 6 was `git log origin/prod..origin/main
--oneline`, which mixes merge commits with the individual commits inside each PR, so what
reached the PR body was whatever the author remembered doing.

**The first derived run surfaced four merged security fixes from a fork that nobody had
thought to mention** — the Ticketmaster key reaching logs/DB/response (#77), a CRLF in a
stored `ticket_url` injecting properties into the favorites `.ics` (#74), modal URL escaping
(#75) — none of them live. That's the argument for this, not tidiness.

## What it produces

Run against the current pending range:

```
**29 commits across 10 pull requests** will ship when `main` reaches `prod`.

## What's shipping

- [**#75**](…) — Escape ticket_url and image_url before interpolating them into modal attributes _(@jakebromberg)_
- [**#74**](…) — Stop a CRLF in a stored ticket_url from injecting properties into the favorites .ics _(@jakebromberg)_
- [**#76**](…) — Populate image_url in the three scrapers that still leave it null _(@jakebromberg)_
- [**#77**](…) — Stop the Ticketmaster API key reaching logs, the database, and the scrape response _(@jakebromberg)_
- [**#88**](…) — Stop Alembic's fileConfig from dismantling app logging
- …
```

Fork contributors are credited; the usual maintainer isn't, because attributing all ten
lines to the same person hides the one line where attribution matters.

## The matching rule is the load-bearing part

PRs are matched to the range by **merge commit SHA**, never by grepping `#\d+` out of commit
subjects. Subject-grepping looks equivalent and isn't:

| case | subject grep | SHA match |
|---|---|---|
| squash-merged PR (no "Merge pull request #N" line) | **missed** | matched |
| commit saying "Fixes #42" for a PR not in the range | **falsely credited** | excluded |
| already-promoted PR | may reappear | excluded |

Both failure cases are tested. Swapping in the grep approach fails **six** tests.

Commits in the range that no merged PR accounts for get their own section — a summary built
only from PRs would otherwise omit a direct push *silently*, which is the same class of
failure the whole thing exists to prevent.

## Shape

Everything comes from the GitHub API, not a working tree — so no checkout of the code, **no
fetch-depth trap on a shallow clone** (the usual way `git rev-list` returns nothing in
Actions), and identical behaviour when run locally. `actions/checkout` appears only to fetch
the script itself, sparsely.

The workflow fires on PRs targeting `prod`; ordinary feature PRs target `main` and get
nothing. It posts a **comment** rather than overwriting the body, which would destroy
whatever the author wrote, and a marker makes it idempotent — re-runs edit the existing
comment instead of burying the PR under near-identical summaries as commits land.
`workflow_dispatch` renders the same notes into the run summary for a preview before the PR
exists.

Permissions are `contents: read` + `pull-requests: write`.

## One bug fixed on the way

Python picks the console encoding for stdout on Windows, which is cp1252 here — so
em-dashes in PR titles came out as raw `0x97`, invalid UTF-8, arriving in a PR body as
mojibake. Verified by decoding the bytes, not by looking at the terminal. Linux runners
default to UTF-8 and would never have shown it, which is exactly the platform split that
hides things. stdout is now pinned.

## Tests

+11 (**584 passing**). Loaded by path, since the script lives outside the package the rest
of the suite imports. Three mutations each caught:

| mutation | tests that caught it |
|---|---|
| match by subject grep instead of merge SHA | 6 |
| stop reporting commits no PR accounts for | 1 |
| drop the merge-time ordering | 1 |

The local `deploy` skill is updated to call the script at step 6 and to note the workflow
posts the comment — that file is gitignored (`.claude*`), so it isn't in this diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
