### PR TITLE
Close queryable read endpoints and restrict CORS origins

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -3,3 +3,6 @@ TICKETMASTER_API_KEY=your_key_here
 ENABLE_SCHEDULER=false
 APP_ENV=development
 LOG_LEVEL=INFO
+# Set true to reopen GET /api/events and GET /api/events/{id}, which are closed
+# while API registration is designed (issue #62). The site never calls them.
+PUBLIC_QUERY_API_ENABLED=false

--- a/backend/app/api/events.py
+++ b/backend/app/api/events.py
@@ -1,21 +1,30 @@
 """
 Event API endpoints for the Triangle Shows calendar.
 
-Role: Serves GET /api/events/fullcalendar (the primary frontend feed), GET /api/events/{id},
-and GET /api/events (paginated list). These endpoints are called by the Vanilla JS +
-FullCalendar v6 frontend on page load and whenever the user navigates the calendar.
+Role: Serves three read endpoints, and only one of them is the site's.
+
+  * GET /api/events/fullcalendar — what frontend/js/app.js loads on page load. The whole
+    calendar, unbounded and unpaginated, filtered in the browser afterwards.
+  * GET /api/events/{id} and GET /api/events — the queryable pair, for interrogating the
+    dataset rather than drawing the calendar. **Neither is called by frontend/**, and both
+    are gated by require_query_api while a registration process is designed (issue #62).
+
+An earlier version of this docstring said all three were called by the frontend. They were
+not, which is what made closing the pair free.
+
 Requires: async PostgreSQL session (app.database), Event/Venue ORM models (app.models),
-response schemas (app.schemas).
+response schemas (app.schemas), settings.PUBLIC_QUERY_API_ENABLED (app.config).
 """
 import re
 from datetime import date, datetime, time
 from typing import Optional
 
-from fastapi import APIRouter, Depends, Query, HTTPException
+from fastapi import APIRouter, Depends, Query, HTTPException, Request
 from sqlalchemy import select, func, and_
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import joinedload
 
+from app.config import settings
 from app.database import get_session
 from app.models import Event, Venue
 from app.timefmt import format_time_12h
@@ -233,12 +242,48 @@ async def get_fullcalendar_events(
     return fc_events
 
 
-@router.get("/{event_id}")
+async def require_query_api(request: Request) -> None:
+    """Gate the queryable read endpoints while a registration process is designed (#62).
+
+    Applied to GET /api/events and GET /api/events/{id} — the two endpoints that let a
+    caller *interrogate* the dataset (search, filter by genre or status, page through it,
+    address a row by id) rather than read the calendar the site draws. Neither is called by
+    frontend/, verified by grep: the site uses only /api/events/fullcalendar, /api/venues
+    and /feeds/events.ics. So closing them costs the site nothing.
+
+    403 rather than 404, and with a message naming where to ask. This is a policy boundary,
+    not a security one — the data is public and the site renders it — so pretending the
+    endpoints do not exist would mislead an integrator acting in good faith while doing
+    nothing to a scraper, who does not need them.
+
+    **What this does not do.** It does not stop bulk collection, and reading it as though it
+    does would be the expensive mistake. /api/events/fullcalendar is unauthenticated, takes
+    no date bound, and returns every event with every field — 2,854 records and 2.4 MB in
+    one request at the time of writing — because that is exactly what the site itself
+    fetches on page load. A commercial actor does not need the endpoints closed here; one
+    request to the endpoint that has to stay open gets them the same data, in a request
+    indistinguishable from a visitor's. See #62 for the payload split that would actually
+    raise the cost.
+    """
+    if settings.PUBLIC_QUERY_API_ENABLED:
+        return
+    raise HTTPException(
+        status_code=403,
+        detail=(
+            "Programmatic access to this endpoint is paused while a registration process "
+            "is set up. The calendar itself stays open at /api/events/fullcalendar and "
+            "/feeds/events.ics. To ask for access, open an issue at "
+            "https://github.com/triangle-shows/triangle-shows/issues."
+        ),
+    )
+
+
+@router.get("/{event_id}", dependencies=[Depends(require_query_api)])
 async def get_event(
     event_id: int,
     session: AsyncSession = Depends(get_session),
 ) -> EventResponse:
-    """Get a single event by ID.
+    """Get a single event by ID. Gated — see require_query_api.
 
     A row folded into another as a duplicate answers 404 like a row that never existed,
     so "hidden" means hidden on every public path rather than only in the listings. The
@@ -246,6 +291,11 @@ async def get_event(
     /api/events/fullcalendar and the modal renders from what it already has — so the
     only callers are third parties, and leaving a back door to rows an admin has
     suppressed would make the flag advisory.
+
+    That the site does not call this is what makes the gate free today, and it is also
+    what #62's payload split would change: moving the modal's fields here would make this
+    the site's own detail source, at which point the gate needs a same-origin exemption
+    rather than a flat refusal.
     """
     result = await session.execute(
         select(Event)
@@ -313,7 +363,7 @@ def _list_conditions(
     return conditions
 
 
-@router.get("")
+@router.get("", dependencies=[Depends(require_query_api)])
 async def list_events(
     start: Optional[str] = Query(None),
     end: Optional[str] = Query(None),

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -25,6 +25,21 @@ class Settings(BaseSettings):
     APP_ENV: str = "development"
     LOG_LEVEL: str = "INFO"
 
+    # --- Public query API (issue #62) ---
+    # Whether the queryable read endpoints — GET /api/events and GET /api/events/{id} —
+    # answer for anyone. Closed by default while a registration process is designed.
+    #
+    # A flag rather than deleted routes, because this is a policy decision that is meant to
+    # be reversed: when #62 lands, the endpoints come back gated by a key instead of by
+    # this. Deleting them would mean rebuilding the handlers, the schemas and their tests
+    # to reopen something that was only ever meant to be paused.
+    #
+    # Closing these does not stop bulk collection, and should not be mistaken for it.
+    # /api/events/fullcalendar is what the site itself loads, unauthenticated and with no
+    # date bound, so the full dataset stays one request away — see the issue for why the
+    # payload split is the change that would actually raise the cost.
+    PUBLIC_QUERY_API_ENABLED: bool = False
+
     # --- Origin enforcement (see app.tokens) ---
     # The Cloud Run service accepts unauthenticated requests, so its .run.app hostnames
     # reach the app without passing Cloudflare. These settings let the app itself verify

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -216,13 +216,52 @@ app = FastAPI(
 # frontend/js/config.js sets API_BASE to window.location.origin and the admin UI fetches
 # relative paths, so every in-app request is same-origin, where CORS does not apply.
 #
-# Keeping "*" rather than an allowlist is deliberate: the read API is public, so leaving it
-# usable from any page costs nothing once credentials are off. Narrowing allow_origins to
-# the real site origins would stop third parties consuming it from a browser — a product
-# decision, not a security one.
+# The "*" is now an allowlist. That is the product decision this comment used to describe as
+# available — taken deliberately, alongside #62's gate on the queryable endpoints.
+#
+# What it stops: a third party building a browser app whose JavaScript calls this API from
+# *their* users' browsers — a competing calendar with no infrastructure and all our
+# bandwidth. Their users' browsers now refuse to hand the response back.
+#
+# What it does not stop, and must not be mistaken for: a server-side scraper. CORS is a
+# browser protection. A script is not a browser, never reads the header, and is unaffected.
+# Neither would an Origin or Referer check be — both are client-set, so
+# `curl -H "Origin: https://triangle-shows.net"` defeats them in one line. Requests carrying
+# no Origin at all — every calendar client polling /feeds/events.ics — are outside CORS
+# entirely and stay unaffected.
+#
+# Note this costs the site nothing, because every in-app request is already same-origin (see
+# above), where CORS does not apply. The allowlist is what a cross-origin caller is measured
+# against, and the site is never one. Listing the real origins rather than an empty list
+# keeps a future cross-origin case working and documents what the sites actually are.
+#
+# allow_credentials stays False regardless. That flag is what made the old "*" merely
+# permissive rather than dangerous, and narrowing origins is not a reason to relax it.
+ALLOWED_ORIGINS = [
+    "https://triangle-shows.net",
+    "https://www.triangle-shows.net",
+    "https://durm.triangle-shows.net",  # the older Durham subdomain, still served
+    "https://durm-shows.net",
+    "https://www.durm-shows.net",
+]
+
+# triangle-shows.org is deliberately absent: Cloudflare 301s it to triangle-shows.net, so a
+# document is never served from that origin and a browser never sends it.
+#
+# Local origins only outside production, so a deployment cannot end up trusting localhost.
+# Port 8080 is the static preview server; *.localhost covers durm-shows.localhost, which is
+# how the Durham variant is opened locally (see frontend/js/config.js).
+if settings.APP_ENV != "production":
+    ALLOWED_ORIGINS += [
+        "http://localhost:8080",
+        "http://127.0.0.1:8080",
+        "http://durm-shows.localhost:8080",
+        "http://localhost:8000",
+    ]
+
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=["*"],
+    allow_origins=ALLOWED_ORIGINS,
     allow_credentials=False,
     allow_methods=["*"],
     allow_headers=["*"],

--- a/backend/tests/test_cors.py
+++ b/backend/tests/test_cors.py
@@ -60,11 +60,86 @@ class TestCredentialsAreNeverAllowed:
         assert response.headers.get("access-control-allow-credentials") is None
 
 
-class TestThePublicApiStaysBrowserConsumable:
-    """The other half of the decision: dropping credentials rather than narrowing origins
-    keeps the public read API usable from any page. If someone later swaps to an origin
-    allowlist, these are the tests that should be updated on purpose rather than deleted."""
+class TestOnlyTheSitesOwnOriginsMayReadFromABrowser:
+    """Updated on purpose, as the class this replaced asked to be.
 
-    def test_a_cross_origin_read_is_permitted(self, client):
-        response = client.get("/openapi.json", headers={"Origin": HOSTILE})
-        assert response.headers.get("access-control-allow-origin") is not None
+    It used to assert that *any* page could read the API, which was true and deliberate
+    while allow_origins was "*". That has been narrowed alongside #62's gate, to stop a
+    third party running a competing calendar whose JavaScript calls this API from their own
+    users' browsers.
+
+    The distinction that makes this worth having: CORS is a browser protection, so this
+    closes the parasitic-frontend case and does nothing whatsoever to a server-side scraper.
+    These tests should not be read as evidence the data is protected.
+    """
+
+    def test_a_hostile_origin_cannot_read(self, client):
+        """The change itself. A page on another domain gets no usable allow-origin header,
+        so the browser discards the response before that page can read it.
+
+        Both branches matter, and the first version of this test only had one. Asserting
+        merely that the header is not the hostile origin passes against `allow_origins=["*"]`
+        — the wildcard is not equal to the origin while permitting it completely — so a
+        revert to the old policy would have gone unnoticed here.
+        """
+        allowed = client.get(
+            "/openapi.json", headers={"Origin": HOSTILE}
+        ).headers.get("access-control-allow-origin")
+        assert allowed != HOSTILE, "the hostile origin was echoed back"
+        assert allowed != "*", "the wildcard is back, which permits every origin"
+
+    @pytest.mark.parametrize("origin", [
+        "https://triangle-shows.net",
+        "https://www.triangle-shows.net",
+        "https://durm.triangle-shows.net",
+        "https://durm-shows.net",
+        "https://www.durm-shows.net",
+    ])
+    def test_every_real_site_origin_is_allowed(self, client, origin):
+        """The regression that would break a site. All five are served by this app — the two
+        domains, their www forms, and the older durm.* subdomain."""
+        response = client.get("/openapi.json", headers={"Origin": origin})
+        assert response.headers.get("access-control-allow-origin") == origin
+
+    def test_a_request_with_no_origin_is_untouched(self, client):
+        """Every calendar client polling /feeds/events.ics sends no Origin, so it is outside
+        CORS entirely. Narrowing the allowlist must not reach them."""
+        response = client.get("/openapi.json")
+        assert response.status_code == 200
+        assert response.headers.get("access-control-allow-origin") is None
+
+    def test_credentials_are_still_refused(self, client):
+        """allow_credentials=False is what made the old "*" merely permissive rather than
+        dangerous. Narrowing origins is not a reason to relax it, and a future change that
+        does should fail here."""
+        response = client.get(
+            "/openapi.json", headers={"Origin": "https://triangle-shows.net"}
+        )
+        assert response.headers.get("access-control-allow-credentials") is None
+
+
+class TestLocalOriginsAreDevelopmentOnly:
+    def test_localhost_is_not_trusted_in_production(self):
+        """A deployment must not end up trusting a loopback origin. Asserted against the
+        list rather than a live request, since APP_ENV is fixed once the module is imported.
+        """
+        import importlib
+
+        from app.config import settings
+
+        original = settings.APP_ENV
+        try:
+            settings.APP_ENV = "production"
+            import app.main
+
+            reloaded = importlib.reload(app.main)
+            assert not any("localhost" in o for o in reloaded.ALLOWED_ORIGINS)
+            assert not any("127.0.0.1" in o for o in reloaded.ALLOWED_ORIGINS)
+        finally:
+            settings.APP_ENV = original
+            importlib.reload(app.main)
+
+    def test_localhost_is_available_outside_production(self):
+        from app.main import ALLOWED_ORIGINS
+
+        assert any("localhost" in o for o in ALLOWED_ORIGINS)

--- a/backend/tests/test_query_api_gate.py
+++ b/backend/tests/test_query_api_gate.py
@@ -1,0 +1,98 @@
+"""The queryable read endpoints are closed while a registration process is designed (#62).
+
+`GET /api/events` and `GET /api/events/{id}` let a caller interrogate the dataset — search
+it, filter by genre or status, page through it, address a row by id. `GET
+/api/events/fullcalendar` draws the calendar the site displays. Only the third is used by
+`frontend/`, so closing the first two costs the site nothing.
+
+**What these tests are not claiming.** Closing them does not stop bulk collection.
+/api/events/fullcalendar is unauthenticated, accepts no date bound, and returns every event
+with every field — because that is what the site itself fetches. The gate removes a
+convenient documented interface; it does not close the door, and the class below that pins
+the open endpoints exists partly to keep that fact visible.
+"""
+
+import pytest
+from fastapi.testclient import TestClient
+
+from app.config import settings
+from app.main import app
+
+
+# raise_server_exceptions=False so an endpoint that reaches the database in this
+# no-database harness surfaces as a 500 response rather than an exception — that
+# distinction is what several assertions below rest on.
+@pytest.fixture
+def client():
+    return TestClient(app, raise_server_exceptions=False)
+
+
+class TestTheQueryableEndpointsAreClosed:
+    @pytest.mark.parametrize("path", ["/api/events", "/api/events/1"])
+    def test_refused(self, client, path):
+        assert client.get(path).status_code == 403
+
+    @pytest.mark.parametrize("path", ["/api/events", "/api/events/1"])
+    def test_refused_before_touching_the_database(self, client, path):
+        """403 rather than 500 in a harness with no database is the evidence: the gate
+        short-circuits, so a closed endpoint costs no connection. If the dependency ordering
+        ever changed so the session resolved first, this would turn into a 500 and a closed
+        endpoint would still be doing work for every caller."""
+        assert client.get(path).status_code != 500
+
+    @pytest.mark.parametrize("path", ["/api/events", "/api/events/1"])
+    def test_the_refusal_says_where_to_ask(self, client, path):
+        """403 with an address, not 404. The data is public and the site renders it, so this
+        is a policy boundary rather than a security one — pretending the endpoint does not
+        exist would mislead an integrator acting in good faith while doing nothing to a
+        scraper, who does not need it."""
+        detail = client.get(path).json()["detail"]
+        assert "registration" in detail
+        assert "github.com/triangle-shows" in detail
+
+    def test_the_refusal_names_what_is_still_open(self, client):
+        """Someone who wanted the calendar should not conclude the whole API is gone."""
+        detail = client.get("/api/events").json()["detail"]
+        assert "/api/events/fullcalendar" in detail
+        assert "/feeds/events.ics" in detail
+
+
+class TestTheSitesOwnEndpointsAreUntouched:
+    """The regression that would take the site down. These three are what `frontend/`
+    actually calls — verified by grep over frontend/js and index.html — and none may be
+    gated by anything added for #62."""
+
+    @pytest.mark.parametrize("path", [
+        "/api/events/fullcalendar",
+        "/api/venues",
+        "/feeds/events.ics",
+    ])
+    def test_not_gated(self, client, path):
+        # 500 here is the no-database harness, not a refusal; what matters is that the
+        # request reached the handler rather than being turned away at the gate.
+        assert client.get(path).status_code != 403
+
+
+class TestItIsReversible:
+    """The point of a flag rather than deleted routes. #62 reopens these behind a key, and
+    that should be a configuration change plus an auth check — not rebuilding handlers,
+    schemas and tests that were removed."""
+
+    def test_the_flag_reopens_them(self, client, monkeypatch):
+        monkeypatch.setattr(settings, "PUBLIC_QUERY_API_ENABLED", True)
+        for path in ("/api/events", "/api/events/1"):
+            assert client.get(path).status_code != 403, f"{path} stayed closed"
+
+    def test_closed_by_default(self):
+        """The setting ships closed, so a deployment that forgets to set it is paused rather
+        than open."""
+        from app.config import Settings
+
+        assert Settings().PUBLIC_QUERY_API_ENABLED is False
+
+    def test_the_routes_still_exist(self):
+        """Gated, not deleted — so the OpenAPI schema still documents them and the handlers,
+        response models and their tests survive intact for #62 to reopen."""
+        paths = {r.path for r in app.routes if hasattr(r, "path")}
+        assert "/api/events" in paths
+        assert "/api/events/{event_id}" in paths

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -198,6 +198,7 @@ commit is live. That's what [`tools/wait_for_deploy.py`](../tools/wait_for_deplo
 | `ENABLE_SCHEDULER` | `false` | Scraping is driven externally by Cloud Scheduler, not in-process |
 | `ENABLE_STARTUP_SCRAPE` | `false` | See below — a detached task cannot work under this service's CPU allocation |
 | `LOG_LEVEL` | `INFO` | |
+| `PUBLIC_QUERY_API_ENABLED` | unset (`false`) | Closes `GET /api/events` and `GET /api/events/{id}` while API registration is designed (#62). The calendar feed and the iCal feed are unaffected — the site does not use the gated pair |
 | `DATABASE_URL` | secret `triangle-shows-db-url` | |
 | `TICKETMASTER_API_KEY` | secret `triangle-shows-tm-api-key` | |
 | `SCRAPE_ALLOWED_SERVICE_ACCOUNTS` | the scheduler's service account | Gates `POST /api/scrape` — see Origin gates |


### PR DESCRIPTION
This pull request introduces a gate for the queryable event API endpoints (`GET /api/events` and `GET /api/events/{id}`), closing them to public access while a registration process is designed (issue #62). The main calendar feed (`GET /api/events/fullcalendar`) and iCal feed remain open and unaffected, ensuring the site and its users are not impacted. The change is implemented as a reversible feature flag (`PUBLIC_QUERY_API_ENABLED`), with comprehensive tests and documentation updates. Additionally, CORS policy is tightened to allow only site-owned origins to read the API from browsers, preventing third-party browser-based frontends from consuming the API.

The most important changes include:

**API Endpoint Gating and Configuration**
- Introduced the `PUBLIC_QUERY_API_ENABLED` flag in `app.config` and `.env.example`, defaulting to `False`, to control public access to the queryable endpoints (`GET /api/events`, `GET /api/events/{id}`) without deleting them. [[1]](diffhunk://#diff-91d704eebe9288029281dfdd5f9656f85cc4c563292c8721107be54754dc359fR28-R42) [[2]](diffhunk://#diff-361f2d0f55c49b270125820efb10f0d9433ced883e9d59b1f58c27b877dc2080R6-R8)
- Added the `require_query_api` dependency to the two queryable endpoints, returning a 403 with an informative message when the flag is disabled. The main calendar feed remains open and unaffected. [[1]](diffhunk://#diff-349c63a3a028639378d776a07c2187aefc3d21191dbe0db8b54ca68073027512L236-R298) [[2]](diffhunk://#diff-349c63a3a028639378d776a07c2187aefc3d21191dbe0db8b54ca68073027512L316-R366)

**CORS Policy Tightening**
- Replaced the permissive CORS wildcard (`*`) with an explicit allowlist of site-owned origins, ensuring only the site's own frontends can read the API from browsers. Localhost origins are allowed only in non-production environments.

**Testing**
- Added a new test suite (`test_query_api_gate.py`) to verify that the queryable endpoints are properly gated, the refusal message is informative, the main site endpoints are unaffected, and the configuration is reversible.
- Updated CORS tests to assert that only allowed origins can read the API from browsers, and that localhost is trusted only outside production.

**Documentation**
- Updated documentation (`ARCHITECTURE.md`) and comments to reflect the new gating and CORS policies, clarifying the intent, limitations, and reversibility of these changes. [[1]](diffhunk://#diff-ff21b6b9a3a33e9d9056ac96882cc348d7077612b5931068f7459707b21eb3d1R201) [[2]](diffhunk://#diff-349c63a3a028639378d776a07c2187aefc3d21191dbe0db8b54ca68073027512L4-R27) [[3]](diffhunk://#diff-82608d38c4441937a3cfb9ff7da1bed9dd59292dec62308de75bfaa2809419a3L219-R264)