### PR TITLE
Fix Slim's event scraper

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,7 +142,8 @@ Each venue is handled by one scraper type. Last updated 2026-06-29 — may drift
 | `tribe_events` | The Cave |
 | `venuepilot` | Haw River Ballroom, Rubies on Five Points, Stanczyks |
 | `squarespace` | Neptune's Parlour, Boom Club |
-| `mec` | Shadowbox Studio, Slim's |
+| `mec` | Shadowbox Studio |
+| `arkon_bar_manager` | Slim's |
 | `tickpick_organizer` | Chapel of Bones |
 | `webflow_cms` | Pour House |
 

--- a/backend/app/scrapers/arkon_bar_manager.py
+++ b/backend/app/scrapers/arkon_bar_manager.py
@@ -32,8 +32,7 @@ class ArkonBarManagerScraper(BaseScraper):
             soup = BeautifulSoup(response.text, "lxml")
             calendar = soup.select_one(".abm-calendar")
             if calendar is None:
-                logger.warning("[ABM] Calendar not found for %s", self.venue_slug)
-                return []
+                raise RuntimeError(f"ABM calendar not found for {self.venue_slug}")
 
             events = self._parse_events(calendar, url)
             ajax_url = calendar.get("data-ajax", "")

--- a/backend/app/scrapers/arkon_bar_manager.py
+++ b/backend/app/scrapers/arkon_bar_manager.py
@@ -1,0 +1,122 @@
+"""Scraper for the Arkon Bar Manager WordPress calendar used by Slim's."""
+
+import logging
+from datetime import date
+from urllib.parse import urljoin
+
+import httpx
+from bs4 import BeautifulSoup
+
+from app.scrapers.base import BaseScraper, BROWSER_HEADERS, ScrapedEvent
+from app.scrapers.html_text import clean_html_text
+
+
+logger = logging.getLogger(__name__)
+
+
+class ArkonBarManagerScraper(BaseScraper):
+    """Parse the initial ABM calendar and follow its cursor-based pagination."""
+
+    MAX_PAGES = 20
+
+    async def scrape(self) -> list[ScrapedEvent]:
+        url = self.config.get("url", "")
+        if not url:
+            raise ValueError(f"No URL configured for {self.venue_slug}")
+
+        async with httpx.AsyncClient(
+            timeout=30, follow_redirects=True, headers=BROWSER_HEADERS
+        ) as client:
+            response = await client.get(url)
+            response.raise_for_status()
+            soup = BeautifulSoup(response.text, "lxml")
+            calendar = soup.select_one(".abm-calendar")
+            if calendar is None:
+                logger.warning("[ABM] Calendar not found for %s", self.venue_slug)
+                return []
+
+            events = self._parse_events(calendar, url)
+            ajax_url = calendar.get("data-ajax", "")
+            cursor = calendar.get("data-cursor", "")
+            count = calendar.get("data-more", "10")
+            last_month = calendar.get("data-last-month", "")
+            category = calendar.get("data-category", "")
+
+            for _ in range(self.MAX_PAGES):
+                if not ajax_url or not cursor:
+                    break
+                page = await client.post(
+                    urljoin(url, ajax_url),
+                    data={
+                        "action": "abm_load_events",
+                        "cursor": cursor,
+                        "count": count,
+                        "last_month": last_month,
+                        "category": category,
+                    },
+                )
+                page.raise_for_status()
+                payload = page.json()
+                data = payload.get("data", {}) if payload.get("success") else {}
+                if not data:
+                    break
+
+                events.extend(
+                    self._parse_events(BeautifulSoup(data.get("html", ""), "lxml"), url)
+                )
+                if not data.get("has_more"):
+                    break
+
+                next_cursor = data.get("cursor", "")
+                if not next_cursor or next_cursor == cursor:
+                    logger.warning("[ABM] Pagination cursor did not advance for %s", self.venue_slug)
+                    break
+                cursor = next_cursor
+                last_month = data.get("last_month", last_month)
+            else:
+                logger.warning(
+                    "[ABM] Stopped %s pagination after the %s-page safety limit",
+                    self.venue_slug,
+                    self.MAX_PAGES,
+                )
+
+        unique = {event.hash: event for event in events}
+        logger.info("[ABM] Found %s events for %s", len(unique), self.venue_slug)
+        return list(unique.values())
+
+    def _parse_events(self, soup: BeautifulSoup, base_url: str) -> list[ScrapedEvent]:
+        events = []
+        for article in soup.select("article.abm-event[data-date]"):
+            title = article.select_one(".abm-event-title a")
+            if title is None:
+                continue
+            try:
+                event_date = date.fromisoformat(article.get("data-date", ""))
+            except ValueError:
+                continue
+
+            name = title.get_text(" ", strip=True)
+            if not name:
+                continue
+            event_url = urljoin(base_url, title.get("href", ""))
+            time_element = article.select_one(".abm-meta-time > span")
+            time_text = time_element.get_text(" ", strip=True) if time_element else ""
+            blurb = article.select_one(".abm-event-blurb")
+            image = article.select_one(".abm-event-flyer img")
+
+            events.append(
+                ScrapedEvent(
+                    name=name,
+                    date=event_date,
+                    venue_slug=self.venue_slug,
+                    source="arkon_bar_manager",
+                    artist=name,
+                    show_time=self.parse_time(time_text),
+                    ticket_url=event_url,
+                    image_url=urljoin(base_url, image.get("src", "")) if image else None,
+                    description=clean_html_text(blurb.get_text(" ", strip=True)) if blurb else None,
+                    source_url=event_url,
+                    status="on_sale",
+                )
+            )
+        return events

--- a/backend/app/scrapers/manager.py
+++ b/backend/app/scrapers/manager.py
@@ -350,6 +350,9 @@ class ScrapeManager:
         elif venue.scraper_type == "mec":
             from app.scrapers.mec import MECScraper
             return MECScraper(venue.slug, venue.scraper_config)
+        elif venue.scraper_type == "arkon_bar_manager":
+            from app.scrapers.arkon_bar_manager import ArkonBarManagerScraper
+            return ArkonBarManagerScraper(venue.slug, venue.scraper_config)
         elif venue.scraper_type == "webflow_cms":
             from app.scrapers.webflow_cms import WebflowCMSScraper
             return WebflowCMSScraper(venue.slug, venue.scraper_config)

--- a/backend/app/seed.py
+++ b/backend/app/seed.py
@@ -30,7 +30,8 @@ logger = logging.getLogger(__name__)
 #   tribe_events      The Cave
 #   venuepilot        Haw River Ballroom, Rubies on Five Points, Stanczyks
 #   squarespace       Neptune's Parlour, Boom Club
-#   mec               Shadowbox Studio, Slim's
+#   mec               Shadowbox Studio
+#   arkon_bar_manager Slim's
 #   tickpick_organizer Chapel of Bones
 #   webflow_cms       Pour House
 VENUES = [
@@ -272,7 +273,7 @@ VENUES = [
         "capacity": 200,
         "size_category": "small",
         "website": "https://slimsdivebar.com/",
-        "scraper_type": "mec",
+        "scraper_type": "arkon_bar_manager",
         "scraper_config": {"url": "https://slimsdivebar.com/music-and-events/"},
         "color": "#4a3a6a",  # deep plum (Raleigh)
     },

--- a/backend/tests/test_arkon_bar_manager.py
+++ b/backend/tests/test_arkon_bar_manager.py
@@ -1,7 +1,10 @@
+import asyncio
 from datetime import date, time
 
+import pytest
 from bs4 import BeautifulSoup
 
+import app.scrapers.arkon_bar_manager as arkon_module
 from app.scrapers.arkon_bar_manager import ArkonBarManagerScraper
 
 
@@ -43,8 +46,88 @@ def test_parses_arkon_calendar_event_fields():
 def test_requires_a_configured_url():
     scraper = ArkonBarManagerScraper("slims", {})
 
-    import asyncio
-    import pytest
-
     with pytest.raises(ValueError, match="No URL configured"):
+        asyncio.run(scraper.scrape())
+
+
+class FakeResponse:
+    def __init__(self, *, text="", payload=None):
+        self.text = text
+        self._payload = payload
+
+    def raise_for_status(self):
+        pass
+
+    def json(self):
+        return self._payload
+
+
+class FakeAsyncClient:
+    instance = None
+
+    def __init__(self, **kwargs):
+        self.post_calls = []
+        FakeAsyncClient.instance = self
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *args):
+        pass
+
+    async def get(self, url):
+        return FakeResponse(
+            text=HTML.replace(
+                '<div class="abm-calendar">',
+                '<div class="abm-calendar" data-ajax="/ajax" '
+                'data-cursor="first-cursor" data-more="10" '
+                'data-last-month="2026-09" data-category="music">',
+            )
+        )
+
+    async def post(self, url, data):
+        self.post_calls.append((url, data))
+        return FakeResponse(
+            payload={
+                "success": True,
+                "data": {
+                    "html": HTML.replace("2026-09-10", "2026-09-11"),
+                    "cursor": "second-cursor",
+                    "last_month": "2026-09",
+                    "has_more": False,
+                },
+            }
+        )
+
+
+def test_follows_arkon_cursor_pagination(monkeypatch):
+    monkeypatch.setattr(arkon_module.httpx, "AsyncClient", FakeAsyncClient)
+    scraper = ArkonBarManagerScraper("slims", {"url": "https://slims.example/events/"})
+
+    events = asyncio.run(scraper.scrape())
+
+    assert [event.date for event in events] == [date(2026, 9, 10), date(2026, 9, 11)]
+    assert FakeAsyncClient.instance.post_calls == [
+        (
+            "https://slims.example/ajax",
+            {
+                "action": "abm_load_events",
+                "cursor": "first-cursor",
+                "count": "10",
+                "last_month": "2026-09",
+                "category": "music",
+            },
+        )
+    ]
+
+
+def test_missing_calendar_is_a_failed_scrape(monkeypatch):
+    async def get_without_calendar(self, url):
+        return FakeResponse(text="<html><body>No calendar</body></html>")
+
+    monkeypatch.setattr(FakeAsyncClient, "get", get_without_calendar)
+    monkeypatch.setattr(arkon_module.httpx, "AsyncClient", FakeAsyncClient)
+    scraper = ArkonBarManagerScraper("slims", {"url": "https://slims.example/events/"})
+
+    with pytest.raises(RuntimeError, match="ABM calendar not found"):
         asyncio.run(scraper.scrape())

--- a/backend/tests/test_arkon_bar_manager.py
+++ b/backend/tests/test_arkon_bar_manager.py
@@ -1,0 +1,50 @@
+from datetime import date, time
+
+from bs4 import BeautifulSoup
+
+from app.scrapers.arkon_bar_manager import ArkonBarManagerScraper
+
+
+HTML = """
+<div class="abm-calendar">
+  <article class="abm-event" data-date="2026-09-10">
+    <a class="abm-event-flyer" href="/music-and-events/hopscotch/">
+      <img src="/uploads/hopscotch.jpg" alt="Hopscotch">
+    </a>
+    <div class="abm-event-title">
+      <a href="/music-and-events/hopscotch/">Bands &amp;amp; Friends</a>
+    </div>
+    <p class="abm-event-blurb">Doors at six. Free show.</p>
+    <span class="abm-meta-row abm-meta-time"><svg></svg><span>6:30 PM - 11:00 PM</span></span>
+  </article>
+  <article class="abm-event" data-date="not-a-date">
+    <div class="abm-event-title"><a href="/bad/">Bad date</a></div>
+  </article>
+</div>
+"""
+
+
+def test_parses_arkon_calendar_event_fields():
+    scraper = ArkonBarManagerScraper("slims", {"url": "https://slims.example/events/"})
+
+    events = scraper._parse_events(BeautifulSoup(HTML, "lxml"), "https://slims.example/events/")
+
+    assert len(events) == 1
+    event = events[0]
+    assert event.name == "Bands & Friends"
+    assert event.date == date(2026, 9, 10)
+    assert event.show_time == time(18, 30)
+    assert event.ticket_url == "https://slims.example/music-and-events/hopscotch/"
+    assert event.image_url == "https://slims.example/uploads/hopscotch.jpg"
+    assert event.description == "Doors at six. Free show."
+    assert event.source == "arkon_bar_manager"
+
+
+def test_requires_a_configured_url():
+    scraper = ArkonBarManagerScraper("slims", {})
+
+    import asyncio
+    import pytest
+
+    with pytest.raises(ValueError, match="No URL configured"):
+        asyncio.run(scraper.scrape())


### PR DESCRIPTION
## Summary
- replace Slim's obsolete Modern Events Calendar integration with a dedicated Arkon Bar Manager scraper
- parse the initial event listing and follow cursor-based Load More pagination
- extract normalized titles, dates, times, descriptions, images, and event URLs
- fail explicitly if the expected calendar disappears so future site drift is observable
- update scraper routing, seed configuration, documentation, and regression coverage

## Root cause
Slim's redesigned its site and moved from Modern Events Calendar markup to the Arkon Bar Manager WordPress plugin. The existing MEC scraper still fetched the page successfully but found no matching event markup.

## Verification
- `python -m pytest tests -q`: 603 passed
- `node --test frontend/tests/*.test.js`: 13 passed
- live read-only scrape: 210 events found
- local end-to-end sync: 210 created, spanning 2026-09-04 through 2028-01-31

## Deployment impact
No migration or new dependency. The existing startup seed changes Slim's scraper type on deploy. Rollback is the previous application revision.

Closes #102