### PR TITLE
Add Bowstring Brewyard Raleigh events

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,7 @@ Each venue is handled by one scraper type. Last updated 2026-06-29 — may drift
 | `venuepilot` | Haw River Ballroom, Rubies on Five Points, Stanczyks |
 | `squarespace` | Neptune's Parlour, Boom Club |
 | `mec` | Shadowbox Studio, Slim's |
+| `eventon` | Bowstring Brewyard Raleigh |
 | `tickpick_organizer` | Chapel of Bones |
 | `webflow_cms` | Pour House |
 

--- a/backend/app/scrapers/eventon.py
+++ b/backend/app/scrapers/eventon.py
@@ -1,0 +1,66 @@
+"""Scraper for WordPress sites using the EventON calendar plugin."""
+
+import logging
+import re
+
+import httpx
+from bs4 import BeautifulSoup
+
+from app.scrapers.base import BROWSER_HEADERS, ScrapedEvent
+from app.scrapers.mec import MECScraper
+
+
+logger = logging.getLogger(__name__)
+
+
+class EventONScraper(MECScraper):
+    """Extract EventON's embedded schema.org events from its listing page."""
+
+    async def scrape(self) -> list[ScrapedEvent]:
+        url = self.config.get("url", "")
+        if not url:
+            raise ValueError(f"No URL configured for {self.venue_slug}")
+
+        async with httpx.AsyncClient(
+            timeout=30, follow_redirects=True, headers=BROWSER_HEADERS
+        ) as client:
+            response = await client.get(url)
+            response.raise_for_status()
+
+        soup = BeautifulSoup(response.text, "lxml")
+        if soup.select_one(".ajde_evcal_calendar") is None:
+            raise RuntimeError(f"EventON calendar not found for {self.venue_slug}")
+
+        events = self._extract_jsonld_events(soup, source_url=url)
+        if not events:
+            raise RuntimeError(f"EventON calendar contained no parseable events for {self.venue_slug}")
+
+        unique = {event.hash: event for event in events}
+        logger.info("[EventON] Found %s events for %s", len(unique), self.venue_slug)
+        return list(unique.values())
+
+    def _parse_jsonld_event(self, data: dict, source_url: str = ""):
+        normalized = dict(data)
+        start = normalized.get("startDate")
+        if isinstance(start, str):
+            # EventON emits values such as 2026-9-5T19:00+0:00. Python's ISO
+            # parser requires zero-padded month/day and a two-digit offset hour.
+            match = re.match(r"^(\d{4})-(\d{1,2})-(\d{1,2})(T.*)$", start)
+            if match:
+                year, month, day, remainder = match.groups()
+                start = f"{year}-{int(month):02d}-{int(day):02d}{remainder}"
+            start = re.sub(r"([+-])(\d):", r"\g<1>0\2:", start)
+            normalized["startDate"] = start
+
+        event_url = normalized.get("url") or source_url
+        description = normalized.get("description")
+        if not normalized.get("offers") and isinstance(description, str):
+            link = BeautifulSoup(description, "lxml").find("a", href=True)
+            if link:
+                normalized["offers"] = {"url": link["href"]}
+
+        parsed = super()._parse_jsonld_event(normalized, source_url=event_url)
+        if parsed:
+            parsed.source = "eventon"
+            parsed.external_id = normalized.get("@id")
+        return parsed

--- a/backend/app/scrapers/manager.py
+++ b/backend/app/scrapers/manager.py
@@ -350,6 +350,9 @@ class ScrapeManager:
         elif venue.scraper_type == "mec":
             from app.scrapers.mec import MECScraper
             return MECScraper(venue.slug, venue.scraper_config)
+        elif venue.scraper_type == "eventon":
+            from app.scrapers.eventon import EventONScraper
+            return EventONScraper(venue.slug, venue.scraper_config)
         elif venue.scraper_type == "webflow_cms":
             from app.scrapers.webflow_cms import WebflowCMSScraper
             return WebflowCMSScraper(venue.slug, venue.scraper_config)

--- a/backend/app/seed.py
+++ b/backend/app/seed.py
@@ -31,6 +31,7 @@ logger = logging.getLogger(__name__)
 #   venuepilot        Haw River Ballroom, Rubies on Five Points, Stanczyks
 #   squarespace       Neptune's Parlour, Boom Club
 #   mec               Shadowbox Studio, Slim's
+#   eventon           Bowstring Brewyard Raleigh
 #   tickpick_organizer Chapel of Bones
 #   webflow_cms       Pour House
 VENUES = [
@@ -264,6 +265,19 @@ VENUES = [
             "base_url": "https://www.pourhouseraleigh.com",
         },
         "color": "#6a3828",  # warm brick (Raleigh)
+    },
+    {
+        "name": "Bowstring Brewyard Raleigh",
+        "slug": "bowstring-brewyard-raleigh",
+        "city": "Raleigh",
+        "capacity": None,
+        "size_category": "small",
+        "website": "https://raleigh.bowstringbrewyard.com/",
+        "scraper_type": "eventon",
+        "scraper_config": {
+            "url": "https://raleigh.bowstringbrewyard.com/live-music-and-events/"
+        },
+        "color": "#80552f",
     },
     {
         "name": "Slim's",

--- a/backend/tests/test_eventon.py
+++ b/backend/tests/test_eventon.py
@@ -1,0 +1,53 @@
+import asyncio
+from datetime import date, time
+
+import pytest
+from bs4 import BeautifulSoup
+
+from app.scrapers.eventon import EventONScraper
+
+
+EVENT = {
+    "@type": "Event",
+    "@id": "event_2251_0",
+    "name": "JET - Down the Moonlit Mile Revue",
+    "startDate": "2026-9-17T19:00+0:00",
+    "url": "https://bowstring.example/events/jet/",
+    "image": "https://bowstring.example/uploads/jet.png",
+    "description": (
+        '<a href="https://tickets.example/jet">Get your tickets here!</a>'
+        " Doors at 6pm."
+    ),
+    "eventStatus": "https://schema.org/EventScheduled",
+}
+
+
+def test_parses_eventon_datetime_and_urls():
+    scraper = EventONScraper("bowstring-brewyard-raleigh", {})
+
+    event = scraper._parse_jsonld_event(EVENT)
+
+    assert event is not None
+    assert event.date == date(2026, 9, 17)
+    assert event.show_time == time(19, 0)
+    assert event.ticket_url == "https://tickets.example/jet"
+    assert event.source_url == "https://bowstring.example/events/jet/"
+    assert event.image_url == "https://bowstring.example/uploads/jet.png"
+    assert event.external_id == "event_2251_0"
+    assert event.source == "eventon"
+
+
+def test_missing_url_fails_before_request():
+    scraper = EventONScraper("bowstring-brewyard-raleigh", {})
+
+    with pytest.raises(ValueError, match="No URL configured"):
+        asyncio.run(scraper.scrape())
+
+
+def test_non_event_jsonld_is_ignored():
+    scraper = EventONScraper("bowstring-brewyard-raleigh", {})
+    soup = BeautifulSoup(
+        '<script type="application/ld+json">{"@type":"WebPage"}</script>', "lxml"
+    )
+
+    assert scraper._extract_jsonld_events(soup) == []


### PR DESCRIPTION
## Summary
- add Bowstring Brewyard Raleigh as a venue source
- add an EventON scraper that reuses the existing schema.org event parser
- normalize EventON's non-zero-padded date and timezone format
- preserve canonical event pages, images, descriptions, and direct ticket links
- fail explicitly if the calendar disappears or contains no parseable events
- add scraper routing, venue seed data, documentation, and regression tests

## Scope
Raleigh only. The Wilmington location remains out of scope as requested in the issue.

## Verification
- `python -m pytest tests -q`: 602 passed
- `node --test frontend/tests/*.test.js`: 13 passed
- live read-only scrape: 14 events
- local EventON-only sync: 14 events updated successfully
- live date range: 2026-09-05 through 2027-04-23

## Deployment impact
No migration or new dependency. Startup seed adds the venue; rollback is the previous application revision.

Closes #106